### PR TITLE
Span hooks

### DIFF
--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -1,0 +1,79 @@
+package metricsbp
+
+import (
+	"fmt"
+
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+const (
+	success = "success"
+	fail    = "fail"
+)
+
+// BaseplateHook registers each Server Span with a MetricsSpanHook.
+type BaseplateHook struct {
+	Prefix  string
+	Metrics Statsd
+}
+
+// OnServerSpanCreate registers MetricSpanHooks on a Server Span.
+func (h BaseplateHook) OnServerSpanCreate(span *tracing.Span) error {
+	name := fmt.Sprintf("%s.%s", h.Prefix, span.Name)
+	serverSpanHook := SpanHook{
+		Name:    name,
+		Metrics: h.Metrics,
+		timer:   NewTimer(h.Metrics.Histogram(name)),
+	}
+	span.RegisterHook(serverSpanHook)
+	return nil
+}
+
+// SpanHook wraps a Span in a Timer and records a "success" or "fail"
+// metric when the Span ends based on whether an error was passed to `span.End`
+// or not.
+type SpanHook struct {
+	Name    string
+	Metrics Statsd
+
+	timer *Timer
+}
+
+// OnCreateChild registers a child MetricsSpanHook on the child Span and starts
+// a new Timer around the Span.
+func (h SpanHook) OnCreateChild(child *tracing.Span) error {
+	childHook := SpanHook{
+		Name:    fmt.Sprintf("%s.%s", h.Name, child.Name),
+		Metrics: h.Metrics,
+		timer:   NewTimer(h.Metrics.Histogram(h.Name)),
+	}
+	child.RegisterHook(childHook)
+	return nil
+}
+
+// OnStart is a nop
+func (h SpanHook) OnStart(span *tracing.Span) error {
+	return nil
+}
+
+// OnEnd stops the Timer started in OnStart and records a metric indicating if
+// the span was a "success" or "fail".
+//
+// A span is marked as "fail" if `err != nil` otherwise it is marked as
+// "success".
+func (h SpanHook) OnEnd(span *tracing.Span, err error) error {
+	h.timer.ObserveDuration()
+	var statusMetricPath string
+	if err != nil {
+		statusMetricPath = fmt.Sprintf("%s.%s", h.Name, fail)
+	} else {
+		statusMetricPath = fmt.Sprintf("%s.%s", h.Name, success)
+	}
+	h.Metrics.Counter(statusMetricPath).Add(1)
+	return nil
+}
+
+var (
+	_ tracing.BaseplateHook = BaseplateHook{}
+	_ tracing.SpanHook      = SpanHook{}
+)

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -1,0 +1,112 @@
+package metricsbp_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+func runSpan(st metricsbp.Statsd, spanErr error) (counter string, histogram string, err error) {
+	ctx := context.Background()
+	span := tracing.StartSpanFromThriftContext(ctx, "foo")
+	time.Sleep(time.Millisecond)
+	span.End(ctx, spanErr)
+
+	var sb strings.Builder
+	if _, err = st.Statsd.WriteTo(&sb); err != nil {
+		return
+	}
+	stats := strings.Split(sb.String(), "\n")
+	if len(stats) != 3 {
+		err = fmt.Errorf("Expected 2 stats, got %d", len(stats)-1)
+		return
+	}
+
+	for _, stat := range stats {
+		if strings.HasSuffix(stat, "|c") {
+			counter = stat
+		} else if strings.HasSuffix(stat, "|ms") {
+			histogram = stat
+		}
+	}
+	return
+}
+
+func TestOnServerSpanCreate(t *testing.T) {
+	sampleRate := 1.0
+	st := metricsbp.NewStatsd(
+		context.Background(),
+		metricsbp.StatsdConfig{
+			DefaultSampleRate: sampleRate,
+		},
+	)
+	defer st.StopReporting()
+
+	hookPrefix := "service.testing"
+	hook := metricsbp.BaseplateHook{
+		Prefix:  hookPrefix,
+		Metrics: st,
+	}
+	tracing.RegisterBaseplateHook(hook)
+	defer tracing.ResetHooks()
+
+	histogramRegex := regexp.MustCompile(`^service\.testing\.foo:\d\.\d+\|ms$`)
+
+	t.Run(
+		"success",
+		func(t *testing.T) {
+			counter, histogram, err := runSpan(st, nil)
+			if err != nil {
+				t.Fatalf("Got error: %s", err)
+			}
+
+			expectedCounter := "service.testing.foo.success:1.000000|c"
+			if counter != expectedCounter {
+				t.Errorf(
+					"Expected counter: %s\nGot counter: %s",
+					expectedCounter,
+					counter,
+				)
+			}
+
+			if !histogramRegex.MatchString(histogram) {
+				t.Errorf(
+					"Histogram %s did not match expected format",
+					histogram,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"fail",
+		func(t *testing.T) {
+			counter, histogram, err := runSpan(st, fmt.Errorf("test error"))
+			if err != nil {
+				t.Fatalf("Got error: %s", err)
+			}
+
+			expectedCounter := "service.testing.foo.fail:1.000000|c"
+			if counter != expectedCounter {
+				t.Errorf(
+					"Expected counter: %s\nGot counter: %s",
+					expectedCounter,
+					counter,
+				)
+			}
+
+			if !histogramRegex.MatchString(histogram) {
+				t.Errorf(
+					"Histogram %s did not match expected format",
+					histogram,
+				)
+			}
+		},
+	)
+}

--- a/metricsbp/example_baseplate_hooks_test.go
+++ b/metricsbp/example_baseplate_hooks_test.go
@@ -1,0 +1,22 @@
+package metricsbp_test
+
+import (
+	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+// This example demonstrates how to use BaseplateHook.
+func ExampleBaseplateHook() {
+	// variables should be properly initialized in production code
+	var statsd metricsbp.Statsd
+	const prefix = "service.server"
+
+	// initialize the BaseplateHook
+	hook := metricsbp.BaseplateHook{
+		Prefix:  prefix,
+		Metrics: statsd,
+	}
+
+	// register the hook with Baseplate
+	tracing.RegisterBaseplateHook(hook)
+}

--- a/tracing/errors.go
+++ b/tracing/errors.go
@@ -1,0 +1,24 @@
+package tracing
+
+import (
+	"fmt"
+)
+
+// InvalidSpanTypeError is the error type returned when trying to use a Span in
+// a way that is incompatible with its type.
+//
+// For example, trying to set a child span as a ServerSpan.
+type InvalidSpanTypeError struct {
+	ExpectedSpanType SpanType
+	ActualSpanType   SpanType
+}
+
+var _ error = (*InvalidSpanTypeError)(nil)
+
+func (e *InvalidSpanTypeError) Error() string {
+	return fmt.Sprintf(
+		"span.spanType: expected (%v) != actual (%v)",
+		e.ExpectedSpanType,
+		e.ActualSpanType,
+	)
+}

--- a/tracing/hooks.go
+++ b/tracing/hooks.go
@@ -1,0 +1,37 @@
+package tracing
+
+// BaseplateHook allows you to inject functionality into the lifecycle of a
+// Baseplate request.
+type BaseplateHook interface {
+	OnServerSpanCreate(span *Span) error
+}
+
+// SpanHook allows you to inject functionality into the lifecycle of Baseplate
+// Spans.
+type SpanHook interface {
+	OnCreateChild(child *Span) error
+	OnStart(span *Span) error
+	OnEnd(span *Span, err error) error
+}
+
+var (
+	hooks []BaseplateHook
+)
+
+// RegisterBaseplateHook registers a Hook into the Baseplate request lifecycle.
+func RegisterBaseplateHook(hook BaseplateHook) {
+	hooks = append(hooks, hook)
+}
+
+// ResetHooks removes all global hooks and resets back to initial state.
+func ResetHooks() {
+	hooks = nil
+}
+
+func onServerSpanCreate(span *Span) {
+	for _, hook := range hooks {
+		if err := hook.OnServerSpanCreate(span); err != nil && span.tracer.Logger != nil {
+			span.tracer.Logger("OnCreateServerSpan hook error: " + err.Error())
+		}
+	}
+}

--- a/tracing/hooks_test.go
+++ b/tracing/hooks_test.go
@@ -1,0 +1,114 @@
+package tracing_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+type CallContainer struct {
+	Calls []string
+}
+
+func (c *CallContainer) AddCall(call string) {
+	c.Calls = append(c.Calls, call)
+}
+
+func (c *CallContainer) Reset() {
+	c.Calls = nil
+}
+
+type TestBaseplateHook struct {
+	Calls *CallContainer
+	Fail  bool
+}
+
+func (h TestBaseplateHook) OnServerSpanCreate(span *tracing.Span) error {
+	label := "on-server-span-create"
+	h.Calls.AddCall(label)
+	span.RegisterHook(TestSpanHook{Calls: h.Calls, Fail: h.Fail})
+	if h.Fail {
+		return fmt.Errorf(label)
+	}
+	return nil
+}
+
+type TestSpanHook struct {
+	Calls *CallContainer
+	Fail  bool
+}
+
+func (h TestSpanHook) OnCreateChild(child *tracing.Span) error {
+	label := "on-create-child"
+	h.Calls.AddCall(label)
+	if h.Fail {
+		return fmt.Errorf(label)
+	}
+	return nil
+}
+
+func (h TestSpanHook) OnStart(child *tracing.Span) error {
+	label := "on-start"
+	h.Calls.AddCall(label)
+	if h.Fail {
+		return fmt.Errorf(label)
+	}
+	return nil
+}
+
+func (h TestSpanHook) OnEnd(child *tracing.Span, err error) error {
+	label := "on-end"
+	h.Calls.AddCall(label)
+	if h.Fail {
+		return fmt.Errorf(label)
+	}
+	return nil
+}
+
+var (
+	_ tracing.BaseplateHook = TestBaseplateHook{}
+	_ tracing.SpanHook      = TestSpanHook{}
+)
+
+func TestHooks(t *testing.T) {
+	hook := TestBaseplateHook{Calls: &CallContainer{}, Fail: false}
+	tracing.RegisterBaseplateHook(hook)
+	defer tracing.ResetHooks()
+
+	ctx := context.Background()
+	span := tracing.StartSpanFromThriftContext(ctx, "foo")
+	span.CreateClientChild("bar")
+	span.End(ctx, nil)
+	expected := []string{
+		"on-server-span-create",
+		"on-start",
+		"on-create-child",
+		"on-end",
+	}
+	if !reflect.DeepEqual(hook.Calls.Calls, expected) {
+		t.Fatalf("Expected %v:\nGot: %v", expected, hook.Calls.Calls)
+	}
+}
+
+func TestHookFailures(t *testing.T) {
+	hook := TestBaseplateHook{Calls: &CallContainer{}, Fail: true}
+	tracing.RegisterBaseplateHook(hook)
+	defer tracing.ResetHooks()
+
+	ctx := context.Background()
+	span := tracing.StartSpanFromThriftContext(ctx, "foo")
+	span.CreateClientChild("bar")
+	span.End(ctx, nil)
+	expected := []string{
+		"on-server-span-create",
+		"on-start",
+		"on-create-child",
+		"on-end",
+	}
+	if !reflect.DeepEqual(hook.Calls.Calls, expected) {
+		t.Fatalf("Expected %v:\nGot: %v", expected, hook.Calls.Calls)
+	}
+}

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -238,3 +238,25 @@ func TestChildSpan(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestCreateServerSpan(t *testing.T) {
+	ip, err := getFirstIPv4()
+	if err != nil {
+		t.Logf("Unable to get local ip address: %v", err)
+	}
+	tracer := Tracer{
+		SampleRate: 0.2,
+		Endpoint: ZipkinEndpointInfo{
+			ServiceName: "test-service",
+			IPv4:        ip,
+		},
+	}
+
+	span := CreateServerSpan(&tracer, "foo")
+	if span.spanType != SpanTypeServer {
+		t.Errorf("Expected span to be a ServerSpan")
+	}
+	if span.start.IsZero() {
+		t.Errorf("Expected span to be started")
+	}
+}

--- a/tracing/thrift.go
+++ b/tracing/thrift.go
@@ -36,9 +36,7 @@ func StartSpanFromThriftContext(ctx context.Context, name string) *Span {
 // StartSpanFromThriftContext, except that it uses the passed in tracer instead
 // of GlobalTracer.
 func StartSpanFromThriftContextWithTracer(ctx context.Context, name string, tracer *Tracer) *Span {
-	span := newSpan(tracer, SpanTypeServer)
-	tracer = span.tracer
-	span.spanType = SpanTypeServer
+	span := CreateServerSpan(tracer, name)
 	if str, ok := thrift.GetHeader(ctx, thriftbp.HeaderTracingTrace); ok {
 		if id, err := strconv.ParseUint(str, 10, 64); err != nil {
 			if tracer.Logger != nil {

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -111,10 +111,10 @@ func (t *Tracer) Close() error {
 
 // NewTrace creates a new trace (top level local span).
 func (t Tracer) NewTrace(name string) *Span {
-	span := newSpan(&t, SpanTypeLocal)
-	span.name = name
+	span := newSpan(&t, name, SpanTypeLocal)
 	span.traceID = rand.Uint64()
 	span.sampled = randbp.ShouldSampleWithRate(t.SampleRate)
+	span.startSpan()
 	return span
 }
 


### PR DESCRIPTION
This PR adds "Hooks" into the tracing lifecycle like the [Observers](https://github.com/reddit/baseplate.py/blob/master/baseplate/__init__.py#L32-L86) in `baseplate.py`.  This allows us to hook custom functionality into the Baseplate request lifecycle and the Span lifecyle.  

This also includes hooks for Metrics which allow us to automatically add timers around Spans and success/fail metrics.