### PR TITLE
Use middleware approach to handle callbacks

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -31,6 +31,37 @@ type Secrets struct {
 	vault             Vault
 }
 
+// GetSimpleSecret fetches a simple secret or error if the key is not present.
+func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
+	secret, ok := s.simpleSecrets[path]
+	if !ok {
+		return secret, ErrorSecretNotFound(path)
+	}
+
+	return secret, nil
+}
+
+// GetVersionedSecret fetches a versioned secret or error if the key is not present.
+func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
+	secret, ok := s.versionedSecrets[path]
+	if !ok {
+		return secret, ErrorSecretNotFound(path)
+	}
+
+	return secret, nil
+}
+
+// GetCredentialSecret fetches a credential secret or error if the key is not
+// present.
+func (s *Secrets) GetCredentialSecret(path string) (CredentialSecret, error) {
+	secret, ok := s.credentialSecrets[path]
+	if !ok {
+		return secret, ErrorSecretNotFound(path)
+	}
+
+	return secret, nil
+}
+
 // SimpleSecret represent basic secrets.
 type SimpleSecret struct {
 	Value Secret
@@ -287,4 +318,12 @@ func (e encoding) decodeValue(value string) (Secret, error) {
 		}
 		return Secret(data), nil
 	}
+}
+
+// ErrorSecretNotFound is returned when the key for a secret is not present in
+// the secret store.
+type ErrorSecretNotFound string
+
+func (path ErrorSecretNotFound) Error() string {
+	return "no secret has been found for " + string(path)
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -35,7 +35,7 @@ type Secrets struct {
 func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
 	secret, ok := s.simpleSecrets[path]
 	if !ok {
-		return secret, ErrorSecretNotFound(path)
+		return secret, SecretNotFoundError(path)
 	}
 
 	return secret, nil
@@ -45,7 +45,7 @@ func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
 func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
 	secret, ok := s.versionedSecrets[path]
 	if !ok {
-		return secret, ErrorSecretNotFound(path)
+		return secret, SecretNotFoundError(path)
 	}
 
 	return secret, nil
@@ -56,7 +56,7 @@ func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
 func (s *Secrets) GetCredentialSecret(path string) (CredentialSecret, error) {
 	secret, ok := s.credentialSecrets[path]
 	if !ok {
-		return secret, ErrorSecretNotFound(path)
+		return secret, SecretNotFoundError(path)
 	}
 
 	return secret, nil
@@ -320,10 +320,10 @@ func (e encoding) decodeValue(value string) (Secret, error) {
 	}
 }
 
-// ErrorSecretNotFound is returned when the key for a secret is not present in
+// SecretNotFoundError is returned when the key for a secret is not present in
 // the secret store.
-type ErrorSecretNotFound string
+type SecretNotFoundError string
 
-func (path ErrorSecretNotFound) Error() string {
+func (path SecretNotFoundError) Error() string {
 	return "no secret has been found for " + string(path)
 }

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -41,7 +41,7 @@ type Store struct {
 func NewStore(ctx context.Context, path string, logger log.Wrapper, middlewares ...SecretMiddleware) (*Store, error) {
 	store := &Store{}
 	if len(middlewares) > 0 {
-		store.SecretHandler(middlewares...)
+		store.secretHandler(middlewares...)
 	}
 
 	result, err := filewatcher.New(ctx, path, store.parser, logger)
@@ -67,7 +67,7 @@ func (s *Store) parser(r io.Reader) (interface{}, error) {
 }
 
 // SecretHandler creates the middleware chain.
-func (s *Store) SecretHandler(middlewares ...SecretMiddleware) {
+func (s *Store) secretHandler(middlewares ...SecretMiddleware) {
 	if s.secretHandlerFunc == nil {
 		s.secretHandlerFunc = noOpSecretHandlerFunc
 	}

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -79,11 +79,9 @@ func (s *Store) secretHandler(middlewares ...SecretMiddleware) {
 
 // GetSimpleSecret loads secrets from watcher, and fetches a simple secret from secrets
 func (s *Store) GetSimpleSecret(path string) (SimpleSecret, error) {
-	var secret SimpleSecret
-
 	secrets, ok := s.watcher.Get().(*Secrets)
 	if !ok {
-		return secret, fmt.Errorf("unexpected type %T", secrets)
+		return SimpleSecret{}, fmt.Errorf("unexpected type %T", secrets)
 	}
 
 	return secrets.GetSimpleSecret(path)
@@ -91,11 +89,9 @@ func (s *Store) GetSimpleSecret(path string) (SimpleSecret, error) {
 
 // GetVersionedSecret loads secrets from watcher, and fetches a versioned secret from secrets
 func (s *Store) GetVersionedSecret(path string) (VersionedSecret, error) {
-	var secret VersionedSecret
-
 	secrets, ok := s.watcher.Get().(*Secrets)
 	if !ok {
-		return secret, fmt.Errorf("unexpected type %T", secrets)
+		return VersionedSecret{}, fmt.Errorf("unexpected type %T", secrets)
 	}
 
 	return secrets.GetVersionedSecret(path)
@@ -103,11 +99,9 @@ func (s *Store) GetVersionedSecret(path string) (VersionedSecret, error) {
 
 // GetCredentialSecret loads secrets from watcher, and fetches a credential secret from secrets
 func (s *Store) GetCredentialSecret(path string) (CredentialSecret, error) {
-	var secret CredentialSecret
-
 	secrets, ok := s.watcher.Get().(*Secrets)
 	if !ok {
-		return secret, fmt.Errorf("unexpected type %T", secrets)
+		return CredentialSecret{}, fmt.Errorf("unexpected type %T", secrets)
 	}
 
 	return secrets.GetCredentialSecret(path)

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -9,10 +9,11 @@ import (
 	"github.com/reddit/baseplate.go/log"
 )
 
-// Middleware functions
 type (
+	// SecretHandlerFunc is the actuall function that works with the Secrets
 	SecretHandlerFunc func(sec *Secrets)
-	SecretMiddleware  func(next SecretHandlerFunc) SecretHandlerFunc
+	// SecretMiddleware creates chain of SecretHandlerFunc calls
+	SecretMiddleware func(next SecretHandlerFunc) SecretHandlerFunc
 )
 
 func noOpSecretHandlerFunc(sec *Secrets) {}

--- a/secrets/store_bench_test.go
+++ b/secrets/store_bench_test.go
@@ -1,0 +1,48 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+func BenchmarkStoreMiddlewares(b *testing.B) {
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	tmpFile.Write([]byte(specificationExample))
+
+	var middleware = func(next SecretHandlerFunc) SecretHandlerFunc {
+		return func(sec *Secrets) {
+			next(sec)
+		}
+	}
+
+	for i := 0; i < 10; i++ {
+		numOfMiddlewares := 1 << i
+
+		middlewares := make([]SecretMiddleware, 0, numOfMiddlewares)
+
+		for j := 0; j < numOfMiddlewares; j++ {
+			middlewares = append(middlewares, middleware)
+		}
+
+		b.Run(
+			fmt.Sprintf("number of middlewares %d", numOfMiddlewares),
+			func(b *testing.B) {
+				for n := 0; n < b.N; n++ {
+					NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(b), middlewares...)
+				}
+			},
+		)
+	}
+}

--- a/secrets/store_test.go
+++ b/secrets/store_test.go
@@ -169,7 +169,7 @@ func TestGetSimpleSecret(t *testing.T) {
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: ErrorSecretNotFound("spez"),
+			expectedError: SecretNotFoundError("spez"),
 		},
 	}
 
@@ -231,7 +231,7 @@ func TestGetVersionedSecret(t *testing.T) {
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: ErrorSecretNotFound("spez"),
+			expectedError: SecretNotFoundError("spez"),
 		},
 	}
 
@@ -293,7 +293,7 @@ func TestGetCredentialSecret(t *testing.T) {
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: ErrorSecretNotFound("spez"),
+			expectedError: SecretNotFoundError("spez"),
 		},
 	}
 


### PR DESCRIPTION
Middleware allows caller to add custom functions to work with Secrets as they see fit. This option allows multiple layers callback and also leaves concurrent and blocking problem to the caller.

~We still need to open up Secrets to allow the caller to interact with it.~

This is entirely open for discussion. I just find it easier to express the idea with actual code :)

Middleware chaining benchmark result:
```
go test -bench=. -benchmem * -test.v -run=BenchmarkStoreMiddlewares
goos: darwin
goarch: amd64
BenchmarkStoreMiddlewares/number_of_middlewares_1-12               52531             22815 ns/op             288 B/op          8 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_2-12               51770             23652 ns/op             304 B/op          9 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_4-12               52406             23373 ns/op             336 B/op         11 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_8-12               51429             23478 ns/op             400 B/op         15 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_16-12              45654             23951 ns/op             528 B/op         23 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_32-12              49756             24492 ns/op             784 B/op         39 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_64-12              44978             26391 ns/op            1296 B/op         71 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_128-12             42652             27812 ns/op            2320 B/op        135 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_256-12             36979             30805 ns/op            4368 B/op        263 allocs/op
BenchmarkStoreMiddlewares/number_of_middlewares_512-12             28684             38541 ns/op            8464 B/op        519 allocs/op
PASS
ok      command-line-arguments  15.572s
```