### PR TITLE
metricsbp: Deprecate* Statsd.StopReporting

### DIFF
--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -49,7 +49,6 @@ func TestOnServerSpanCreate(t *testing.T) {
 			DefaultSampleRate: sampleRate,
 		},
 	)
-	defer st.StopReporting()
 
 	hook := metricsbp.BaseplateHook{Metrics: st}
 	tracing.RegisterBaseplateHook(hook)

--- a/metricsbp/example_nil_check_test.go
+++ b/metricsbp/example_nil_check_test.go
@@ -29,15 +29,16 @@ func ExampleCheckNilFields() {
 		sampleRate = 1
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	st := metricsbp.NewStatsd(
-		context.Background(),
+		ctx,
 		metricsbp.StatsdConfig{
 			Prefix:            prefix,
 			Address:           statsdAddr,
 			DefaultSampleRate: sampleRate,
 		},
 	)
-	defer st.StopReporting()
 
 	// Initialize metrics
 	m := PreCreatedMetrics{

--- a/metricsbp/statsd_test.go
+++ b/metricsbp/statsd_test.go
@@ -29,7 +29,6 @@ func BenchmarkStatsd(b *testing.B) {
 			Labels:            initialLabels,
 		},
 	)
-	defer st.StopReporting()
 
 	b.Run(
 		"pre-create",

--- a/metricsbp/sys_stats.go
+++ b/metricsbp/sys_stats.go
@@ -23,7 +23,7 @@ func pullRuntimeStats() (cpu cpuStats, mem runtime.MemStats) {
 
 // RunSysStats starts a goroutine to periodically pull and report sys stats.
 //
-// StopReporting will also stop this goroutine.
+// Canceling the context passed into NewStatsd will stop this goroutine.
 func (st Statsd) RunSysStats() {
 	// init the gauges
 	// cpu
@@ -60,10 +60,7 @@ func (st Statsd) RunSysStats() {
 	// other
 	memOther := st.Gauge("mem.othersys")
 
-	st.wg.Add(1)
 	go func() {
-		defer st.wg.Done()
-
 		ticker := time.NewTicker(SysStatsTickerInterval)
 		defer ticker.Stop()
 


### PR DESCRIPTION
Simplify it that canceling the passed in context is sufficient to
reclaim all the resources and stop all the goroutines.

The old code also has a bug that if NewStatsd is called with empty
Address, calling RunSysStats could panic. It's fixed with this change as
well.

* Actually it's "delete", so this is a breaking change.