### PR TITLE
Add http go-kit integrations

### DIFF
--- a/httpbp/doc.go
+++ b/httpbp/doc.go
@@ -1,0 +1,3 @@
+// Package httpbp provides Baseplate specific helpers and integrations for http
+// services using go-kit.
+package httpbp

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -1,0 +1,209 @@
+package httpbp
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	// EdgeContextHeader is the key use to get the raw edge context from
+	// the HTTP request headers.
+	EdgeContextHeader = "X-Edge-Request"
+
+	// ParentIDHeader is the key use to get the span parent ID from
+	// the HTTP request headers.
+	ParentIDHeader = "X-Parent"
+
+	// SpanIDHeader is the key use to get the span ID from the HTTP
+	// request headers.
+	SpanIDHeader = "X-Span"
+
+	// SpanFlagsHeader is the key use to get the span flags from the HTTP
+	// request headers.
+	SpanFlagsHeader = "X-Flags"
+
+	// SpanSampledHeader is the key use to get the sampled flag from the
+	// HTTP request headers.
+	SpanSampledHeader = "X-Sampled"
+
+	// TraceIDHeader is the key use to get the trace ID from the HTTP
+	// request headers.
+	TraceIDHeader = "X-Trace"
+)
+
+type headerContextKey int
+
+const (
+	edgeContextContextKey headerContextKey = iota
+	traceIDContextKey
+	parentIDContextKey
+	spanIDContextKey
+	spanFlagsContextKey
+	spanSampledContextKey
+)
+
+// HeaderContextKey is an Enum used to get HTTP headers from a context object.
+//
+// It is not used as the actual key in the context, these enums are mapped to
+// un-exported values that serve as the actual context keys.
+type HeaderContextKey int
+
+const (
+	// EdgeContextContextKey is the key for the raw edge request context
+	EdgeContextContextKey HeaderContextKey = iota
+
+	// TraceIDContextKey is the header for the trace ID passed by the caller
+	TraceIDContextKey
+
+	// ParentIDContextKey is the header for the parent ID passed by the caller
+	ParentIDContextKey
+
+	// SpanIDContextKey is the header for the span ID passed by the caller
+	SpanIDContextKey
+
+	// SpanFlagsContextKey is the header for the span flags passed by the caller
+	SpanFlagsContextKey
+
+	// SpanSampledContextKey is the header for the sampled flag passed by the caller
+	SpanSampledContextKey
+)
+
+var headerKeyToContextKey = map[HeaderContextKey]headerContextKey{
+	EdgeContextContextKey: edgeContextContextKey,
+	TraceIDContextKey:     traceIDContextKey,
+	ParentIDContextKey:    parentIDContextKey,
+	SpanIDContextKey:      spanIDContextKey,
+	SpanFlagsContextKey:   spanFlagsContextKey,
+	SpanSampledContextKey: spanSampledContextKey,
+}
+
+// GetHeader returns the HTTP header stored on the context at key.
+func GetHeader(ctx context.Context, key HeaderContextKey) (header string) {
+	if contextKey, ok := headerKeyToContextKey[key]; ok {
+		if h, ok := ctx.Value(contextKey).(string); ok {
+			header = h
+		}
+	}
+	return
+}
+
+// Headers is an interface to collect all of the HTTP headers for a particular
+// baseplate resource (spans and edge contexts) into a struct that provides an
+// easy way to convert them into HTTP headers.
+//
+// This interface exists so we can avoid having to do runtime checks on maps to
+// ensure that they have the right keys set when we are trying to sign or verify
+// a set of HTTP headers.
+type Headers interface {
+	// AsMap returns the Headers struct as a map of header keys to header
+	// values.
+	AsMap() map[string]string
+}
+
+// EdgeContextHeaders implements the Headers interface for HTTP EdgeContext
+// headers.
+type EdgeContextHeaders struct {
+	EdgeRequest string
+}
+
+// NewEdgeContextHeaders returns a new EdgeContextHeaders object from the given
+// HTTP headers.
+func NewEdgeContextHeaders(h http.Header) *EdgeContextHeaders {
+	return &EdgeContextHeaders{
+		EdgeRequest: h.Get(EdgeContextHeader),
+	}
+}
+
+// AsMap returns the EdgeContextHeaders as a map of header keys to header
+// values.
+func (s *EdgeContextHeaders) AsMap() map[string]string {
+	return map[string]string{
+		EdgeContextHeader: s.EdgeRequest,
+	}
+}
+
+// SpanHeaders implements the Headers interface for HTTP Span headers.
+type SpanHeaders struct {
+	TraceID  string
+	ParentID string
+	SpanID   string
+	Flags    string
+	Sampled  string
+}
+
+// NewSpanHeaders returns a new SpanHeaders object from the given HTTP headers.
+func NewSpanHeaders(h http.Header) *SpanHeaders {
+	return &SpanHeaders{
+		TraceID:  h.Get(TraceIDHeader),
+		ParentID: h.Get(ParentIDHeader),
+		SpanID:   h.Get(SpanIDHeader),
+		Flags:    h.Get(SpanFlagsHeader),
+		Sampled:  h.Get(SpanSampledHeader),
+	}
+}
+
+// AsMap returns the SpanHeaders as a map of header keys to header values.
+func (s *SpanHeaders) AsMap() map[string]string {
+	return map[string]string{
+		TraceIDHeader:     s.TraceID,
+		ParentIDHeader:    s.ParentID,
+		SpanIDHeader:      s.SpanID,
+		SpanFlagsHeader:   s.Flags,
+		SpanSampledHeader: s.Sampled,
+	}
+}
+
+var (
+	_ Headers = (*EdgeContextHeaders)(nil)
+	_ Headers = (*SpanHeaders)(nil)
+)
+
+// InjectBaseplateContextFromHTTP takes baseplate HTTP headers from the request,
+// verifies that it should trust the headers using the provided
+// HeaderTrustHandler, and attaches the trusted headers to the context.
+//
+// These headers can be retrieved using httpbp.GetHeader.
+func InjectBaseplateContextFromHTTP(ctx context.Context, t HeaderTrustHandler, r *http.Request) context.Context {
+	if t.TrustEdgeContext(r) {
+		ctx = context.WithValue(
+			ctx,
+			edgeContextContextKey,
+			r.Header.Get(EdgeContextHeader),
+		)
+	}
+
+	if t.TrustSpan(r) {
+		for k, v := range map[headerContextKey]string{
+			traceIDContextKey:     r.Header.Get(TraceIDHeader),
+			parentIDContextKey:    r.Header.Get(ParentIDHeader),
+			spanIDContextKey:      r.Header.Get(SpanIDHeader),
+			spanFlagsContextKey:   r.Header.Get(SpanFlagsHeader),
+			spanSampledContextKey: r.Header.Get(SpanSampledHeader),
+		} {
+			ctx = context.WithValue(ctx, k, v)
+		}
+	}
+
+	return ctx
+}
+
+// PopulateBaseplateRequestContext returns a function that calls
+// InjectBaseplateContextFromHTTP with the HeaderTrustHandler you pass to it.
+// The function that this produces can be passed to go-kit's http.ServerBefore
+// ServerOption.
+//
+// example:
+//		trustHandler := httpbp.NeverTrustHeaders{}
+//		httpgk.NewServer(
+//			endpoints.IsHealthy,
+//			DecodeIsHealthyRequest,
+//			EncodeResponse,
+//			httpgk.ServerBefore(
+//				httpbp.PopulateRequestContext(trustHandler),
+//			),
+//		)
+func PopulateBaseplateRequestContext(t HeaderTrustHandler) func(ctx context.Context, r *http.Request) context.Context {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		return InjectBaseplateContextFromHTTP(ctx, t, r)
+	}
+}

