### PR TITLE
secrets: Allow adding additional middlewares

### DIFF
--- a/edgecontext/init_test.go
+++ b/edgecontext/init_test.go
@@ -46,6 +46,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Panic(err)
 	}
+	defer store.Close()
 
 	edgecontext.Init(edgecontext.Config{Store: store})
 	os.Exit(m.Run())

--- a/httpbp/trust_handlers_test.go
+++ b/httpbp/trust_handlers_test.go
@@ -126,6 +126,7 @@ func TestTrustHeaderSignatureSignAndVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer store.Close()
 
 	t.Run(
 		"edge context",
@@ -207,6 +208,7 @@ func TestTrustHeaderSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer store.Close()
 
 	t.Run(
 		"no signature",

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -273,7 +273,7 @@ func NewSecrets(r io.Reader) (*Secrets, error) {
 	return secrets, nil
 }
 
-// Encoding represents the encoding used to encode the secrets.
+// encoding represents the encoding used to encode the secrets.
 type encoding int
 
 const (

--- a/secrets/store_bench_test.go
+++ b/secrets/store_bench_test.go
@@ -1,4 +1,4 @@
-package secrets
+package secrets_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/secrets"
 )
 
 func BenchmarkStoreMiddlewares(b *testing.B) {
@@ -21,8 +22,8 @@ func BenchmarkStoreMiddlewares(b *testing.B) {
 	}
 	tmpFile.Write([]byte(specificationExample))
 
-	var middleware = func(next SecretHandlerFunc) SecretHandlerFunc {
-		return func(sec *Secrets) {
+	var middleware = func(next secrets.SecretHandlerFunc) secrets.SecretHandlerFunc {
+		return func(sec *secrets.Secrets) {
 			next(sec)
 		}
 	}
@@ -30,7 +31,7 @@ func BenchmarkStoreMiddlewares(b *testing.B) {
 	for i := 0; i < 10; i++ {
 		numOfMiddlewares := 1 << i
 
-		middlewares := make([]SecretMiddleware, 0, numOfMiddlewares)
+		middlewares := make([]secrets.SecretMiddleware, 0, numOfMiddlewares)
 
 		for j := 0; j < numOfMiddlewares; j++ {
 			middlewares = append(middlewares, middleware)
@@ -40,7 +41,7 @@ func BenchmarkStoreMiddlewares(b *testing.B) {
 			fmt.Sprintf("number of middlewares %d", numOfMiddlewares),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
-					NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(b), middlewares...)
+					secrets.NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(b), middlewares...)
 				}
 			},
 		)

--- a/secrets/store_internal_test.go
+++ b/secrets/store_internal_test.go
@@ -1,0 +1,80 @@
+package secrets
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+func TestNewStore(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected *Secrets
+	}{
+		{
+			name: "specification example",
+			input: `
+					{
+						"secrets": {
+							"secret/myservice/external-account-key": {
+								"type": "versioned",
+								"current": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=",
+								"previous": "aHVudGVyMg=="
+							},
+							"secret/myservice/some-api-key": {
+								"type": "simple",
+								"value": "Y2RvVXhNMVdsTXJma3BDaHRGZ0dPYkVGSg==",
+								"encoding": "base64"
+							},
+							"secret/myservice/some-database-credentials": {
+								"type": "credential",
+								"username": "spez",
+								"password": "hunter2"
+							}
+						},
+						"vault": {
+							"url": "vault.reddit.ue1.snooguts.net",
+							"token": "17213328-36d4-11e7-8459-525400f56d04"
+						}
+					}
+			`,
+		},
+	}
+
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for _, tt := range tests {
+		t.Run(
+			tt.name,
+			func(t *testing.T) {
+				tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+				if err != nil {
+					t.Fatal(err)
+				}
+				tmpPath := tmpFile.Name()
+				tmpFile.Write([]byte(tt.input))
+				if err := tmpFile.Close(); err != nil {
+					t.Fatal(err)
+				}
+
+				store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer store.Close()
+
+				if store.watcher.Get() == nil {
+					t.Fatal("expected secret store watcher to return secrets")
+				}
+			},
+		)
+	}
+}

--- a/secrets/store_test.go
+++ b/secrets/store_test.go
@@ -1,4 +1,4 @@
-package secrets
+package secrets_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/secrets"
 )
 
 const specificationExample = `
@@ -36,108 +37,6 @@ const specificationExample = `
 	}
 }`
 
-func TestNewStore(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected *Secrets
-	}{
-		{
-			name: "specification example",
-			input: `
-					{
-						"secrets": {
-							"secret/myservice/external-account-key": {
-								"type": "versioned",
-								"current": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=",
-								"previous": "aHVudGVyMg=="
-							},
-							"secret/myservice/some-api-key": {
-								"type": "simple",
-								"value": "Y2RvVXhNMVdsTXJma3BDaHRGZ0dPYkVGSg==",
-								"encoding": "base64"
-							},
-							"secret/myservice/some-database-credentials": {
-								"type": "credential",
-								"username": "spez",
-								"password": "hunter2"
-							}
-						},
-						"vault": {
-							"url": "vault.reddit.ue1.snooguts.net",
-							"token": "17213328-36d4-11e7-8459-525400f56d04"
-						}
-					}
-			`,
-		},
-	}
-
-	dir, err := ioutil.TempDir("", "secret_test_")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	for _, tt := range tests {
-		t.Run(
-			tt.name,
-			func(t *testing.T) {
-				tmpFile, err := ioutil.TempFile(dir, "secrets.json")
-				if err != nil {
-					t.Fatal(err)
-				}
-				tmpPath := tmpFile.Name()
-				tmpFile.Write([]byte(tt.input))
-				if err := tmpFile.Close(); err != nil {
-					t.Fatal(err)
-				}
-
-				store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer store.watcher.Stop()
-				if store.watcher.Get() == nil {
-					t.Fatal("expected secret store watcher to return secrets")
-				}
-			},
-		)
-	}
-}
-
-func TestNewStoreMiddleware(t *testing.T) {
-	dir, err := ioutil.TempDir("", "secret_test_")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpFile.Write([]byte(specificationExample))
-
-	var (
-		expectedMiddlewareCalls = 2
-		middlewareCall          int
-
-		middleware = func(next SecretHandlerFunc) SecretHandlerFunc {
-			return func(sec *Secrets) {
-				middlewareCall++
-				next(sec)
-			}
-		}
-	)
-	_, err = NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(t), middleware, middleware)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if middlewareCall != expectedMiddlewareCalls {
-		t.Errorf("expecting %d calls, got %d instead", expectedMiddlewareCalls, middlewareCall)
-	}
-}
-
 func TestGetSimpleSecret(t *testing.T) {
 	dir, err := ioutil.TempDir("", "secret_test_")
 	if err != nil {
@@ -159,17 +58,17 @@ func TestGetSimpleSecret(t *testing.T) {
 		name          string
 		key           string
 		expectedError error
-		expected      SimpleSecret
+		expected      secrets.SimpleSecret
 	}{
 		{
 			name:     "specification example",
 			key:      "secret/myservice/some-api-key",
-			expected: SimpleSecret{Value: Secret("cdoUxM1WlMrfkpChtFgGObEFJ")},
+			expected: secrets.SimpleSecret{Value: secrets.Secret("cdoUxM1WlMrfkpChtFgGObEFJ")},
 		},
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: SecretNotFoundError("spez"),
+			expectedError: secrets.SecretNotFoundError("spez"),
 		},
 	}
 
@@ -177,11 +76,12 @@ func TestGetSimpleSecret(t *testing.T) {
 		t.Run(
 			tt.name,
 			func(t *testing.T) {
-				store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+				store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer store.watcher.Stop()
+				defer store.Close()
+
 				secret, err := store.GetSimpleSecret(tt.key)
 				if tt.expectedError == nil && err != nil {
 					t.Fatal(err)
@@ -218,20 +118,20 @@ func TestGetVersionedSecret(t *testing.T) {
 		name          string
 		key           string
 		expectedError error
-		expected      VersionedSecret
+		expected      secrets.VersionedSecret
 	}{
 		{
 			name: "specification example",
 			key:  "secret/myservice/external-account-key",
-			expected: VersionedSecret{
-				Current:  Secret("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU="),
-				Previous: Secret("aHVudGVyMg=="),
+			expected: secrets.VersionedSecret{
+				Current:  secrets.Secret("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU="),
+				Previous: secrets.Secret("aHVudGVyMg=="),
 			},
 		},
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: SecretNotFoundError("spez"),
+			expectedError: secrets.SecretNotFoundError("spez"),
 		},
 	}
 
@@ -239,11 +139,12 @@ func TestGetVersionedSecret(t *testing.T) {
 		t.Run(
 			tt.name,
 			func(t *testing.T) {
-				store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+				store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer store.watcher.Stop()
+				defer store.Close()
+
 				secret, err := store.GetVersionedSecret(tt.key)
 				if tt.expectedError == nil && err != nil {
 					t.Fatal(err)
@@ -280,12 +181,12 @@ func TestGetCredentialSecret(t *testing.T) {
 		name          string
 		key           string
 		expectedError error
-		expected      CredentialSecret
+		expected      secrets.CredentialSecret
 	}{
 		{
 			name: "specification example",
 			key:  "secret/myservice/some-database-credentials",
-			expected: CredentialSecret{
+			expected: secrets.CredentialSecret{
 				Username: "spez",
 				Password: "hunter2",
 			},
@@ -293,7 +194,7 @@ func TestGetCredentialSecret(t *testing.T) {
 		{
 			name:          "missing key",
 			key:           "spez",
-			expectedError: SecretNotFoundError("spez"),
+			expectedError: secrets.SecretNotFoundError("spez"),
 		},
 	}
 
@@ -301,11 +202,12 @@ func TestGetCredentialSecret(t *testing.T) {
 		t.Run(
 			tt.name,
 			func(t *testing.T) {
-				store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+				store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer store.watcher.Stop()
+				defer store.Close()
+
 				secret, err := store.GetCredentialSecret(tt.key)
 				if tt.expectedError == nil && err != nil {
 					t.Fatal(err)
@@ -338,11 +240,12 @@ func TestSecretFileIsUpdated(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err := NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+	store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer store.watcher.Stop()
+	defer store.Close()
+
 	secret, err := store.GetSimpleSecret("secret/myservice/some-api-key")
 	if err != nil {
 		t.Fatal(err)
@@ -383,5 +286,166 @@ func TestSecretFileIsUpdated(t *testing.T) {
 	expected = "updated secret"
 	if string(secret.Value) != expected {
 		t.Fatalf("expected secret to be %s, actual: %s", expected, secret.Value)
+	}
+}
+
+type mockMiddleware struct {
+	tb    testing.TB
+	calls int
+
+	simpleKey  string
+	simpleData secrets.SimpleSecret
+
+	versionedKey  string
+	versionedData secrets.VersionedSecret
+
+	credentialKey  string
+	credentialData secrets.CredentialSecret
+}
+
+func (m *mockMiddleware) middleware(next secrets.SecretHandlerFunc) secrets.SecretHandlerFunc {
+	return func(sec *secrets.Secrets) {
+		m.tb.Helper()
+		m.calls++
+		if m.simpleKey != "" {
+			data, err := sec.GetSimpleSecret(m.simpleKey)
+			if err != nil {
+				m.tb.Errorf("failed to get SimpleSecret %q: %v", m.simpleKey, err)
+			}
+			if !reflect.DeepEqual(data, m.simpleData) {
+				m.tb.Errorf(
+					"expected SimpleSecret for %q: %+v, got %+v",
+					m.simpleKey,
+					m.simpleData,
+					data,
+				)
+			}
+		}
+		if m.versionedKey != "" {
+			data, err := sec.GetVersionedSecret(m.versionedKey)
+			if err != nil {
+				m.tb.Errorf("failed to get VersionedSecret %q: %v", m.versionedKey, err)
+			}
+			if !reflect.DeepEqual(data, m.versionedData) {
+				m.tb.Errorf(
+					"expected VersionedSecret for %q: %+v, got %+v",
+					m.versionedKey,
+					m.versionedData,
+					data,
+				)
+			}
+		}
+		if m.credentialKey != "" {
+			data, err := sec.GetCredentialSecret(m.credentialKey)
+			if err != nil {
+				m.tb.Errorf("failed to get CredentialSecret %q: %v", m.credentialKey, err)
+			}
+			if !reflect.DeepEqual(data, m.credentialData) {
+				m.tb.Errorf(
+					"expected CredentialSecret for %q: %+v, got %+v",
+					m.credentialKey,
+					m.credentialData,
+					data,
+				)
+			}
+		}
+		next(sec)
+	}
+}
+
+func TestNewStoreMiddleware(t *testing.T) {
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Write([]byte(specificationExample))
+
+	const expectedMiddlewareCalls = 2
+	m := mockMiddleware{
+		tb: t,
+
+		simpleKey: "secret/myservice/some-api-key",
+		simpleData: secrets.SimpleSecret{
+			Value: secrets.Secret("cdoUxM1WlMrfkpChtFgGObEFJ"),
+		},
+
+		versionedKey: "secret/myservice/external-account-key",
+		versionedData: secrets.VersionedSecret{
+			Current:  secrets.Secret("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU="),
+			Previous: secrets.Secret("aHVudGVyMg=="),
+		},
+
+		credentialKey: "secret/myservice/some-database-credentials",
+		credentialData: secrets.CredentialSecret{
+			Username: "spez",
+			Password: "hunter2",
+		},
+	}
+
+	store, err := secrets.NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(t), m.middleware, m.middleware)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if m.calls != expectedMiddlewareCalls {
+		t.Errorf("expecting %d calls, got %d instead", expectedMiddlewareCalls, m.calls)
+	}
+}
+
+func TestAddMiddleware(t *testing.T) {
+	dir, err := ioutil.TempDir("", "secret_test_")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Write([]byte(specificationExample))
+
+	initial := mockMiddleware{
+		tb: t,
+
+		simpleKey: "secret/myservice/some-api-key",
+		simpleData: secrets.SimpleSecret{
+			Value: secrets.Secret("cdoUxM1WlMrfkpChtFgGObEFJ"),
+		},
+
+		versionedKey: "secret/myservice/external-account-key",
+		versionedData: secrets.VersionedSecret{
+			Current:  secrets.Secret("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU="),
+			Previous: secrets.Secret("aHVudGVyMg=="),
+		},
+
+		credentialKey: "secret/myservice/some-database-credentials",
+		credentialData: secrets.CredentialSecret{
+			Username: "spez",
+			Password: "hunter2",
+		},
+	}
+
+	store, err := secrets.NewStore(context.Background(), tmpFile.Name(), log.TestWrapper(t), initial.middleware)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	const expectedAdditionalCalls = 2
+	additional := initial
+	additional.calls = 0
+	store.AddMiddlewares(additional.middleware, additional.middleware)
+	if expectedAdditionalCalls != additional.calls {
+		t.Errorf(
+			"expecting %d calls to additional middleware, got %d instead",
+			expectedAdditionalCalls,
+			additional.calls,
+		)
 	}
 }


### PR DESCRIPTION
Also:

1. Remove the type check after filewatcher.Get, which would never fail.
2. Add Store.Stop()