### PR TITLE
Stop HTTP spans after endpoint finishes

### DIFF
--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -19,21 +19,13 @@ import (
 // the context object.  This can be done by adding httpbp.PopulateRequestContext
 // as a ServerBefore option when setting up the request handler for an endpoint.
 func InjectHTTPServerSpan(name string) endpoint.Middleware {
-	return func(next endpoint.Endpoint) endpoint.Endpoint {
-		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			ctx, span := StartSpanFromHTTPContext(ctx, name)
-			defer span.Stop(ctx, err)
-
-			response, err = next(ctx, request)
-			return
-		}
-	}
+	return InjectHTTPServerSpanWithTracer(name, nil)
 }
 
 // InjectHTTPServerSpanWithTracer is the same as InjectHTTPServerSpan except it
 // uses StartSpanFromHTTPContextWithTracer to initialize the server span rather
 // than StartSpanFromHTTPContext.
-func InjectHTTPServerSpanWithTracer(tracer *Tracer, name string) endpoint.Middleware {
+func InjectHTTPServerSpanWithTracer(name string, tracer *Tracer) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			ctx, span := StartSpanFromHTTPContextWithTracer(ctx, name, tracer)

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -19,9 +19,7 @@ func InjectHTTPServerSpan(name string) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			ctx, span := StartSpanFromHTTPContext(ctx, name)
-			defer func() {
-				span.Stop(ctx, err)
-			}()
+			defer span.Stop(ctx, err)
 
 			response, err = next(ctx, request)
 			return
@@ -36,9 +34,7 @@ func InjectHTTPServerSpanWithTracer(tracer *Tracer, name string) endpoint.Middle
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			ctx, span := StartSpanFromHTTPContextWithTracer(ctx, name, tracer)
-			defer func() {
-				span.Stop(ctx, err)
-			}()
+			defer span.Stop(ctx, err)
 
 			response, err = next(ctx, request)
 			return

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -43,7 +43,3 @@ func InjectHTTPServerSpanWithTracer(tracer *Tracer, name string) endpoint.Middle
 		}
 	}
 }
-
-var (
-	_ httpgk.ServerFinalizerFunc = FinalizeHTTPServerSpan
-)

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -11,6 +11,9 @@ import (
 //
 // Starts the server span before calling the `next` endpoint and stops the span
 // after the endpoint finishes.
+// If the endpoint returns an error, that will be passed to span.Stop. If the
+// response implements ErrorResponse, the error returned by Err() will not be
+// passed to span.Stop.
 //
 // Note, this function depends on the edge context headers already being set on
 // the context object.  This can be done by adding httpbp.PopulateRequestContext

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -21,7 +21,8 @@ func InjectHTTPServerSpan(name string) endpoint.Middleware {
 			ctx, span := StartSpanFromHTTPContext(ctx, name)
 			defer func() {
 				span.Stop(ctx, err)
-			}
+			}()
+
 			response, err = next(ctx, request)
 			return
 		}
@@ -34,10 +35,11 @@ func InjectHTTPServerSpan(name string) endpoint.Middleware {
 func InjectHTTPServerSpanWithTracer(tracer *Tracer, name string) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-			ctx, _ = StartSpanFromHTTPContextWithTracer(ctx, name, tracer)
+			ctx, span := StartSpanFromHTTPContextWithTracer(ctx, name, tracer)
 			defer func() {
 				span.Stop(ctx, err)
-			}
+			}()
+
 			response, err = next(ctx, request)
 			return
 		}

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -29,7 +29,9 @@ func InjectHTTPServerSpanWithTracer(name string, tracer *Tracer) endpoint.Middle
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			ctx, span := StartSpanFromHTTPContextWithTracer(ctx, name, tracer)
-			defer span.Stop(ctx, err)
+			defer func() {
+				span.Stop(ctx, err)
+			}()
 
 			response, err = next(ctx, request)
 			return

--- a/tracing/middlewares.go
+++ b/tracing/middlewares.go
@@ -9,9 +9,12 @@ import (
 // InjectHTTPServerSpan returns a go-kit endpoint.Middleware that injects a server
 // span into the `next` context.
 //
-// Note, this depends on the edge context headers already being set on the
-// context object.  This can be done by adding httpbp.PopulateRequestContext as
-// a ServerBefore option when setting up the request handler for an endpoint.
+// Starts the server span before calling the `next` endpoint and stops the span
+// after the endpoint finishes.
+//
+// Note, this function depends on the edge context headers already being set on
+// the context object.  This can be done by adding httpbp.PopulateRequestContext
+// as a ServerBefore option when setting up the request handler for an endpoint.
 func InjectHTTPServerSpan(name string) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {

--- a/tracing/middlewares_test.go
+++ b/tracing/middlewares_test.go
@@ -1,0 +1,66 @@
+package tracing_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/mqsend"
+	"github.com/reddit/baseplate.go/runtimebp"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+func testEndpoint(ctx context.Context, request interface{}) (interface{}, error) {
+	return nil, errors.New("test error")
+}
+
+func TestInjectHTTPServerSpanWithTracer(t *testing.T) {
+	ip, err := runtimebp.GetFirstIPv4()
+	if err != nil {
+		t.Logf("Unable to get local ip address: %v", err)
+	}
+	tracer := tracing.Tracer{
+		SampleRate: 1,
+		Endpoint: tracing.ZipkinEndpointInfo{
+			ServiceName: "test-service",
+			IPv4:        ip,
+		},
+	}
+
+	tracer.Recorder = mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
+		MaxQueueSize:   100,
+		MaxMessageSize: 1024,
+	})
+
+	ctx := context.Background()
+	ctx = httpbp.SetHeader(ctx, httpbp.SpanSampledContextKey, "1")
+	middleware := tracing.InjectHTTPServerSpanWithTracer("test", &tracer)
+	wrapped := middleware(testEndpoint)
+	wrapped(ctx, nil)
+	mmq := tracer.Recorder.(*mqsend.MockMessageQueue)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	msg, err := mmq.Receive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("Encoded span: %s", msg)
+
+	var trace tracing.ZipkinSpan
+	err = json.Unmarshal(msg, &trace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasError := false
+	for _, annotation := range trace.BinaryAnnotations {
+		if annotation.Key == "error" {
+			hasError = true
+		}
+	}
+	if !hasError {
+		t.Error("Error binary annotation was not present.")
+	}
+}


### PR DESCRIPTION
Use the same `endpoint.Middleware` that we are using to inject server spans into the context to also stop the server span after the endpoint has finished.