### PR TITLE
tracing.getFirstIPv4 -> runtimebp.GetFirstIPv4

### DIFF
--- a/runtimebp/doc.go
+++ b/runtimebp/doc.go
@@ -1,3 +1,2 @@
-// Package runtimebp provides some container aware extensions to the stdlib
-// runtime package.
+// Package runtimebp provides extensions to the stdlib runtime package.
 package runtimebp

--- a/runtimebp/ip.go
+++ b/runtimebp/ip.go
@@ -1,4 +1,4 @@
-package tracing
+package runtimebp
 
 import (
 	"errors"
@@ -9,10 +9,12 @@ import (
 // UndefinedIP is used when we fail to get the ip address of this machine.
 const UndefinedIP = "undefined"
 
-var errNoIPv4Found = errors.New("no IPv4 ip found")
+// ErrNoIPv4Found is an error could be returned by GetFirstIPv4 when we can't
+// find any non-loopback IPv4 addresses on this machine.
+var ErrNoIPv4Found = errors.New("runtimebp: no IPv4 ip found")
 
-// get the first IPv4 address that's not loopback.
-func getFirstIPv4() (string, error) {
+// GetFirstIPv4 returns the first local IPv4 address that's not a loopback.
+func GetFirstIPv4() (string, error) {
 	host, err := os.Hostname()
 	if err != nil {
 		return UndefinedIP, err
@@ -32,5 +34,5 @@ func getFirstIPv4() (string, error) {
 		}
 		return ip.String(), nil
 	}
-	return UndefinedIP, errNoIPv4Found
+	return UndefinedIP, ErrNoIPv4Found
 }

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -7,6 +7,7 @@ import (
 	"testing/quick"
 
 	"github.com/reddit/baseplate.go/randbp"
+	"github.com/reddit/baseplate.go/runtimebp"
 )
 
 func TestDebugFlag(t *testing.T) {
@@ -178,7 +179,7 @@ var (
 )
 
 func TestChildSpan(t *testing.T) {
-	ip, err := getFirstIPv4()
+	ip, err := runtimebp.GetFirstIPv4()
 	if err != nil {
 		t.Logf("Unable to get local ip address: %v", err)
 	}
@@ -240,7 +241,7 @@ func TestChildSpan(t *testing.T) {
 }
 
 func TestCreateServerSpan(t *testing.T) {
-	ip, err := getFirstIPv4()
+	ip, err := runtimebp.GetFirstIPv4()
 	if err != nil {
 		t.Logf("Unable to get local ip address: %v", err)
 	}

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/randbp"
+	"github.com/reddit/baseplate.go/runtimebp"
 )
 
 // Configuration values for the message queue.
@@ -82,7 +83,7 @@ func InitGlobalTracer(
 	}
 	GlobalTracer.Recorder = recorder
 
-	ip, err := getFirstIPv4()
+	ip, err := runtimebp.GetFirstIPv4()
 	if err != nil && logger != nil {
 		logger(`Unable to get local ip address: ` + err.Error())
 	}

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"
+	"github.com/reddit/baseplate.go/runtimebp"
 )
 
 func TestTracer(t *testing.T) {
@@ -20,7 +21,7 @@ func TestTracer(t *testing.T) {
 		return
 	}
 
-	ip, err := getFirstIPv4()
+	ip, err := runtimebp.GetFirstIPv4()
 	if err != nil {
 		t.Logf("Unable to get local ip address: %v", err)
 	}


### PR DESCRIPTION
Export the function as it will be useful for microservices wanted to add
that as a label to their metrics.

I chose runtimebp package over metricsbp package as the use case is not
limited to metrics, and also moving it into metricsbp will cause cyclic
importing.