### PR TITLE
runtimebp: GOMAXPROCS return two values instead of one

### DIFF
--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -86,14 +86,16 @@ func defaultMaxProcsFormula(n float64) int {
 // in bound of [min, max].
 //
 // Currently the default formula is NumCPU()*2-1 rounding up.
-func GOMAXPROCS(min, max int) int {
+func GOMAXPROCS(min, max int) (oldVal, newVal int) {
 	return GOMAXPROCSwithFormula(min, max, defaultMaxProcsFormula)
 }
 
 // GOMAXPROCSwithFormula sets runtime.GOMAXPROCS with the given formula,
 // in bound of [min, max].
-func GOMAXPROCSwithFormula(min, max int, formula MaxProcsFormula) int {
-	return runtime.GOMAXPROCS(boundNtoMinMax(formula(NumCPU()), min, max))
+func GOMAXPROCSwithFormula(min, max int, formula MaxProcsFormula) (oldVal, newVal int) {
+	newVal = boundNtoMinMax(formula(NumCPU()), min, max)
+	oldVal = runtime.GOMAXPROCS(newVal)
+	return
 }
 
 func boundNtoMinMax(n, min, max int) int {


### PR DESCRIPTION
I thought runtime.GOMAXPROCS returns the new value set, but apparently I
was wrong and it actually returns the previous value. So make
runtimebp.GOMAXPROCS to return both old value (from the return value of
runtime.GOMAXPROCS) and new value to make it more useful for debugging.

This is a breaking change, but the impact should be minimal.