### PR TITLE
Remove -v in go test in drone config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,10 +7,10 @@ platform:
 
 steps:
 - name: test
-  image: golang:1.13.4-buster
+  image: golang:1.13.7-buster
   pull: if-not-exists
   commands:
-  - go test ./... -race -v
+  - go test ./... -race
   - go vet ./...
   when:
     branch:
@@ -20,7 +20,7 @@ steps:
     - push
 
 - name: check-go-modules
-  image: golang:1.13.4-buster
+  image: golang:1.13.7-buster
   pull: if-not-exists
   commands:
   - go mod tidy
@@ -35,7 +35,7 @@ steps:
     - push
     
 - name: lint
-  image: golang:1.13.4-buster
+  image: golang:1.13.7-buster
   pull: if-not-exists
   commands:
   - go get -u golang.org/x/lint/golint


### PR DESCRIPTION
This is less useful now and also makes the test result harder to look
at.

While I'm here, also upgrade to go 1.13.7 in drone config.