### PR TITLE
Add timebp package

### DIFF
--- a/edgecontext/edgecontext.go
+++ b/edgecontext/edgecontext.go
@@ -10,6 +10,7 @@ import (
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/thriftbp"
+	"github.com/reddit/baseplate.go/timebp"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )
@@ -90,7 +91,7 @@ func New(ctx context.Context, args NewArgs) (*EdgeRequestContext, error) {
 		}
 		request.Loid = &baseplate.Loid{
 			ID:        args.LoID,
-			CreatedMs: TimeToMilliseconds(args.LoIDCreatedAt),
+			CreatedMs: timebp.TimeToMilliseconds(args.LoIDCreatedAt),
 		}
 	}
 	if args.SessionID != "" {
@@ -138,7 +139,7 @@ func FromThriftContext(ctx context.Context) (*EdgeRequestContext, error) {
 	}
 	if request.Loid != nil {
 		raw.LoID = request.Loid.ID
-		raw.LoIDCreatedAt = MillisecondsToTime(request.Loid.CreatedMs)
+		raw.LoIDCreatedAt = timebp.MillisecondsToTime(request.Loid.CreatedMs)
 	}
 	return &EdgeRequestContext{
 		header: header,

--- a/edgecontext/token.go
+++ b/edgecontext/token.go
@@ -1,6 +1,8 @@
 package edgecontext
 
 import (
+	"github.com/reddit/baseplate.go/timebp"
+
 	jwt "gopkg.in/dgrijalva/jwt-go.v3"
 )
 
@@ -17,8 +19,8 @@ type AuthenticationToken struct {
 	Scopes          []string `json:"scopes,omitempty"`
 
 	LoID struct {
-		ID        string               `json:"id,omitempty"`
-		CreatedAt TimestampMillisecond `json:"created_ms,omitempty"`
+		ID        string                      `json:"id,omitempty"`
+		CreatedAt timebp.TimestampMillisecond `json:"created_ms,omitempty"`
 	} `json:"loid,omitempty"`
 }
 

--- a/timebp/doc.go
+++ b/timebp/doc.go
@@ -1,0 +1,3 @@
+// Package timebp defines some time related types used by various baseplate
+// components, along with their helper functions.
+package timebp

--- a/timebp/microsecond.go
+++ b/timebp/microsecond.go
@@ -1,0 +1,116 @@
+package timebp
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+var (
+	_ json.Marshaler   = TimestampMicrosecond{}
+	_ json.Unmarshaler = (*TimestampMicrosecond)(nil)
+	_ json.Marshaler   = DurationMicrosecond(0)
+	_ json.Unmarshaler = (*DurationMicrosecond)(nil)
+)
+
+const microsecondsPerSecond = int64(time.Second / time.Microsecond)
+
+// TimestampMicrosecond implements json encoding/decoding using microseconds
+// since EPOCH.
+type TimestampMicrosecond time.Time
+
+func (ts TimestampMicrosecond) String() string {
+	return ts.ToTime().String()
+}
+
+// ToTime converts TimestampMicrosecond back to time.Time.
+func (ts TimestampMicrosecond) ToTime() time.Time {
+	return time.Time(ts)
+}
+
+// MarshalJSON implements json.Marshaler interface, using epoch microseconds.
+func (ts TimestampMicrosecond) MarshalJSON() ([]byte, error) {
+	t := ts.ToTime()
+	if t.IsZero() {
+		return []byte("null"), nil
+	}
+
+	return []byte(strconv.FormatInt(TimeToMicroseconds(t), 10)), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (ts *TimestampMicrosecond) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" {
+		*ts = TimestampMicrosecond{}
+		return nil
+	}
+
+	us, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*ts = TimestampMicrosecond(MicrosecondsToTime(us))
+	return nil
+}
+
+// MicrosecondsToTime converts milliseconds since EPOCH to time.Time.
+func MicrosecondsToTime(us int64) time.Time {
+	if us == 0 {
+		return time.Time{}
+	}
+	// NOTE: A timestamp before the year 1678 or after 2262 would overflow this,
+	// but that's OK.
+	return time.Unix(
+		us/microsecondsPerSecond,                         // sec
+		us%microsecondsPerSecond*int64(time.Microsecond), // nanosec
+	)
+}
+
+// TimeToMicroseconds converts time.Time to microseconds since EPOCH.
+func TimeToMicroseconds(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	us := t.Unix() * microsecondsPerSecond
+	us += int64(t.Nanosecond()) / int64(time.Microsecond)
+	return us
+}
+
+// DurationMicrosecond implements json encoding/decoding using microseconds
+// as int.
+type DurationMicrosecond time.Duration
+
+func (zd DurationMicrosecond) String() string {
+	return zd.ToDuration().String()
+}
+
+// ToDuration converts DurationMicrosecond back to time.Duration.
+func (zd DurationMicrosecond) ToDuration() time.Duration {
+	return time.Duration(zd)
+}
+
+// MarshalJSON implements json.Marshaler interface, using microseconds.
+func (zd DurationMicrosecond) MarshalJSON() ([]byte, error) {
+	if zd == 0 {
+		return []byte("null"), nil
+	}
+	n := int64(zd.ToDuration() / time.Microsecond)
+	return []byte(strconv.FormatInt(n, 10)), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler interface.
+func (zd *DurationMicrosecond) UnmarshalJSON(data []byte) error {
+	s := string(data)
+	if s == "null" {
+		*zd = 0
+		return nil
+	}
+
+	d, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return err
+	}
+	*zd = DurationMicrosecond(time.Duration(d) * time.Microsecond)
+	return nil
+}

--- a/timebp/microsecond_test.go
+++ b/timebp/microsecond_test.go
@@ -1,4 +1,4 @@
-package edgecontext_test
+package timebp_test
 
 import (
 	"encoding/json"
@@ -8,20 +8,21 @@ import (
 	"testing/quick"
 	"time"
 
-	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/timebp"
 )
 
-type jsonTestType struct {
-	Timestamp edgecontext.TimestampMillisecond `json:"timestamp,omitempty"`
+type jsonTestTypeMicrosecond struct {
+	Timestamp timebp.TimestampMicrosecond `json:"timestamp,omitempty"`
+	Duration  timebp.DurationMicrosecond  `json:"duration,omitempty"`
 }
 
-func TestTimestampQuick(t *testing.T) {
-	f := func(ms int64) bool {
-		time := edgecontext.MillisecondsToTime(ms)
-		actual := edgecontext.TimeToMilliseconds(time)
-		if actual != ms {
+func TestTimestampMicrosecondQuick(t *testing.T) {
+	f := func(us int64) bool {
+		time := timebp.MicrosecondsToTime(us)
+		actual := timebp.TimeToMicroseconds(time)
+		if actual != us {
 			t.Errorf(
-				"For timestamp %d we got %v and %d", ms, time, actual,
+				"For timestamp %d we got %v and %d", us, time, actual,
 			)
 			return false
 		}
@@ -33,18 +34,19 @@ func TestTimestampQuick(t *testing.T) {
 }
 
 func TestTimestampJSONQuick(t *testing.T) {
-	f := func(ms int64) bool {
-		var v1, v2 jsonTestType
+	f := func(us int64, duration time.Duration) bool {
+		var v1, v2 jsonTestTypeMicrosecond
 
-		v1 = jsonTestType{
-			Timestamp: edgecontext.TimestampMillisecond(edgecontext.MillisecondsToTime(ms)),
+		v1 = jsonTestTypeMicrosecond{
+			Timestamp: timebp.TimestampMicrosecond(timebp.MicrosecondsToTime(us)),
+			Duration:  timebp.DurationMicrosecond(duration.Round(time.Microsecond)),
 		}
 		s, err := json.Marshal(v1)
 		if err != nil {
 			t.Error(err)
 			return false
 		}
-		substr := strconv.FormatInt(ms, 10)
+		substr := strconv.FormatInt(us, 10)
 		if !strings.Contains(string(s), substr) {
 			t.Errorf("Encoded json expected to contain %q, got %q", substr, s)
 		}
@@ -57,6 +59,9 @@ func TestTimestampJSONQuick(t *testing.T) {
 		if !v2.Timestamp.ToTime().Equal(v1.Timestamp.ToTime()) {
 			t.Errorf("Expected timestamp %v, got %v", v1.Timestamp, v2.Timestamp)
 		}
+		if v2.Duration != v1.Duration {
+			t.Errorf("Expected duration %v, got %v", v1.Duration, v2.Duration)
+		}
 		return !t.Failed()
 	}
 	if err := quick.Check(f, nil); err != nil {
@@ -65,7 +70,7 @@ func TestTimestampJSONQuick(t *testing.T) {
 }
 
 func TestTimestampJSON(t *testing.T) {
-	var v jsonTestType
+	var v jsonTestTypeMicrosecond
 
 	t.Run(
 		"null",
@@ -83,7 +88,7 @@ func TestTimestampJSON(t *testing.T) {
 				t.Errorf("Encoded json expected to be %q, got %q", expectedStr, s)
 			}
 
-			v.Timestamp = edgecontext.TimestampMillisecond(time.Now())
+			v.Timestamp = timebp.TimestampMicrosecond(time.Now())
 			err = json.Unmarshal(s, &v)
 			if err != nil {
 				t.Fatal(err)
@@ -91,20 +96,23 @@ func TestTimestampJSON(t *testing.T) {
 			if !v.Timestamp.ToTime().IsZero() {
 				t.Errorf("Timestamp expected to be zero, got %v", v.Timestamp)
 			}
+			if v.Duration != 0 {
+				t.Errorf("Duration expected to be zero, got %v", v.Duration)
+			}
 		},
 	)
 
-	label := "2019-12-31T23:59:59.123Z"
+	label := "2019-12-31T23:59:59.123456Z"
 	t.Run(
 		label,
 		func(t *testing.T) {
-			const substr = "1577836799123"
+			const substr = "1577836799123456"
 
 			ts, err := time.Parse(time.RFC3339Nano, label)
 			if err != nil {
 				t.Fatal(err)
 			}
-			v.Timestamp = edgecontext.TimestampMillisecond(ts)
+			v.Timestamp = timebp.TimestampMicrosecond(ts)
 			s, err := json.Marshal(v)
 			if err != nil {
 				t.Fatal(err)
@@ -117,13 +125,47 @@ func TestTimestampJSON(t *testing.T) {
 				t.Errorf("Encoded json expected to be %q, got %q", expectedStr, s)
 			}
 
-			v.Timestamp = edgecontext.TimestampMillisecond(time.Now())
+			v.Timestamp = timebp.TimestampMicrosecond(time.Now())
 			err = json.Unmarshal(s, &v)
 			if err != nil {
 				t.Fatal(err)
 			}
 			if !v.Timestamp.ToTime().Equal(ts) {
 				t.Errorf("Timestamp expected %v, got %v", ts, v.Timestamp)
+			}
+		},
+	)
+
+	label = "10s"
+	t.Run(
+		label,
+		func(t *testing.T) {
+			const substr = "10000000"
+			const expectedStr = `{"timestamp":1577836799123456,"duration":10000000}`
+
+			duration, err := time.ParseDuration(label)
+			if err != nil {
+				t.Fatal(err)
+			}
+			v.Duration = timebp.DurationMicrosecond(duration)
+			s, err := json.Marshal(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(s), substr) {
+				t.Errorf("Encoded json expected to contain %q, got %q", substr, s)
+			}
+			if string(s) != expectedStr {
+				t.Errorf("Encoded json expected to be %q, got %q", expectedStr, s)
+			}
+
+			v.Duration = 0
+			err = json.Unmarshal(s, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v.Duration.ToDuration() != duration {
+				t.Errorf("Duration expected %v, got %v", duration, v.Duration)
 			}
 		},
 	)

--- a/timebp/millisecond_test.go
+++ b/timebp/millisecond_test.go
@@ -1,0 +1,130 @@
+package timebp_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/reddit/baseplate.go/timebp"
+)
+
+type jsonTestTypeMillisecond struct {
+	Timestamp timebp.TimestampMillisecond `json:"timestamp,omitempty"`
+}
+
+func TestTimestampMillisecondQuick(t *testing.T) {
+	f := func(ms int64) bool {
+		time := timebp.MillisecondsToTime(ms)
+		actual := timebp.TimeToMilliseconds(time)
+		if actual != ms {
+			t.Errorf(
+				"For timestamp %d we got %v and %d", ms, time, actual,
+			)
+			return false
+		}
+		return true
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTimestampMillisecondJSONQuick(t *testing.T) {
+	f := func(ms int64) bool {
+		var v1, v2 jsonTestTypeMillisecond
+
+		v1 = jsonTestTypeMillisecond{
+			Timestamp: timebp.TimestampMillisecond(timebp.MillisecondsToTime(ms)),
+		}
+		s, err := json.Marshal(v1)
+		if err != nil {
+			t.Error(err)
+			return false
+		}
+		substr := strconv.FormatInt(ms, 10)
+		if !strings.Contains(string(s), substr) {
+			t.Errorf("Encoded json expected to contain %q, got %q", substr, s)
+		}
+
+		err = json.Unmarshal(s, &v2)
+		if err != nil {
+			t.Error(err)
+			return false
+		}
+		if !v2.Timestamp.ToTime().Equal(v1.Timestamp.ToTime()) {
+			t.Errorf("Expected timestamp %v, got %v", v1.Timestamp, v2.Timestamp)
+		}
+		return !t.Failed()
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestTimestampMillisecondJSON(t *testing.T) {
+	var v jsonTestTypeMillisecond
+
+	t.Run(
+		"null",
+		func(t *testing.T) {
+			s, err := json.Marshal(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			substr := "null"
+			if !strings.Contains(string(s), substr) {
+				t.Errorf("Encoded json expected to contain %q, got %q", substr, s)
+			}
+			expectedStr := `{"timestamp":null}`
+			if string(s) != expectedStr {
+				t.Errorf("Encoded json expected to be %q, got %q", expectedStr, s)
+			}
+
+			v.Timestamp = timebp.TimestampMillisecond(time.Now())
+			err = json.Unmarshal(s, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v.Timestamp.ToTime().IsZero() {
+				t.Errorf("Timestamp expected to be zero, got %v", v.Timestamp)
+			}
+		},
+	)
+
+	label := "2019-12-31T23:59:59.123Z"
+	t.Run(
+		label,
+		func(t *testing.T) {
+			const substr = "1577836799123"
+
+			ts, err := time.Parse(time.RFC3339Nano, label)
+			if err != nil {
+				t.Fatal(err)
+			}
+			v.Timestamp = timebp.TimestampMillisecond(ts)
+			s, err := json.Marshal(v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(s), substr) {
+				t.Errorf("Encoded json expected to contain %q, got %q", substr, s)
+			}
+			expectedStr := `{"timestamp":` + substr + `}`
+			if string(s) != expectedStr {
+				t.Errorf("Encoded json expected to be %q, got %q", expectedStr, s)
+			}
+
+			v.Timestamp = timebp.TimestampMillisecond(time.Now())
+			err = json.Unmarshal(s, &v)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !v.Timestamp.ToTime().Equal(ts) {
+				t.Errorf("Timestamp expected %v, got %v", ts, v.Timestamp)
+			}
+		},
+	)
+}

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math/rand"
 	"time"
+
+	"github.com/reddit/baseplate.go/timebp"
 )
 
 // SpanType enum.
@@ -77,14 +79,14 @@ func (s *Span) ToZipkinSpan() ZipkinSpan {
 		TraceID:  s.traceID,
 		Name:     s.name,
 		SpanID:   s.spanID,
-		Start:    ZipkinTimestamp(s.start),
+		Start:    timebp.TimestampMicrosecond(s.start),
 		ParentID: s.parentID,
 	}
 	end := s.end
 	if end.IsZero() {
 		end = time.Now()
 	}
-	zs.Duration = ZipkinDuration(end.Sub(s.start))
+	zs.Duration = timebp.DurationMicrosecond(end.Sub(s.start))
 
 	var endpoint ZipkinEndpointInfo
 	if s.tracer != nil {
@@ -97,12 +99,12 @@ func (s *Span) ToZipkinSpan() ZipkinSpan {
 			{
 				Endpoint:  endpoint,
 				Key:       ZipkinTimeAnnotationKeyServerReceive,
-				Timestamp: ZipkinTimestamp(s.start),
+				Timestamp: timebp.TimestampMicrosecond(s.start),
 			},
 			{
 				Endpoint:  endpoint,
 				Key:       ZipkinTimeAnnotationKeyServerSend,
-				Timestamp: ZipkinTimestamp(end),
+				Timestamp: timebp.TimestampMicrosecond(end),
 			},
 		}
 	case SpanTypeClient:
@@ -110,12 +112,12 @@ func (s *Span) ToZipkinSpan() ZipkinSpan {
 			{
 				Endpoint:  endpoint,
 				Key:       ZipkinTimeAnnotationKeyClientSend,
-				Timestamp: ZipkinTimestamp(s.start),
+				Timestamp: timebp.TimestampMicrosecond(s.start),
 			},
 			{
 				Endpoint:  endpoint,
 				Key:       ZipkinTimeAnnotationKeyClientReceive,
-				Timestamp: ZipkinTimestamp(end),
+				Timestamp: timebp.TimestampMicrosecond(end),
 			},
 		}
 	}

--- a/tracing/zipkin.go
+++ b/tracing/zipkin.go
@@ -1,15 +1,8 @@
 package tracing
 
 import (
-	"encoding/json"
-	"errors"
-	"strconv"
-	"time"
+	"github.com/reddit/baseplate.go/timebp"
 )
-
-// ErrZeroZipkinTimestamp is the error returned when the ZipkinTimestamp field
-// is zero.
-var ErrZeroZipkinTimestamp = errors.New("zero zipkin timestamp")
 
 // ZipkinSpan defines a span in zipkin's json format.
 //
@@ -20,11 +13,11 @@ var ErrZeroZipkinTimestamp = errors.New("zero zipkin timestamp")
 // https://github.com/reddit/baseplate.py/blob/1ca8488bcd42c8786e6a3db35b2a99517fd07a99/baseplate/observers/tracing.py#L266-L280
 type ZipkinSpan struct {
 	// Required fields.
-	TraceID  uint64          `json:"traceId"`
-	Name     string          `json:"name"`
-	SpanID   uint64          `json:"id"`
-	Start    ZipkinTimestamp `json:"timestamp"`
-	Duration ZipkinDuration  `json:"duration"`
+	TraceID  uint64                      `json:"traceId"`
+	Name     string                      `json:"name"`
+	SpanID   uint64                      `json:"id"`
+	Start    timebp.TimestampMicrosecond `json:"timestamp"`
+	Duration timebp.DurationMicrosecond  `json:"duration"`
 
 	// parentId is actually optional,
 	// but when it's absent 0 needs to be set explicitly.
@@ -43,8 +36,8 @@ type ZipkinEndpointInfo struct {
 
 // ZipkinTimeAnnotation defines Zipkin's time annotation json format.
 type ZipkinTimeAnnotation struct {
-	Endpoint  ZipkinEndpointInfo `json:"endpoint"`
-	Timestamp ZipkinTimestamp    `json:"timestamp"`
+	Endpoint  ZipkinEndpointInfo          `json:"endpoint"`
+	Timestamp timebp.TimestampMicrosecond `json:"timestamp"`
 	// In time annotations the value is actually the timestamp and the key is
 	// actually the value.
 	Key string `json:"value"`
@@ -74,81 +67,4 @@ const (
 	// Boolean values
 	ZipkinBinaryAnnotationKeyDebug = "debug"
 	ZipkinBinaryAnnotationKeyError = "error"
-)
-
-// ZipkinTimestamp defines zipkin's timestamp format in json.
-type ZipkinTimestamp time.Time
-
-const microsecondsPerSecond = int64(time.Second / time.Microsecond)
-
-func (zt ZipkinTimestamp) toMicrosecond() int64 {
-	t := time.Time(zt)
-	ts := t.Unix() * microsecondsPerSecond
-	ts += int64(t.Nanosecond()) / int64(time.Microsecond)
-	return ts
-}
-
-func (zt ZipkinTimestamp) String() string {
-	return time.Time(zt).String()
-}
-
-// MarshalJSON implements json.Marshaler interface, using epoch microseconds.
-func (zt ZipkinTimestamp) MarshalJSON() ([]byte, error) {
-	if time.Time(zt).IsZero() {
-		return nil, ErrZeroZipkinTimestamp
-	}
-	return []byte(strconv.FormatInt(zt.toMicrosecond(), 10)), nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (zt *ZipkinTimestamp) UnmarshalJSON(data []byte) error {
-	s := string(data)
-	if s == "null" {
-		return nil
-	}
-
-	ts, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return err
-	}
-	// NOTE: A timestamp before the year 1678 or after 2262 would overflow this,
-	// but that's OK.
-	ts *= int64(time.Microsecond)
-	*zt = ZipkinTimestamp(time.Unix(0, ts))
-	return nil
-}
-
-// ZipkinDuration defines zipkin's time duration format in json.
-type ZipkinDuration time.Duration
-
-func (zd ZipkinDuration) String() string {
-	return time.Duration(zd).String()
-}
-
-// MarshalJSON implements json.Marshaler interface, using microseconds.
-func (zd ZipkinDuration) MarshalJSON() ([]byte, error) {
-	n := int64(time.Duration(zd) / time.Microsecond)
-	return []byte(strconv.FormatInt(n, 10)), nil
-}
-
-// UnmarshalJSON implements json.Unmarshaler interface.
-func (zd *ZipkinDuration) UnmarshalJSON(data []byte) error {
-	s := string(data)
-	if s == "null" {
-		return nil
-	}
-
-	d, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return err
-	}
-	*zd = ZipkinDuration(time.Duration(d) * time.Microsecond)
-	return nil
-}
-
-var (
-	_ json.Marshaler   = ZipkinTimestamp{}
-	_ json.Unmarshaler = (*ZipkinTimestamp)(nil)
-	_ json.Marshaler   = ZipkinDuration(0)
-	_ json.Unmarshaler = (*ZipkinDuration)(nil)
 )

--- a/tracing/zipkin_test.go
+++ b/tracing/zipkin_test.go
@@ -2,11 +2,11 @@ package tracing_test
 
 import (
 	"encoding/json"
-	"errors"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/reddit/baseplate.go/timebp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -26,21 +26,21 @@ func TestZipkinSpan(t *testing.T) {
 			TraceID:  1234,
 			Name:     "foo",
 			SpanID:   4321,
-			Start:    tracing.ZipkinTimestamp(now),
-			Duration: tracing.ZipkinDuration(duration),
+			Start:    timebp.TimestampMicrosecond(now),
+			Duration: timebp.DurationMicrosecond(duration),
 		},
 		"optional-filled": {
 			TraceID:  1234,
 			Name:     "foo",
 			SpanID:   4321,
-			Start:    tracing.ZipkinTimestamp(now),
-			Duration: tracing.ZipkinDuration(duration),
+			Start:    timebp.TimestampMicrosecond(now),
+			Duration: timebp.DurationMicrosecond(duration),
 			ParentID: 54321,
 			TimeAnnotations: []tracing.ZipkinTimeAnnotation{
 				{
 					Endpoint:  endpoint,
 					Key:       tracing.ZipkinTimeAnnotationKeyClientReceive,
-					Timestamp: tracing.ZipkinTimestamp(cr),
+					Timestamp: timebp.TimestampMicrosecond(cr),
 				},
 			},
 			BinaryAnnotations: []tracing.ZipkinBinaryAnnotation{
@@ -79,15 +79,4 @@ func TestZipkinSpan(t *testing.T) {
 			},
 		)
 	}
-
-	t.Run(
-		"zero-timestamp",
-		func(t *testing.T) {
-			span := tracing.ZipkinSpan{}
-			_, err := json.Marshal(span)
-			if !errors.Is(err, tracing.ErrZeroZipkinTimestamp) {
-				t.Errorf("Expected ErrZeroZipkinTimestamp, got %v", err)
-			}
-		},
-	)
 }


### PR DESCRIPTION
Move tracing.ZipkinTimestamp, tracing.ZipkinDuration, and
edgecontext.TimestampMillisecond into that package.

Also a slight behavior change on how timebp.TimestampMicrosecond handles
"null" in json marshal/unmarshal.