### PR TITLE
Add thriftpool package

### DIFF
--- a/thriftpool/bench_test.go
+++ b/thriftpool/bench_test.go
@@ -1,0 +1,36 @@
+package thriftpool_test
+
+import (
+	"testing"
+
+	"github.com/reddit/baseplate.go/thriftpool"
+)
+
+func BenchmarkPoolGetRelease(b *testing.B) {
+	opener := func() (thriftpool.Client, error) {
+		return &testClient{}, nil
+	}
+
+	const min, max = 0, 100
+	channelPool, _ := thriftpool.NewChannelPool(min, max, opener)
+
+	for label, pool := range map[string]thriftpool.Pool{
+		"channel": channelPool,
+	} {
+		b.Run(
+			label,
+			func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					c, err := pool.Get()
+					if err != nil {
+						b.Fatalf("pool.Get returned error on run #%d: %v", i, err)
+					}
+
+					if err := pool.Release(c); err != nil {
+						b.Fatalf("pool.Release returned error on run #%d: %v", i, err)
+					}
+				}
+			},
+		)
+	}
+}

--- a/thriftpool/channel.go
+++ b/thriftpool/channel.go
@@ -1,0 +1,120 @@
+package thriftpool
+
+import (
+	"sync/atomic"
+)
+
+type channelPool struct {
+	pool           chan Client
+	opener         ClientOpener
+	numActive      int32
+	minConnections int
+	maxConnections int
+}
+
+// Make sure channelPool implements Pool interface.
+var _ Pool = (*channelPool)(nil)
+
+// NewChannelPool creates a new thrift client pool implemented via channel.
+func NewChannelPool(minConnections, maxConnections int, opener ClientOpener) (Pool, error) {
+	if minConnections > maxConnections {
+		return nil, &ConfigError{
+			MinConnections: minConnections,
+			MaxConnections: maxConnections,
+		}
+	}
+
+	pool := make(chan Client, maxConnections)
+	for i := 0; i < minConnections; i++ {
+		c, err := opener()
+		if err != nil {
+			return nil, err
+		}
+		pool <- c
+	}
+
+	return &channelPool{
+		pool:           pool,
+		opener:         opener,
+		minConnections: minConnections,
+		maxConnections: maxConnections,
+	}, nil
+}
+
+// Get returns a thrift client from the pool.
+func (cp *channelPool) Get() (client Client, err error) {
+	defer func() {
+		if err == nil {
+			atomic.AddInt32(&cp.numActive, 1)
+		}
+	}()
+
+	select {
+	case c := <-cp.pool:
+		if c.IsOpen() {
+			return c, nil
+		}
+	default:
+	}
+
+	if cp.IsExhausted() {
+		err = ErrExhausted
+		return
+	}
+	return cp.opener()
+}
+
+// Release releases a client back to the pool.
+//
+// If the pool is full, the client will be closed instead.
+//
+// Calling Release after Close will cause panic.
+func (cp *channelPool) Release(c Client) error {
+	if c == nil {
+		return nil
+	}
+
+	if !c.IsOpen() {
+		newC, err := cp.opener()
+		if err != nil {
+			return err
+		}
+		c = newC
+	}
+
+	select {
+	case cp.pool <- c:
+		atomic.AddInt32(&cp.numActive, -1)
+		return nil
+	default:
+		// Pool is full, just close it instead.
+		return c.Close()
+	}
+}
+
+// Close closes the pool, and all allocated clients.
+func (cp *channelPool) Close() error {
+	var lastErr error
+	close(cp.pool)
+	for c := range cp.pool {
+		if err := c.Close(); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+// NumActiveClients returns the number of clients curently given out for use.
+func (cp *channelPool) NumActiveClients() int32 {
+	return atomic.LoadInt32(&cp.numActive)
+}
+
+// NumAllocated returns the number of allocated clients in internal pool.
+func (cp *channelPool) NumAllocated() int32 {
+	return int32(len(cp.pool))
+}
+
+// IsExhausted returns true when NumActiveClients >= max capacity.
+func (cp *channelPool) IsExhausted() bool {
+	return cp.NumActiveClients() >= int32(cp.maxConnections)
+}

--- a/thriftpool/channel_test.go
+++ b/thriftpool/channel_test.go
@@ -1,0 +1,100 @@
+package thriftpool_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/reddit/baseplate.go/thriftpool"
+)
+
+func TestChannelPoolInvalidConfig(t *testing.T) {
+	const min, max = 5, 1
+	_, err := thriftpool.NewChannelPool(min, max, nil)
+	if err == nil {
+		t.Errorf(
+			"NewChannelPool with min %d and max %d expected an error, got nil.",
+			min,
+			max,
+		)
+	}
+}
+
+func TestChannelPool(t *testing.T) {
+	opener := func(called *int32) thriftpool.ClientOpener {
+		return func() (thriftpool.Client, error) {
+			if called != nil {
+				atomic.AddInt32(called, 1)
+			}
+			return &testClient{}, nil
+		}
+	}
+
+	const min, max = 2, 5
+	var openerCalled int32
+	pool, err := thriftpool.NewChannelPool(min, max, opener(&openerCalled))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("min: %d, max: %d", min, max)
+
+	testPool(t, pool, &openerCalled, min, max)
+}
+
+func TestChannelPoolWithOpenerFailure(t *testing.T) {
+	// In this opener, every other call will fail
+	opener := func() thriftpool.ClientOpener {
+		var called int32
+		failure := errors.New("failed")
+		return func() (thriftpool.Client, error) {
+			if atomic.AddInt32(&called, 1)%2 == 0 {
+				return nil, failure
+			}
+			return &testClient{}, nil
+		}
+	}
+
+	const min, max = 1, 5
+	t.Run(
+		"new-with-min-2-should-fail-initialization",
+		func(t *testing.T) {
+			_, err := thriftpool.NewChannelPool(2, max, opener())
+			if err == nil {
+				t.Error("NewChannelPool with min = 2 should fail but did not.")
+			}
+		},
+	)
+
+	pool, err := thriftpool.NewChannelPool(min, max, opener())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("min: %d, max: %d", min, max)
+
+	t.Run(
+		"drain-the-pool",
+		func(t *testing.T) {
+			for i := 0; i < min; i++ {
+				_, err := pool.Get()
+				if err != nil {
+					t.Errorf("pool.Get returned error: %v", err)
+				}
+			}
+
+			checkActiveAndAllocated(t, pool, min, 0)
+		},
+	)
+
+	t.Run(
+		"get-one-more-with-failed-opener",
+		func(t *testing.T) {
+			// The next opener call would fail
+			_, err := pool.Get()
+			if err == nil {
+				t.Error("pool.Get should return error, got nil")
+			}
+
+			checkActiveAndAllocated(t, pool, min, 0)
+		},
+	)
+}

--- a/thriftpool/doc.go
+++ b/thriftpool/doc.go
@@ -1,0 +1,2 @@
+// Package thriftpool provides implementations of thrift client pool.
+package thriftpool

--- a/thriftpool/errors.go
+++ b/thriftpool/errors.go
@@ -1,0 +1,26 @@
+package thriftpool
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrExhausted is the error returned by Get when the pool is exhausted.
+var ErrExhausted = errors.New("client pool exhausted")
+
+// ConfigError is the error type returned when trying to open a new thrift
+// client pool, but the configuration values passed in won't work.
+type ConfigError struct {
+	MinConnections int
+	MaxConnections int
+}
+
+var _ error = (*ConfigError)(nil)
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf(
+		"thriftpool: minConnections (%d) > maxConnections (%d)",
+		e.MinConnections,
+		e.MaxConnections,
+	)
+}

