### PR TITLE
Migrate more metrics related examples to metricsbp.M

### DIFF
--- a/metricsbp/example_timer_test.go
+++ b/metricsbp/example_timer_test.go
@@ -11,7 +11,6 @@ func ExampleTimer() {
 	type timerContextKeyType struct{}
 	// variables should be properly initialized in production code
 	var (
-		statsd          metricsbp.Statsd
 		ctx             context.Context
 		timerContextKey timerContextKeyType
 	)
@@ -21,7 +20,7 @@ func ExampleTimer() {
 	ctx = context.WithValue(
 		ctx,
 		timerContextKey,
-		metricsbp.NewTimer(statsd.Histogram(metricsPath)),
+		metricsbp.NewTimer(metricsbp.M.Histogram(metricsPath)),
 	)
 	// do the work
 	dummyCall(ctx)

--- a/signing/doc_test.go
+++ b/signing/doc_test.go
@@ -14,7 +14,6 @@ func Example() {
 	var (
 		store      *secrets.Store
 		secretPath string
-		metrics    metricsbp.Statsd
 	)
 
 	secret, _ := store.GetVersionedSecret(secretPath)
@@ -31,12 +30,12 @@ func Example() {
 	// Verify
 	err := signing.Verify([]byte(msg), signature, secret.GetAll()...)
 	if err != nil {
-		metrics.Counter("invalid-signature").Add(1)
+		metricsbp.M.Counter("invalid-signature").Add(1)
 		var e signing.VerifyError
 		if errors.As(err, &e) {
 			switch e.Reason {
 			case signing.VerifyErrorReasonExpired:
-				metrics.Counter("signature-expired").Add(1)
+				metricsbp.M.Counter("signature-expired").Add(1)
 			}
 		}
 	}


### PR DESCRIPTION
Note that I haven't changed `metricsbp.BaseplateHook` and related code/tests/examples. @pacejackson maybe you can do that with your span refactor.