--- a/httpbp/headers_test.go
+++ b/httpbp/headers_test.go
@@ -1,0 +1,283 @@
+package httpbp_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/reddit/baseplate.go/httpbp"
+)
+
+const (
+	traceID     = "1234"
+	parentID    = "5678"
+	spanID      = "90123"
+	flags       = "0"
+	sampled     = "1"
+	edgeContext = "edge-context"
+)
+
+func getHeaders() http.Header {
+	headers := make(http.Header)
+	for k, v := range map[string]string{
+		httpbp.TraceIDHeader:     traceID,
+		httpbp.ParentIDHeader:    parentID,
+		httpbp.SpanIDHeader:      spanID,
+		httpbp.SpanFlagsHeader:   flags,
+		httpbp.SpanSampledHeader: sampled,
+		httpbp.EdgeContextHeader: edgeContext,
+	} {
+		headers.Add(k, v)
+	}
+	return headers
+}
+
+func TestSetAndGetHeaders(t *testing.T) {
+	t.Parallel()
+
+	request := http.Request{Header: getHeaders()}
+	ctx := httpbp.PopulateBaseplateRequestContext(
+		httpbp.AlwaysTrustHeaders{},
+	)(context.Background(), &request)
+
+	cases := []struct {
+		name     string
+		key      httpbp.HeaderContextKey
+		expected string
+	}{
+		{
+			name:     "Trace ID",
+			key:      httpbp.TraceIDContextKey,
+			expected: traceID,
+		},
+		{
+			name:     "Parent ID",
+			key:      httpbp.ParentIDContextKey,
+			expected: parentID,
+		},
+		{
+			name:     "Span ID",
+			key:      httpbp.SpanIDContextKey,
+			expected: spanID,
+		},
+		{
+			name:     "Flags",
+			key:      httpbp.SpanFlagsContextKey,
+			expected: flags,
+		},
+		{
+			name:     "Sampled",
+			key:      httpbp.SpanSampledContextKey,
+			expected: sampled,
+		},
+		{
+			name:     "Edge Context",
+			key:      httpbp.EdgeContextContextKey,
+			expected: edgeContext,
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				header := httpbp.GetHeader(ctx, c.key)
+				if header != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						header,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestNewSpanHeaders(t *testing.T) {
+	t.Parallel()
+
+	headers := getHeaders()
+	spanHeaders := httpbp.NewSpanHeaders(headers)
+
+	cases := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "Trace ID",
+			value:    spanHeaders.TraceID,
+			expected: traceID,
+		},
+		{
+			name:     "Parent ID",
+			value:    spanHeaders.ParentID,
+			expected: parentID,
+		},
+		{
+			name:     "Span ID",
+			value:    spanHeaders.SpanID,
+			expected: spanID,
+		},
+		{
+			name:     "Flags",
+			value:    spanHeaders.Flags,
+			expected: flags,
+		},
+		{
+			name:     "Sampled",
+			value:    spanHeaders.Sampled,
+			expected: sampled,
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				if c.value != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						c.value,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestSpanHeadersAsMap(t *testing.T) {
+	t.Parallel()
+
+	headers := getHeaders()
+	spanHeaders := httpbp.NewSpanHeaders(headers)
+
+	cases := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "Trace ID",
+			key:      httpbp.TraceIDHeader,
+			expected: traceID,
+		},
+		{
+			name:     "Parent ID",
+			key:      httpbp.ParentIDHeader,
+			expected: parentID,
+		},
+		{
+			name:     "Span ID",
+			key:      httpbp.SpanIDHeader,
+			expected: spanID,
+		},
+		{
+			name:     "Flags",
+			key:      httpbp.SpanFlagsHeader,
+			expected: flags,
+		},
+		{
+			name:     "Sampled",
+			key:      httpbp.SpanSampledHeader,
+			expected: sampled,
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				got := spanHeaders.AsMap()[c.key]
+				if got != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						got,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestNewEdgeContextHeaders(t *testing.T) {
+	t.Parallel()
+
+	headers := getHeaders()
+	edgeContextHeaders := httpbp.NewEdgeContextHeaders(headers)
+
+	cases := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{
+			name:     "Edge Context",
+			value:    edgeContextHeaders.EdgeRequest,
+			expected: edgeContext,
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				if c.value != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						c.value,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestEdgeContextHeadersAsMap(t *testing.T) {
+	t.Parallel()
+
+	headers := getHeaders()
+	edgeContextHeaders := httpbp.NewEdgeContextHeaders(headers)
+
+	asHTTPHeadersCases := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "Edge Context",
+			key:      httpbp.EdgeContextHeader,
+			expected: edgeContext,
+		},
+	}
+	for _, _c := range asHTTPHeadersCases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				got := edgeContextHeaders.AsMap()[c.key]
+				if got != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						got,
+					)
+				}
+			},
+		)
+	}
+}