--- a/thriftpool/interface.go
+++ b/thriftpool/interface.go
@@ -1,0 +1,30 @@
+package thriftpool
+
+import (
+	"io"
+)
+
+// Client is a minimal interface for a thrift client needed by the pool.
+//
+// TTransport interface in thrift satisfies Client interface,
+// so embedding the TTransport used by the actual client is a common way to
+// implement the ClientOpener.
+type Client interface {
+	io.Closer
+
+	IsOpen() bool
+}
+
+// ClientOpener defines a generator for clients.
+type ClientOpener func() (Client, error)
+
+// Pool defines the thrift client pool interface.
+type Pool interface {
+	io.Closer
+
+	Get() (Client, error)
+	Release(c Client) error
+	NumActiveClients() int32
+	NumAllocated() int32
+	IsExhausted() bool
+}

--- a/thriftpool/interface_test.go
+++ b/thriftpool/interface_test.go
@@ -1,0 +1,286 @@
+package thriftpool_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/reddit/baseplate.go/thriftpool"
+)
+
+type testClient struct {
+	closed bool
+}
+
+func (tc *testClient) IsOpen() bool {
+	return !tc.closed
+}
+
+func (tc *testClient) Close() error {
+	tc.closed = true
+	return nil
+}
+
+func checkActiveAndAllocated(t *testing.T, pool thriftpool.Pool, expectedActive, expectedAllocated int) {
+	t.Helper()
+
+	active := pool.NumActiveClients()
+	if active != int32(expectedActive) {
+		t.Errorf(
+			"pool.NumActiveClients() expected %d, got %d",
+			expectedActive,
+			active,
+		)
+	}
+
+	allocated := pool.NumAllocated()
+	if allocated != int32(expectedAllocated) {
+		t.Errorf(
+			"pool.NumAllocated() expected %d, got %d",
+			expectedAllocated,
+			allocated,
+		)
+	}
+}
+
+func testPool(t *testing.T, pool thriftpool.Pool, openerCalled *int32, min, max int) {
+	t.Run(
+		"drain-the-pool",
+		func(t *testing.T) {
+			for i := 0; i < min; i++ {
+				_, err := pool.Get()
+				if err != nil {
+					t.Errorf("pool.Get returned error: %v", err)
+				}
+			}
+
+			checkActiveAndAllocated(t, pool, min, 0)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"get-one-more",
+		func(t *testing.T) {
+			_, err := pool.Get()
+			if err != nil {
+				t.Errorf("pool.Get returned error: %v", err)
+			}
+
+			checkActiveAndAllocated(t, pool, min+1, 0)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"get-to-max",
+		func(t *testing.T) {
+			for i := 0; i < max-min-1; i++ {
+				_, err := pool.Get()
+				if err != nil {
+					t.Errorf("pool.Get returned error: %v", err)
+				}
+			}
+
+			checkActiveAndAllocated(t, pool, max, 0)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"get-one-more-after-max",
+		func(t *testing.T) {
+			exhausted := pool.IsExhausted()
+			if !exhausted {
+				t.Errorf(
+					"pool.IsExhausted() expected true, got false. Allocated = %d, Active = %d",
+					pool.NumAllocated(),
+					pool.NumActiveClients(),
+				)
+			}
+
+			beforeOpenerCalled := atomic.LoadInt32(openerCalled)
+			_, err := pool.Get()
+			if err == nil {
+				t.Error("pool.Get expected error, got nil")
+			}
+
+			diff := atomic.LoadInt32(openerCalled) - beforeOpenerCalled
+			if diff != 0 {
+				t.Errorf("pool.Get should not call opener, called %d times", diff)
+			}
+
+			checkActiveAndAllocated(t, pool, max, 0)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"get-should-not-return-closed-client",
+		func(t *testing.T) {
+			// This test relies on the pool being empty
+			if n := pool.NumAllocated(); n != 0 {
+				t.Fatalf("The pool should be empty, but has %d allocated instead", n)
+			}
+
+			c := &testClient{}
+			if err := pool.Release(c); err != nil {
+				t.Errorf("pool.Release returned error: %v", err)
+			}
+			// Close the client in the pool
+			c.closed = true
+
+			beforeOpenerCalled := atomic.LoadInt32(openerCalled)
+			newc, err := pool.Get()
+			if err != nil {
+				t.Fatalf("pool.Get returned error: %v", err)
+			}
+			if !newc.IsOpen() {
+				t.Error("pool.Get returned closed client")
+			}
+			diff := atomic.LoadInt32(openerCalled) - beforeOpenerCalled
+			if diff != 1 {
+				t.Error("opener not called with closed client")
+			}
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"release-min-closed-clients",
+		func(t *testing.T) {
+			beforeOpenerCalled := atomic.LoadInt32(openerCalled)
+
+			for i := 0; i < min; i++ {
+				c := &testClient{
+					closed: true,
+				}
+				if err := pool.Release(c); err != nil {
+					t.Errorf("pool.Release returned error: %v", err)
+				}
+			}
+
+			diff := atomic.LoadInt32(openerCalled) - beforeOpenerCalled
+			if int(diff) != min {
+				t.Errorf(
+					"Expected opener to be called %d times, called %d times instead",
+					min,
+					diff,
+				)
+			}
+
+			checkActiveAndAllocated(t, pool, max-min, min)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"release-to-max-minus-1",
+		func(t *testing.T) {
+			beforeOpenerCalled := atomic.LoadInt32(openerCalled)
+
+			for i := 0; i < max-min-1; i++ {
+				c := &testClient{}
+				if err := pool.Release(c); err != nil {
+					t.Errorf("pool.Release returned error: %v", err)
+				}
+			}
+
+			diff := atomic.LoadInt32(openerCalled) - beforeOpenerCalled
+			if diff != 0 {
+				t.Errorf(
+					"Didn't expect opener to be called, called %d times instead",
+					diff,
+				)
+			}
+
+			checkActiveAndAllocated(t, pool, 1, max-1)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	lastClient := &testClient{}
+
+	t.Run(
+		"release-to-max",
+		func(t *testing.T) {
+			if err := pool.Release(lastClient); err != nil {
+				t.Errorf("pool.Release returned error: %v", err)
+			}
+
+			if lastClient.closed {
+				t.Error("pool.Release should not close client released")
+			}
+
+			checkActiveAndAllocated(t, pool, 0, max)
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"release-one-more",
+		func(t *testing.T) {
+			c := &testClient{}
+			if err := pool.Release(c); err != nil {
+				t.Errorf("pool.Release returned error: %v", err)
+			}
+
+			checkActiveAndAllocated(t, pool, 0, max)
+
+			if !c.closed {
+				t.Error("pool.Release did not close extra released client")
+			}
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+
+	t.Run(
+		"concurrency",
+		func(t *testing.T) {
+			n := max * 2
+			var wg sync.WaitGroup
+			wg.Add(n)
+			begin := time.Now()
+			for i := 0; i < n; i++ {
+				go func(i int) {
+					defer wg.Done()
+					client, err := pool.Get()
+					if err != nil {
+						t.Errorf("pool.Get on #%d failed with: %v", i, err)
+					} else {
+						if err := pool.Release(client); err != nil {
+							t.Errorf("pool.Release on #%d failed with: %v", i, err)
+						}
+					}
+				}(i)
+			}
+			wg.Wait()
+			t.Logf("%d Get/Release took %v", n, time.Since(begin))
+		},
+	)
+
+	t.Run(
+		"close-pool",
+		func(t *testing.T) {
+			if err := pool.Close(); err != nil {
+				t.Errorf("pool.Close returned error: %v", err)
+			}
+
+			if !lastClient.closed {
+				t.Error("pool.Close did not close client")
+			}
+
+			t.Logf("opener called %d times", atomic.LoadInt32(openerCalled))
+		},
+	)
+}


### PR DESCRIPTION
This package defines an thrift client pool interface, and comes with a
channel based implementation.

The benchmark result shows that the channel based implementation takes
~100ns for a Get/Release pair calls.

    $ go test -bench=. -benchmem
    goos: darwin
    goarch: amd64
    pkg: github.com/reddit/baseplate.go/thriftpool
    BenchmarkPoolGetRelease/channel-8         	12180511	        95.9 ns/op	       0 B/op	       0 allocs/op
    PASS
    ok  	github.com/reddit/baseplate.go/thriftpool	1.288s
