### PR TITLE
metricsbp: Split DefaultSampleRate into counter and histogram

### DIFF
--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -41,12 +41,9 @@ func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounte
 }
 
 func TestOnCreateServerSpan(t *testing.T) {
-	sampleRate := 1.0
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
-			DefaultSampleRate: sampleRate,
-		},
+		metricsbp.StatsdConfig{},
 	)
 
 	hook := metricsbp.CreateServerSpanHook{Metrics: st}

--- a/metricsbp/example_nil_check_test.go
+++ b/metricsbp/example_nil_check_test.go
@@ -34,9 +34,10 @@ func ExampleCheckNilFields() {
 	metricsbp.M = metricsbp.NewStatsd(
 		ctx,
 		metricsbp.StatsdConfig{
-			Prefix:            prefix,
-			Address:           statsdAddr,
-			DefaultSampleRate: sampleRate,
+			Prefix:                     prefix,
+			Address:                    statsdAddr,
+			DefaultCounterSampleRate:   sampleRate,
+			DefaultHistogramSampleRate: sampleRate,
 		},
 	)
 

--- a/metricsbp/sample_rate_test.go
+++ b/metricsbp/sample_rate_test.go
@@ -1,0 +1,53 @@
+package metricsbp
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func compareFloats(t *testing.T, expected, actual float64) {
+	const epsilon = 1e-9
+	t.Helper()
+
+	if math.Abs(expected-actual) < epsilon {
+		return
+	}
+	t.Errorf("Expected %v, got %v", expected, actual)
+}
+
+func TestConvertSampleRate(t *testing.T) {
+	cases := []struct {
+		value, expected float64
+	}{
+		{
+			value:    0,
+			expected: 1,
+		},
+		{
+			value:    1,
+			expected: 1,
+		},
+		{
+			value:    -1,
+			expected: 0,
+		},
+		{
+			value:    0.1,
+			expected: 0.1,
+		},
+		{
+			value:    0.01,
+			expected: 0.01,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(
+			fmt.Sprintf("%v", c.value),
+			func(t *testing.T) {
+				compareFloats(t, c.expected, convertSampleRate(c.value))
+			},
+		)
+	}
+}

--- a/metricsbp/statsd_test.go
+++ b/metricsbp/statsd_test.go
@@ -37,8 +37,7 @@ func TestNoFallback(t *testing.T) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.StatsdConfig{
-			Prefix:            prefix,
-			DefaultSampleRate: 1,
+			Prefix: prefix,
 		},
 	)
 	st.Counter("foo").Add(1)
@@ -53,8 +52,7 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.StatsdConfig{
-			Prefix:            prefix,
-			DefaultSampleRate: 1,
+			Prefix: prefix,
 		},
 	)
 	st.Histogram("foo").Observe(1)
@@ -69,8 +67,7 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.StatsdConfig{
-			Prefix:            prefix,
-			DefaultSampleRate: 1,
+			Prefix: prefix,
 		},
 	)
 	st.Timing("foo").Observe(1)
@@ -85,8 +82,7 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.StatsdConfig{
-			Prefix:            prefix,
-			DefaultSampleRate: 1,
+			Prefix: prefix,
 		},
 	)
 	st.Gauge("foo").Set(1)
@@ -116,8 +112,7 @@ func BenchmarkStatsd(b *testing.B) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.StatsdConfig{
-			DefaultSampleRate: sampleRate,
-			Labels:            initialLabels,
+			Labels: initialLabels,
 		},
 	)
 


### PR DESCRIPTION
In influxstatsd implementation, all histograms are not aggregated, and
forwarded to statsd as-is, while counters are aggregated (gauges are
always snapshotted without the conception of sample rate). This means we
usually need a different (lower) sample rate for histograms (including
timings) to avoid sending too much data to statsd.

Split DefaultSampleRate into DefaultCounterSampleRate and
DefaultHistogramSampleRate to resolve this problem.

Also for user convenience, treat zero value of the sample rate configs
as 1, and <0 as 0.

This is a breaking change.