### PR TITLE
edgecontext: Also verify the signing method

### DIFF
--- a/edgecontext/init_test.go
+++ b/edgecontext/init_test.go
@@ -24,8 +24,6 @@ const secretStore = `
 }`
 
 func TestMain(m *testing.M) {
-	log.InitLogger(log.DebugLevel)
-
 	dir, err := ioutil.TempDir("", "edge_context_test_")
 	if err != nil {
 		log.Panic(err)

--- a/edgecontext/validator.go
+++ b/edgecontext/validator.go
@@ -70,7 +70,7 @@ func ValidateToken(token string) (*AuthenticationToken, error) {
 			continue
 		}
 
-		if claims, ok := token.Claims.(*AuthenticationToken); ok && token.Valid {
+		if claims, ok := token.Claims.(*AuthenticationToken); ok && token.Valid && token.Method.Alg() == jwtAlg {
 			return claims, nil
 		}
 


### PR DESCRIPTION
Also disable logging in tests as the failure auth tests will call
log.Errorw.