### PR TITLE
Span enhancements and cleanup

### DIFF
--- a/metricsbp/example_baseplate_hooks_test.go
+++ b/metricsbp/example_baseplate_hooks_test.go
@@ -12,10 +12,7 @@ func ExampleBaseplateHook() {
 	const prefix = "service.server"
 
 	// initialize the BaseplateHook
-	hook := metricsbp.BaseplateHook{
-		Prefix:  prefix,
-		Metrics: statsd,
-	}
+	hook := metricsbp.BaseplateHook{Metrics: statsd}
 
 	// register the hook with Baseplate
 	tracing.RegisterBaseplateHook(hook)

--- a/tracing/error_reporter_hooks.go
+++ b/tracing/error_reporter_hooks.go
@@ -15,16 +15,8 @@ func (h ErrorReporterBaseplateHook) OnServerSpanCreate(span *Span) error {
 }
 
 // ErrorReporterSpanHook publishes errors sent to OnEnd to Sentry.
-type ErrorReporterSpanHook struct{}
-
-// OnCreateChild is a nop.
-func (h ErrorReporterSpanHook) OnCreateChild(child *Span) error {
-	return nil
-}
-
-// OnStart is a nop
-func (h ErrorReporterSpanHook) OnStart(span *Span) error {
-	return nil
+type ErrorReporterSpanHook struct {
+	NopSpanHook
 }
 
 // OnEnd logs a message and sends err to Sentry if err is non-nil.
@@ -32,16 +24,6 @@ func (h ErrorReporterSpanHook) OnEnd(span *Span, err error) error {
 	if err != nil {
 		raven.CaptureError(err, nil)
 	}
-	return nil
-}
-
-// OnSetTag is a nop
-func (h ErrorReporterSpanHook) OnSetTag(span *Span, key string, value interface{}) error {
-	return nil
-}
-
-// OnAddCounter is a nop
-func (h ErrorReporterSpanHook) OnAddCounter(span *Span, key string, delta float64) error {
 	return nil
 }
 

--- a/tracing/error_reporter_hooks.go
+++ b/tracing/error_reporter_hooks.go
@@ -35,6 +35,16 @@ func (h ErrorReporterSpanHook) OnEnd(span *Span, err error) error {
 	return nil
 }
 
+// OnSetTag is a nop
+func (h ErrorReporterSpanHook) OnSetTag(span *Span, key string, value interface{}) error {
+	return nil
+}
+
+// OnAddCounter is a nop
+func (h ErrorReporterSpanHook) OnAddCounter(span *Span, key string, delta float64) error {
+	return nil
+}
+
 var (
 	_ BaseplateHook = ErrorReporterBaseplateHook{}
 	_ SpanHook      = ErrorReporterSpanHook{}

--- a/tracing/hooks.go
+++ b/tracing/hooks.go
@@ -41,3 +41,34 @@ func onServerSpanCreate(span *Span) {
 		}
 	}
 }
+
+// NopSpanHook can be embedded in a SpanHook implementation to provide default,
+// no-op implementations for all methods in the SpanHook interface.
+type NopSpanHook struct{}
+
+// OnCreateChild is a nop
+func (h NopSpanHook) OnCreateChild(child *Span) error {
+	return nil
+}
+
+// OnStart is a nop
+func (h NopSpanHook) OnStart(span *Span) error {
+	return nil
+}
+
+// OnEnd is a nop
+func (h NopSpanHook) OnEnd(span *Span, err error) error {
+	return nil
+}
+
+// OnSetTag is a nop
+func (h NopSpanHook) OnSetTag(span *Span, key string, value interface{}) error {
+	return nil
+}
+
+// OnAddCounter is a nop
+func (h NopSpanHook) OnAddCounter(span *Span, key string, delta float64) error {
+	return nil
+}
+
+var _ SpanHook = NopSpanHook{}

--- a/tracing/hooks.go
+++ b/tracing/hooks.go
@@ -12,6 +12,8 @@ type SpanHook interface {
 	OnCreateChild(child *Span) error
 	OnStart(span *Span) error
 	OnEnd(span *Span, err error) error
+	OnSetTag(span *Span, key string, value interface{}) error
+	OnAddCounter(span *Span, key string, delta float64) error
 }
 
 var (

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -256,11 +256,23 @@ func (s *Span) End(ctx context.Context, err error) error {
 // AddCounter adds delta to a counter annotation.
 func (s *Span) AddCounter(key string, delta float64) {
 	s.counters[key] += delta
+
+	for _, hook := range s.hooks {
+		if err := hook.OnAddCounter(s, key, delta); err != nil && s.tracer.Logger != nil {
+			s.tracer.Logger("OnAddCounter hook error: " + err.Error())
+		}
+	}
 }
 
 // SetTag sets a binary tag annotation.
 func (s *Span) SetTag(key string, value interface{}) {
 	s.tags[key] = value
+
+	for _, hook := range s.hooks {
+		if err := hook.OnSetTag(s, key, value); err != nil && s.tracer.Logger != nil {
+			s.tracer.Logger("OnSetTag hook error: " + err.Error())
+		}
+	}
 }
 
 // SetDebug sets or unsets the debug flag of this span.


### PR DESCRIPTION
* Remove 'Prefix' from metricsbp.BaseplateHook
  - This should be set by the metrics client and/or whatever backend
    is collecting your metrics

* Add 'OnSetTag' and 'OnAddCounter' functions to the `tracing.SpanHook`
  interface.
  - This brings us close to par with the span Observers in baseplate.py