### PR TITLE
metricsbp: Allow Statsd to fallback to M

### DIFF
--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -13,7 +13,7 @@ const (
 
 // BaseplateHook registers each Server Span with a MetricsSpanHook.
 type BaseplateHook struct {
-	Metrics Statsd
+	Metrics *Statsd
 }
 
 // OnServerSpanCreate registers MetricSpanHooks on a Server Span.
@@ -30,12 +30,12 @@ type SpanHook struct {
 	tracing.NopSpanHook
 
 	Name    string
-	Metrics Statsd
+	Metrics *Statsd
 
 	timer *Timer
 }
 
-func newSpanHook(metrics Statsd, span *tracing.Span) SpanHook {
+func newSpanHook(metrics *Statsd, span *tracing.Span) SpanHook {
 	name := fmt.Sprintf("%v.%s", span.SpanType(), span.Name)
 	return SpanHook{
 		Name:    name,

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-func runSpan(st metricsbp.Statsd, spanErr error) (counter string, successCounter string, histogram string, err error) {
+func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounter string, histogram string, err error) {
 	ctx := context.Background()
 	span := tracing.StartSpanFromThriftContext(ctx, "foo")
 	time.Sleep(time.Millisecond)

--- a/metricsbp/example_baseplate_hooks_test.go
+++ b/metricsbp/example_baseplate_hooks_test.go
@@ -7,12 +7,10 @@ import (
 
 // This example demonstrates how to use BaseplateHook.
 func ExampleBaseplateHook() {
-	// variables should be properly initialized in production code
-	var statsd metricsbp.Statsd
 	const prefix = "service.server"
 
 	// initialize the BaseplateHook
-	hook := metricsbp.BaseplateHook{Metrics: statsd}
+	hook := metricsbp.BaseplateHook{}
 
 	// register the hook with Baseplate
 	tracing.RegisterBaseplateHook(hook)

--- a/metricsbp/sys_stats.go
+++ b/metricsbp/sys_stats.go
@@ -24,7 +24,9 @@ func pullRuntimeStats() (cpu cpuStats, mem runtime.MemStats) {
 // RunSysStats starts a goroutine to periodically pull and report sys stats.
 //
 // Canceling the context passed into NewStatsd will stop this goroutine.
-func (st Statsd) RunSysStats() {
+func (st *Statsd) RunSysStats() {
+	st = st.fallback()
+
 	// init the gauges
 	// cpu
 	cpuGoroutines := st.Gauge("cpu.goroutines")


### PR DESCRIPTION
Change NewStatsd to return *Statsd instead of Statsd, and for all
*Statsd functions, fallback to M when it's nil.

The global statsd change should eliminated most of the use cases to pass
a Statsd around. But for the few cases that's still useful, this change
will allow it to be nil (zero value) when not needed.