--- a/httpbp/trust_handers.go
+++ b/httpbp/trust_handers.go
@@ -1,0 +1,233 @@
+package httpbp
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/reddit/baseplate.go/secrets"
+	"github.com/reddit/baseplate.go/signing"
+)
+
+const (
+	// EdgeContextSignatureHeader is the key use to get the signature for
+	// the edge context headers from the HTTP request headers.
+	EdgeContextSignatureHeader = "X-Edge-Request-Signature"
+
+	// SpanSignatureHeader is the key use to get the signature for
+	// the span headers from the HTTP request headers.
+	SpanSignatureHeader = "X-Span-Signature"
+)
+
+// HeaderTrustHandler provides an interface PopulateBaseplateRequestContext to
+// verify that it should trust the HTTP headers it receives.
+type HeaderTrustHandler interface {
+	// TrustEdgeContext informs the function returned by PopulateBaseplateRequestContext
+	// if it can trust the HTTP headers that can be used to create an edge
+	// context.
+	//
+	// If it can trust those headers, then the headers will be copied into the
+	// context object to be later used to initialize the edge context for the
+	// request.
+	TrustEdgeContext(r *http.Request) bool
+
+	// TrustSpan informs the function returned by PopulateBaseplateRequestContext
+	// if it can trust the HTTP headers that can be used to create a server
+	// span.
+	//
+	// If it can trust those headers, then the headers will be copied into the
+	// context object to later be used to initialize the server span for the
+	// request.
+	TrustSpan(r *http.Request) bool
+}
+
+// NeverTrustHeaders implements the HeaderTrustHandler interface and always
+// returns false.
+type NeverTrustHeaders struct{}
+
+// TrustEdgeContext always returns false.  The edge context headers will never
+// be added to the context.
+func (h NeverTrustHeaders) TrustEdgeContext(r *http.Request) bool {
+	return false
+}
+
+// TrustSpan always returns false.  The span headers will never be added to the
+// context.
+func (h NeverTrustHeaders) TrustSpan(r *http.Request) bool {
+	return false
+}
+
+// AlwaysTrustHeaders implements the HeaderTrustHandler interface and always
+// returns true.
+type AlwaysTrustHeaders struct{}
+
+// TrustEdgeContext always returns true.  The edge context headers will always
+// be added to the context.
+func (h AlwaysTrustHeaders) TrustEdgeContext(r *http.Request) bool {
+	return true
+}
+
+// TrustSpan always returns true.  The span headers will always be added to the
+// context.
+func (h AlwaysTrustHeaders) TrustSpan(r *http.Request) bool {
+	return true
+}
+
+// HeaderSignatureTrustHandler implements the HeaderTrustHandler interface and
+// checks the headers for a valid signature header.  If the headers are signed,
+// then they can be trusted and the Trust request returns true.  If there is no
+// signature or the signature is invalid, then the Trust request returns false.
+//
+// For both the span and edge context headers, the trust handler expects the
+// caller to provide the signature of a message in the following format:
+//
+// 		"{header0}:{value0}|{header1}|{value1}|...|{headerN}:{valueN}"
+//
+// where the headers are sorted lexicographically.  Additionally, the signature
+// should be generated using the baseplate provided `signing.Sign` function.
+//
+// HeaderSignatureTrustHandler provides implementations for both signing and
+// verifying edge context and span headers.
+type HeaderSignatureTrustHandler struct {
+	secrets               *secrets.Store
+	edgeContextSecretPath string
+	spanSecretPath        string
+}
+
+// HeaderSignatureTrustHandlerArgs is used as input to create a new
+// HeaderSignatureTrustHandler.
+type HeaderSignatureTrustHandlerArgs struct {
+	SecretsStore          *secrets.Store
+	EdgeContextSecretPath string
+	SpanSecretPath        string
+}
+
+// NewHeaderSignatureTrustHandler returns a new HMACTrustHandler that uses the
+// provided HeaderSignatureTrustHandlerArgs
+func NewHeaderSignatureTrustHandler(args HeaderSignatureTrustHandlerArgs) HeaderSignatureTrustHandler {
+	return HeaderSignatureTrustHandler{
+		secrets:               args.SecretsStore,
+		edgeContextSecretPath: args.EdgeContextSecretPath,
+		spanSecretPath:        args.SpanSecretPath,
+	}
+}
+
+func (h HeaderSignatureTrustHandler) signHeaders(headers Headers, secretPath string, expiresIn time.Duration) (string, error) {
+	secret, err := h.secrets.GetVersionedSecret(secretPath)
+	if err != nil {
+		return "", err
+	}
+	return signing.Sign(signing.SignArgs{
+		Message:   headerMessage(headers),
+		Key:       secret.Current,
+		ExpiresIn: expiresIn,
+	})
+}
+
+func (h HeaderSignatureTrustHandler) verifyHeaders(headers Headers, signature string, secretPath string) (bool, error) {
+	if signature == "" {
+		return false, nil
+	}
+
+	secret, err := h.secrets.GetVersionedSecret(secretPath)
+	if err != nil {
+		return false, err
+	}
+
+	if err = signing.Verify(headerMessage(headers), signature, secret.GetAll()...); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// SignEdgeContextHeader signs the edge context header using signing.Sign.
+//
+// The message that is signed has the following format:
+//
+//		"X-Edge-Request:{headerValue}
+func (h HeaderSignatureTrustHandler) SignEdgeContextHeader(headers *EdgeContextHeaders, expiresIn time.Duration) (string, error) {
+	return h.signHeaders(headers, h.edgeContextSecretPath, expiresIn)
+}
+
+// VerifyEdgeContextHeader verifies the edge context header using signing.Verify.
+func (h HeaderSignatureTrustHandler) VerifyEdgeContextHeader(headers *EdgeContextHeaders, signature string) (bool, error) {
+	return h.verifyHeaders(headers, signature, h.edgeContextSecretPath)
+}
+
+// SignSpanHeaders signs the given span headers using signing.Sign.
+//
+// The message that is signed has the following format:
+//
+//		"{header0}:{value0}|{header1}|{value1}|...|{headerN}:{valueN}"
+//
+// where the headers are sorted lexicographically.
+func (h HeaderSignatureTrustHandler) SignSpanHeaders(headers *SpanHeaders, expiresIn time.Duration) (string, error) {
+	return h.signHeaders(headers, h.spanSecretPath, expiresIn)
+}
+
+// VerifySpanHeaders verifies the edge context header using signing.Verify.
+func (h HeaderSignatureTrustHandler) VerifySpanHeaders(headers *SpanHeaders, signature string) (bool, error) {
+	return h.verifyHeaders(headers, signature, h.spanSecretPath)
+}
+
+// TrustEdgeContext returns true if the request has the header
+// "X-Edge-Request-Signature" set and is a valid signature of the header:
+//		"X-Edge-Request"
+//
+// The message that should be signed is:
+//
+//		"X-Edge-Request:{headerValue}"
+func (h HeaderSignatureTrustHandler) TrustEdgeContext(r *http.Request) bool {
+	signature := r.Header.Get(EdgeContextSignatureHeader)
+	ok, err := h.VerifyEdgeContextHeader(NewEdgeContextHeaders(r.Header), signature)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+// TrustSpan returns true if the request has the header
+// "X-Span-Signature" set and is a valid signature of the headers:
+//
+//		"X-Flags"
+//		"X-Parent"
+//		"X-Sampled"
+//		"X-Span"
+//		"X-Trace"
+//
+// The message that should be signed is:
+//
+//		"{header0}:{value0}|{header1}|{value1}|...|{headerN}:{valueN}"
+//
+// where the headers are sorted lexicographically.
+func (h HeaderSignatureTrustHandler) TrustSpan(r *http.Request) bool {
+	signature := r.Header.Get(SpanSignatureHeader)
+	ok, err := h.VerifySpanHeaders(NewSpanHeaders(r.Header), signature)
+	if err != nil {
+		return false
+	}
+	return ok
+}
+
+var (
+	_ HeaderTrustHandler = AlwaysTrustHeaders{}
+	_ HeaderTrustHandler = HeaderSignatureTrustHandler{}
+	_ HeaderTrustHandler = NeverTrustHeaders{}
+)
+
+func headerMessage(h Headers) []byte {
+	headers := h.AsMap()
+	components := make([]string, 0, len(headers))
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		components = append(components, fmt.Sprintf("%s:%s", key, headers[key]))
+	}
+	return []byte(strings.Join(components, "|"))
+}

--- a/httpbp/trust_handlers_test.go
+++ b/httpbp/trust_handlers_test.go
@@ -1,0 +1,513 @@
+package httpbp_test
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/secrets"
+)
+
+const secretsFile = `{
+	"secrets": {
+		"secret/http/edge-context-signature": {
+			"type": "versioned",
+			"current": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=",
+			"previous": "aHVudGVyMg==",
+			"encoding": "base64"
+		},
+		"secret/http/span-signature": {
+			"type": "versioned",
+			"current": "Y2RvVXhNMVdsTXJma3BDaHRGZ0dPYkVGSg==",
+			"encoding": "base64"
+		}
+	},
+	"vault": {
+		"url": "vault.reddit.ue1.snooguts.net",
+		"token": "17213328-36d4-11e7-8459-525400f56d04"
+	}
+}`
+
+func getHeaderSignatureTrustHandler(secretsStore *secrets.Store) httpbp.HeaderSignatureTrustHandler {
+	return httpbp.NewHeaderSignatureTrustHandler(httpbp.HeaderSignatureTrustHandlerArgs{
+		SecretsStore:          secretsStore,
+		EdgeContextSecretPath: "secret/http/edge-context-signature",
+		SpanSecretPath:        "secret/http/span-signature",
+	})
+}
+
+func TestNeverTrustHeaders(t *testing.T) {
+	t.Parallel()
+
+	request := http.Request{Header: getHeaders()}
+	ctx := httpbp.PopulateBaseplateRequestContext(
+		httpbp.NeverTrustHeaders{},
+	)(context.Background(), &request)
+
+	cases := []struct {
+		name     string
+		key      httpbp.HeaderContextKey
+		expected string
+	}{
+		{
+			name:     "Trace ID",
+			key:      httpbp.TraceIDContextKey,
+			expected: "",
+		},
+		{
+			name:     "Parent ID",
+			key:      httpbp.ParentIDContextKey,
+			expected: "",
+		},
+		{
+			name:     "Span ID",
+			key:      httpbp.SpanIDContextKey,
+			expected: "",
+		},
+		{
+			name:     "Flags",
+			key:      httpbp.SpanFlagsContextKey,
+			expected: "",
+		},
+		{
+			name:     "Sampled",
+			key:      httpbp.SpanSampledContextKey,
+			expected: "",
+		},
+		{
+			name:     "Edge Context",
+			key:      httpbp.EdgeContextContextKey,
+			expected: "",
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+				header := httpbp.GetHeader(ctx, c.key)
+				if header != c.expected {
+					t.Errorf(
+						"Expected %s to be %v, got %v",
+						c.name,
+						c.expected,
+						header,
+					)
+				}
+			},
+		)
+	}
+}
+
+func TestHeaderSignatureTrustHandlerSignAndVerify(t *testing.T) {
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Write([]byte(secretsFile))
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(
+		"edge context",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			trustHandler := getHeaderSignatureTrustHandler(store)
+			signature, err := trustHandler.SignEdgeContextHeader(
+				httpbp.NewEdgeContextHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to sign headers: %v", err)
+			}
+
+			ok, err := trustHandler.VerifyEdgeContextHeader(
+				httpbp.NewEdgeContextHeaders(request.Header),
+				signature,
+			)
+			if err != nil {
+				t.Errorf(
+					"Got an unexpected error while trying to verify signature: %v",
+					err,
+				)
+			}
+			if !ok {
+				t.Errorf("Signature %v failed to verify", signature)
+			}
+		},
+	)
+
+	t.Run(
+		"span",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			trustHandler := getHeaderSignatureTrustHandler(store)
+			signature, err := trustHandler.SignSpanHeaders(
+				httpbp.NewSpanHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to sign headers: %v", err)
+			}
+
+			ok, err := trustHandler.VerifySpanHeaders(
+				httpbp.NewSpanHeaders(request.Header),
+				signature,
+			)
+			if err != nil {
+				t.Errorf(
+					"Got an unexpected error while trying to verify signature: %v",
+					err,
+				)
+			}
+			if !ok {
+				t.Errorf("Signature %v failed to verify", signature)
+			}
+		},
+	)
+}
+
+func TestHeaderSignatureTrustHandler(t *testing.T) {
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Write([]byte(secretsFile))
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(
+		"no signature",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			ctx := httpbp.PopulateBaseplateRequestContext(
+				getHeaderSignatureTrustHandler(store),
+			)(context.Background(), &request)
+
+			cases := []struct {
+				name     string
+				key      httpbp.HeaderContextKey
+				expected string
+			}{
+				{
+					name:     "Trace ID",
+					key:      httpbp.TraceIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Parent ID",
+					key:      httpbp.ParentIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Span ID",
+					key:      httpbp.SpanIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Flags",
+					key:      httpbp.SpanFlagsContextKey,
+					expected: "",
+				},
+				{
+					name:     "Sampled",
+					key:      httpbp.SpanSampledContextKey,
+					expected: "",
+				},
+				{
+					name:     "Edge Context",
+					key:      httpbp.EdgeContextContextKey,
+					expected: "",
+				},
+			}
+			for _, _c := range cases {
+				c := _c
+				t.Run(
+					c.name,
+					func(t *testing.T) {
+						header := httpbp.GetHeader(ctx, c.key)
+						if header != c.expected {
+							t.Errorf(
+								"Expected %s to be %v, got %v",
+								c.name,
+								c.expected,
+								header,
+							)
+						}
+					},
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"edge context signature",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			trustHandler := getHeaderSignatureTrustHandler(store)
+			signature, err := trustHandler.SignEdgeContextHeader(
+				httpbp.NewEdgeContextHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to sign headers: %v", err)
+			}
+
+			request.Header.Add(
+				httpbp.EdgeContextSignatureHeader,
+				signature,
+			)
+			ctx := httpbp.PopulateBaseplateRequestContext(
+				getHeaderSignatureTrustHandler(store),
+			)(context.Background(), &request)
+
+			cases := []struct {
+				name     string
+				key      httpbp.HeaderContextKey
+				expected string
+			}{
+				{
+					name:     "Trace ID",
+					key:      httpbp.TraceIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Parent ID",
+					key:      httpbp.ParentIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Span ID",
+					key:      httpbp.SpanIDContextKey,
+					expected: "",
+				},
+				{
+					name:     "Flags",
+					key:      httpbp.SpanFlagsContextKey,
+					expected: "",
+				},
+				{
+					name:     "Sampled",
+					key:      httpbp.SpanSampledContextKey,
+					expected: "",
+				},
+				{
+					name:     "Edge Context",
+					key:      httpbp.EdgeContextContextKey,
+					expected: edgeContext,
+				},
+			}
+			for _, _c := range cases {
+				c := _c
+				t.Run(
+					c.name,
+					func(t *testing.T) {
+						header := httpbp.GetHeader(ctx, c.key)
+						if header != c.expected {
+							t.Errorf(
+								"Expected %s to be %v, got %v",
+								c.name,
+								c.expected,
+								header,
+							)
+						}
+					},
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"span signature",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			trustHandler := getHeaderSignatureTrustHandler(store)
+			signature, err := trustHandler.SignSpanHeaders(
+				httpbp.NewSpanHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to sign headers: %v", err)
+			}
+
+			request.Header.Add(httpbp.SpanSignatureHeader, signature)
+			ctx := httpbp.PopulateBaseplateRequestContext(
+				getHeaderSignatureTrustHandler(store),
+			)(context.Background(), &request)
+
+			cases := []struct {
+				name     string
+				key      httpbp.HeaderContextKey
+				expected string
+			}{
+				{
+					name:     "Trace ID",
+					key:      httpbp.TraceIDContextKey,
+					expected: traceID,
+				},
+				{
+					name:     "Parent ID",
+					key:      httpbp.ParentIDContextKey,
+					expected: parentID,
+				},
+				{
+					name:     "Span ID",
+					key:      httpbp.SpanIDContextKey,
+					expected: spanID,
+				},
+				{
+					name:     "Flags",
+					key:      httpbp.SpanFlagsContextKey,
+					expected: flags,
+				},
+				{
+					name:     "Sampled",
+					key:      httpbp.SpanSampledContextKey,
+					expected: sampled,
+				},
+				{
+					name:     "Edge Context",
+					key:      httpbp.EdgeContextContextKey,
+					expected: "",
+				},
+			}
+			for _, _c := range cases {
+				c := _c
+				t.Run(
+					c.name,
+					func(t *testing.T) {
+						header := httpbp.GetHeader(ctx, c.key)
+						if header != c.expected {
+							t.Errorf(
+								"Expected %s to be %v, got %v",
+								c.name,
+								c.expected,
+								header,
+							)
+						}
+					},
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"both signatures",
+		func(t *testing.T) {
+			request := http.Request{Header: getHeaders()}
+			trustHandler := getHeaderSignatureTrustHandler(store)
+
+			signature, err := trustHandler.SignSpanHeaders(
+				httpbp.NewSpanHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to sign span headers: %v", err)
+			}
+			request.Header.Add(httpbp.SpanSignatureHeader, signature)
+
+			signature, err = trustHandler.SignEdgeContextHeader(
+				httpbp.NewEdgeContextHeaders(request.Header),
+				time.Minute,
+			)
+			if err != nil {
+				t.Fatalf("Got an unexpected error while trying to edge context headers: %v", err)
+			}
+
+			request.Header.Add(
+				httpbp.EdgeContextSignatureHeader,
+				signature,
+			)
+
+			ctx := httpbp.PopulateBaseplateRequestContext(
+				getHeaderSignatureTrustHandler(store),
+			)(context.Background(), &request)
+
+			cases := []struct {
+				name     string
+				key      httpbp.HeaderContextKey
+				expected string
+			}{
+				{
+					name:     "Trace ID",
+					key:      httpbp.TraceIDContextKey,
+					expected: traceID,
+				},
+				{
+					name:     "Parent ID",
+					key:      httpbp.ParentIDContextKey,
+					expected: parentID,
+				},
+				{
+					name:     "Span ID",
+					key:      httpbp.SpanIDContextKey,
+					expected: spanID,
+				},
+				{
+					name:     "Flags",
+					key:      httpbp.SpanFlagsContextKey,
+					expected: flags,
+				},
+				{
+					name:     "Sampled",
+					key:      httpbp.SpanSampledContextKey,
+					expected: sampled,
+				},
+				{
+					name:     "Edge Context",
+					key:      httpbp.EdgeContextContextKey,
+					expected: edgeContext,
+				},
+			}
+			for _, _c := range cases {
+				c := _c
+				t.Run(
+					c.name,
+					func(t *testing.T) {
+						header := httpbp.GetHeader(ctx, c.key)
+						if header != c.expected {
+							t.Errorf(
+								"Expected %s to be %v, got %v",
+								c.name,
+								c.expected,
+								header,
+							)
+						}
+					},
+				)
+			}
+		},
+	)
+}


### PR DESCRIPTION
- [x] Add `httpbp` package to provide the base helpers to get headers from the HTTP request and put them on the context object.
- [x] Add `httpbp.HMACTrustHandler` to allow us to trust HTTP headers based on an HMAC signature
- [x] Add tests for `httpbp` package
- [ ] Add function to build a new EdgeContext from HTTP headers
- [ ] Add tests for `EdgeContextFromHTTP`
- [ ] Add go-kit Middleware to inject an EdgeContext into the context
- [ ] Add tests for `InjectEdgeContext`
- [ ] Add function to build a new Span from HTTP headers
- [ ] Add tests for `SpanFromHTTP`
- [ ] Add go-kit Middleware to inject a server Span into the context
- [ ] Add tests for `InjectServerSpan`