### PR TITLE
metricsbp: Split histogram into histogram and timing

### DIFF
--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -34,7 +34,7 @@ func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounte
 			counter = stat
 		} else if strings.HasSuffix(stat, "|c") {
 			successCounter = stat
-		} else if strings.HasSuffix(stat, "|ms") {
+		} else if strings.HasSuffix(stat, "|h") {
 			histogram = stat
 		}
 	}
@@ -54,7 +54,10 @@ func TestOnServerSpanCreate(t *testing.T) {
 	tracing.RegisterBaseplateHook(hook)
 	defer tracing.ResetHooks()
 
-	histogramRegex := regexp.MustCompile(`^server\.foo:\d\.\d+\|ms$`)
+	histogramRegex, err := regexp.Compile(`^server\.foo:\d\.\d+\|h$`)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	t.Run(
 		"success",

--- a/metricsbp/doc.go
+++ b/metricsbp/doc.go
@@ -15,15 +15,18 @@
 //     goos: darwin
 //     goarch: amd64
 //     pkg: github.com/reddit/baseplate.go/metricsbp
-//     BenchmarkStatsd/pre-create/histogram-8           9548755               121 ns/op              39 B/op          0 allocs/op
-//     BenchmarkStatsd/pre-create/counter-8            10924286               122 ns/op              44 B/op          0 allocs/op
-//     BenchmarkStatsd/pre-create/gauge-8              100000000               10.7 ns/op             0 B/op          0 allocs/op
-//     BenchmarkStatsd/on-the-fly/histogram-8           4342429               247 ns/op              94 B/op          2 allocs/op
-//     BenchmarkStatsd/on-the-fly/counter-8             4850746               263 ns/op             125 B/op          2 allocs/op
-//     BenchmarkStatsd/on-the-fly/gauge-8              29172970                40.7 ns/op             0 B/op          0 allocs/op
-//     BenchmarkStatsd/on-the-fly-with-labels/histogram-8               2687974               449 ns/op             191 B/op          4 allocs/op
-//     BenchmarkStatsd/on-the-fly-with-labels/counter-8                 2680872               448 ns/op             191 B/op          4 allocs/op
-//     BenchmarkStatsd/on-the-fly-with-labels/gauge-8                   3645584               331 ns/op             112 B/op          3 allocs/op
+//     BenchmarkStatsd/pre-create/histogram-8         	 8583646	       124 ns/op	      44 B/op	       0 allocs/op
+//     BenchmarkStatsd/pre-create/timing-8            	10221859	       120 ns/op	      47 B/op	       0 allocs/op
+//     BenchmarkStatsd/pre-create/counter-8           	10205341	       120 ns/op	      47 B/op	       0 allocs/op
+//     BenchmarkStatsd/pre-create/gauge-8             	96462238	        12.4 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkStatsd/on-the-fly/histogram-8         	 4665778	       256 ns/op	      99 B/op	       2 allocs/op
+//     BenchmarkStatsd/on-the-fly/timing-8            	 4784816	       273 ns/op	     126 B/op	       2 allocs/op
+//     BenchmarkStatsd/on-the-fly/counter-8           	 4818908	       259 ns/op	     125 B/op	       2 allocs/op
+//     BenchmarkStatsd/on-the-fly/gauge-8             	28754060	        40.6 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkStatsd/on-the-fly-with-labels/histogram-8         	 2624264	       453 ns/op	     192 B/op	       4 allocs/op
+//     BenchmarkStatsd/on-the-fly-with-labels/timing-8            	 2639377	       449 ns/op	     192 B/op	       4 allocs/op
+//     BenchmarkStatsd/on-the-fly-with-labels/counter-8           	 2600418	       457 ns/op	     193 B/op	       4 allocs/op
+//     BenchmarkStatsd/on-the-fly-with-labels/gauge-8             	 3429901	       339 ns/op	     112 B/op	       3 allocs/op
 //     PASS
-//     ok      github.com/reddit/baseplate.go/metricsbp        14.045s
+//     ok  	github.com/reddit/baseplate.go/metricsbp	18.675s
 package metricsbp

--- a/metricsbp/example_timer_test.go
+++ b/metricsbp/example_timer_test.go
@@ -20,7 +20,7 @@ func ExampleTimer() {
 	ctx = context.WithValue(
 		ctx,
 		timerContextKey,
-		metricsbp.NewTimer(metricsbp.M.Histogram(metricsPath)),
+		metricsbp.NewTimer(metricsbp.M.Timing(metricsPath)),
 	)
 	// do the work
 	dummyCall(ctx)

--- a/metricsbp/statsd.go
+++ b/metricsbp/statsd.go
@@ -148,12 +148,22 @@ func (st *Statsd) Counter(name string) metrics.Counter {
 	return st.Statsd.NewCounter(name, st.sampleRate)
 }
 
-// Histogram returns a histogram metrics to the name.
+// Histogram returns a histogram metrics to the name with no specific unit.
+//
+// It uses the DefaultSampleRate used to create Statsd object.
+// If you need a different sample rate,
+// you could use st.Statsd.NewHistogram instead.
+func (st *Statsd) Histogram(name string) metrics.Histogram {
+	st = st.fallback()
+	return st.Statsd.NewHistogram(name, st.sampleRate)
+}
+
+// Timing returns a histogram metrics to the name with milliseconds as the unit.
 //
 // It uses the DefaultSampleRate used to create Statsd object.
 // If you need a different sample rate,
 // you could use st.Statsd.NewTiming instead.
-func (st *Statsd) Histogram(name string) metrics.Histogram {
+func (st *Statsd) Timing(name string) metrics.Histogram {
 	st = st.fallback()
 	return st.Statsd.NewTiming(name, st.sampleRate)
 }


### PR DESCRIPTION
We used to use go-kit's statsd implementation, which only provided
timing as histogram. We have since switched to influxstatsd
implementation, which actually provided both histogram and timing.

I looked into the code, looks like the only difference between them is
that for histograms it's writing to the wire with "|h" while for timing
it's writing to the wire with "|ms".