### PR TITLE
tracing: Add server timeout span annotation

### DIFF
--- a/tracing/span.go
+++ b/tracing/span.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"time"
 
@@ -229,6 +230,9 @@ func (s *Span) End(ctx context.Context, err error) error {
 
 	if err != nil {
 		s.SetTag(ZipkinBinaryAnnotationKeyError, true)
+		if s.spanType == SpanTypeServer && errors.Is(err, context.DeadlineExceeded) {
+			s.SetTag(ZipkinBinaryAnnotationKeyTimeOut, true)
+		}
 	}
 	if s.isDebugSet() {
 		s.SetTag(ZipkinBinaryAnnotationKeyDebug, true)

--- a/tracing/zipkin.go
+++ b/tracing/zipkin.go
@@ -65,6 +65,7 @@ const (
 	ZipkinBinaryAnnotationKeyLocalComponent = "lc"
 
 	// Boolean values
-	ZipkinBinaryAnnotationKeyDebug = "debug"
-	ZipkinBinaryAnnotationKeyError = "error"
+	ZipkinBinaryAnnotationKeyDebug   = "debug"
+	ZipkinBinaryAnnotationKeyError   = "error"
+	ZipkinBinaryAnnotationKeyTimeOut = "timed_out"
 )


### PR DESCRIPTION
Add Baseplate.py 1.2 server timeout span annotation. Note that this
change does not add the metrics.