### PR TITLE
batcherror: Better inspectibility with Is and As

### DIFF
--- a/batcherror/batch_test.go
+++ b/batcherror/batch_test.go
@@ -2,7 +2,6 @@ package batcherror_test
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -140,31 +139,5 @@ func TestGetErrors(t *testing.T) {
 			expect,
 			errs,
 		)
-	}
-}
-
-func TestUnwrap(t *testing.T) {
-	expected := errors.New("foo")
-	err0 := fmt.Errorf("wrapped: %w", expected)
-
-	var batch batcherror.BatchError
-	if err := batch.Unwrap(); err != nil {
-		t.Errorf("Unwrap on empty batch expected nil, got %#v", err)
-	}
-	if errors.Is(batch, expected) {
-		t.Errorf("errors.Is on empty batch expected false, got true")
-	}
-
-	batch.Add(err0)
-	if !errors.Is(batch, expected) {
-		t.Errorf("errors.Is on one item batch expected true, got false")
-	}
-
-	batch.Add(err0)
-	if err := batch.Unwrap(); err != nil {
-		t.Errorf("Unwrap on more-than-one batch expected nil, got %#v", err)
-	}
-	if errors.Is(batch, expected) {
-		t.Errorf("errors.Is on more-than-one batch expected false, got true")
 	}
 }


### PR DESCRIPTION
Implement Is and As for BatchError so that any error inside the batch
can be inspected with errors.Is and errors.As, including wrapped ones.

Also remove Unwrap, as it's no longer useful.