### PR TITLE
Add redisbp.MonitoredCmdableFactory

### DIFF
--- a/integrations/doc.go
+++ b/integrations/doc.go
@@ -1,3 +1,0 @@
-// Package integrations provides Baseplate integration with client libraries for
-// caches, databases, etc.
-package integrations

--- a/redisbp/doc.go
+++ b/redisbp/doc.go
@@ -1,0 +1,5 @@
+// Package redisbp provides Baseplate integrations for go-redis.
+//
+// See https://pkg.go.dev/github.com/go-redis/redis/v7 for documentation for
+// go-redis
+package redisbp

--- a/redisbp/example_hooks_test.go
+++ b/redisbp/example_hooks_test.go
@@ -1,17 +1,20 @@
-package integrations_test
+package redisbp_test
 
 import (
 	"context"
 
 	"github.com/go-redis/redis/v7"
 
-	"github.com/reddit/baseplate.go/integrations"
+	"github.com/reddit/baseplate.go/redisbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-// This example demonstrates how to use RedisSpanHook to automatically add Spans
+// This example demonstrates how to use SpanHook to automatically add Spans
 // around Redis commands using go-redis
-func ExampleRedisSpanHook() {
+//
+// baseplate.go also provides the MonitoredCmdableFactory object that you can
+// use to create Redis clients with a SpanHook already attached.
+func ExampleSpanHook() {
 	// variables should be properly initialized in production code
 	var (
 		// baseClient is not actually used to run commands, we register the Hook
@@ -20,7 +23,7 @@ func ExampleRedisSpanHook() {
 		tracer     *tracing.Tracer
 	)
 	// Add the Hook onto baseClient
-	baseClient.AddHook(integrations.RedisSpanHook{ClientName: "redis"})
+	baseClient.AddHook(redisbp.SpanHook{ClientName: "redis"})
 	// Get a context object and a server Span, with the server Span set on the
 	// context
 	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")

--- a/redisbp/example_monitored_client_test.go
+++ b/redisbp/example_monitored_client_test.go
@@ -1,0 +1,97 @@
+package redisbp_test
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v7"
+
+	"github.com/reddit/baseplate.go/redisbp"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+// This example demonstrates how to use a MonitoredCmdableFactory to create
+// monitored redis.Client objects.
+func ExampleMonitoredCmdableFactory_client() {
+	// variables should be properly initialized in production code
+	var tracer *tracing.Tracer
+	// Create a factory
+	factory := redisbp.NewMonitoredClientFactory(
+		"redis",
+		redis.NewClient(&redis.Options{Addr: ":6379"}),
+	)
+	// Get a context object and a server Span, with the server Span set on the
+	// context
+	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	// Create a new client using the context for the Server Span
+	client := factory.BuildClient(ctx)
+	// Commands should now be wrapped using Client Spans
+	client.Ping()
+}
+
+// This example demonstrates how to use a MonitoredCmdableFactory to create
+// monitored redis.ClusterClient objects.
+func ExampleMonitoredCmdableFactory_cluster() {
+	// variables should be properly initialized in production code
+	var tracer *tracing.Tracer
+	// Create a factory
+	factory := redisbp.NewMonitoredClusterFactory(
+		"redis",
+		redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs: []string{":7000", ":7001", ":7002"},
+		}),
+	)
+	// Get a context object and a server Span, with the server Span set on the
+	// context
+	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	// Create a new client using the context for the Server Span
+	client := factory.BuildClient(ctx)
+	// Commands should now be wrapped using Client Spans
+	client.Ping()
+}
+
+// This example demonstrates how to use a MonitoredCmdableFactory to create
+// monitored redis.Client objects that implement failover using Redis Sentinel.
+func ExampleMonitoredCmdableFactory_sentinel() {
+	// variables should be properly initialized in production code
+	var tracer *tracing.Tracer
+	// Create a factory
+	factory := redisbp.NewMonitoredClientFactory(
+		"redis",
+		redis.NewFailoverClient(&redis.FailoverOptions{
+			MasterName:    "master",
+			SentinelAddrs: []string{":6379"},
+		}),
+	)
+	// Get a context object and a server Span, with the server Span set on the
+	// context
+	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	// Create a new client using the context for the Server Span
+	client := factory.BuildClient(ctx)
+	// Commands should now be wrapped using Client Spans
+	client.Ping()
+}
+
+// This example demonstrates how to use a MonitoredCmdableFactory to create
+// monitored redis.Ring objects.
+func ExampleMonitoredCmdableFactory_ring() {
+	// variables should be properly initialized in production code
+	var tracer *tracing.Tracer
+	// Create a factory
+	factory := redisbp.NewMonitoredRingFactory(
+		"redis",
+		redis.NewRing(&redis.RingOptions{
+			Addrs: map[string]string{
+				"shard0": ":7000",
+				"shard1": ":7001",
+				"shard2": ":7002",
+			},
+		}),
+	)
+	// Get a context object and a server Span, with the server Span set on the
+	// context
+	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	// Create a new client using the context for the Server Span
+	client := factory.BuildClient(ctx)
+	// Commands should now be wrapped using Client Spans
+	client.Ping()
+}

--- a/redisbp/example_monitored_client_test.go
+++ b/redisbp/example_monitored_client_test.go
@@ -10,23 +10,23 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-// ExampleService is an example go-kit service to help demonstrate how to use
+// Service is an example go-kit service to help demonstrate how to use
 // redisbp.type MonitoredCmdableFactory in a service.
-type ExampleService struct {
+type Service struct {
 	RedisFactory redisbp.MonitoredCmdableFactory
 }
 
-// ExampleEndpoint is an example endpoint that will use redis.
-func (s ExampleService) ExampleEndpoint(ctx context.Context) error {
+// Endpoint is an example endpoint that will use redis.
+func (s Service) Endpoint(ctx context.Context) error {
 	// Use the factory to create a new, monitored redis client that can be
 	// injected into your endpoint handler
 	redis := s.RedisFactory.BuildClient(ctx)
-	return ExampleEndpoint(ctx, redis)
+	return EndpointHandler(ctx, redis)
 }
 
-// ExampleEndpoint is the actual handler function for
-// ExampleService.ExampleEndpoint.
-func ExampleEndpoint(ctx context.Context, client redisbp.MonitoredCmdable) error {
+// EndpointHandler is the actual handler function for
+// Service.Endpoint.
+func EndpointHandler(ctx context.Context, client redisbp.MonitoredCmdable) error {
 	if span := tracing.GetServerSpan(ctx); span != nil {
 		log.Debug("Span: %s", span.Name())
 	}
@@ -41,7 +41,7 @@ func ExampleMonitoredCmdableFactory_client() {
 	// variables should be properly initialized in production code
 	var tracer *tracing.Tracer
 	// Create a service with a factory
-	svc := ExampleService{
+	svc := Service{
 		RedisFactory: redisbp.NewMonitoredClientFactory(
 			"redis",
 			redis.NewClient(&redis.Options{Addr: ":6379"}),
@@ -58,7 +58,7 @@ func ExampleMonitoredCmdableFactory_client() {
 	//
 	// In production, the service framework will call these endpoints in
 	// response to requests from clients rather than you calling it manually.
-	svc.ExampleEndpoint(ctx)
+	svc.Endpoint(ctx)
 }
 
 // This example demonstrates how to use a MonitoredCmdableFactory to create
@@ -67,7 +67,7 @@ func ExampleMonitoredCmdableFactory_cluster() {
 	// variables should be properly initialized in production code
 	var tracer *tracing.Tracer
 	// Create service with a factory
-	svc := ExampleService{
+	svc := Service{
 		RedisFactory: redisbp.NewMonitoredClusterFactory(
 			"redis",
 			redis.NewClusterClient(&redis.ClusterOptions{
@@ -86,7 +86,7 @@ func ExampleMonitoredCmdableFactory_cluster() {
 	//
 	// In production, the service framework will call these endpoints in
 	// response to requests from clients rather than you calling it manually.
-	svc.ExampleEndpoint(ctx)
+	svc.Endpoint(ctx)
 }
 
 // This example demonstrates how to use a MonitoredCmdableFactory to create
@@ -95,7 +95,7 @@ func ExampleMonitoredCmdableFactory_sentinel() {
 	// variables should be properly initialized in production code
 	var tracer *tracing.Tracer
 	// Create service with a factory
-	svc := ExampleService{
+	svc := Service{
 		RedisFactory: redisbp.NewMonitoredClientFactory(
 			"redis",
 			redis.NewFailoverClient(&redis.FailoverOptions{
@@ -115,7 +115,7 @@ func ExampleMonitoredCmdableFactory_sentinel() {
 	//
 	// In production, the service framework will call these endpoints in
 	// response to requests from clients rather than you calling it manually.
-	svc.ExampleEndpoint(ctx)
+	svc.Endpoint(ctx)
 }
 
 // This example demonstrates how to use a MonitoredCmdableFactory to create
@@ -124,7 +124,7 @@ func ExampleMonitoredCmdableFactory_ring() {
 	// variables should be properly initialized in production code
 	var tracer *tracing.Tracer
 	// Create service with a factory
-	svc := ExampleService{
+	svc := Service{
 		RedisFactory: redisbp.NewMonitoredRingFactory(
 			"redis",
 			redis.NewRing(&redis.RingOptions{
@@ -147,5 +147,5 @@ func ExampleMonitoredCmdableFactory_ring() {
 	//
 	// In production, the service framework will call these endpoints in
 	// response to requests from clients rather than you calling it manually.
-	svc.ExampleEndpoint(ctx)
+	svc.Endpoint(ctx)
 }

--- a/redisbp/example_monitored_client_test.go
+++ b/redisbp/example_monitored_client_test.go
@@ -35,12 +35,11 @@ func EndpointHandler(ctx context.Context, client redisbp.MonitoredCmdable) error
 	return nil
 }
 
-// This example demonstrates how to use a MonitoredCmdableFactory to create
-// monitored redis.Client objects.
-func ExampleMonitoredCmdableFactory_client() {
+// This example demonstrates how to use a MonitoredCmdableFactory.
+func ExampleMonitoredCmdableFactory() {
 	// variables should be properly initialized in production code
 	var tracer *tracing.Tracer
-	// Create a service with a factory
+	// Create a service with a factory using a basic redis.Client
 	svc := Service{
 		RedisFactory: redisbp.NewMonitoredClientFactory(
 			"redis",
@@ -59,43 +58,10 @@ func ExampleMonitoredCmdableFactory_client() {
 	// In production, the service framework will call these endpoints in
 	// response to requests from clients rather than you calling it manually.
 	svc.Endpoint(ctx)
-}
 
-// This example demonstrates how to use a MonitoredCmdableFactory to create
-// monitored redis.ClusterClient objects.
-func ExampleMonitoredCmdableFactory_cluster() {
-	// variables should be properly initialized in production code
-	var tracer *tracing.Tracer
-	// Create service with a factory
-	svc := Service{
-		RedisFactory: redisbp.NewMonitoredClusterFactory(
-			"redis",
-			redis.NewClusterClient(&redis.ClusterOptions{
-				Addrs: []string{":7000", ":7001", ":7002"},
-			}),
-		),
-	}
-	// Get a context object and a server Span, with the server Span set on the
-	// context
-	//
-	// In production, this will be handled by service middleware rather than
-	// being called manually.
-	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
-	// Calls to this endpoint will use the factory to create a new client and
-	// inject it into the actual implementation
-	//
-	// In production, the service framework will call these endpoints in
-	// response to requests from clients rather than you calling it manually.
-	svc.Endpoint(ctx)
-}
-
-// This example demonstrates how to use a MonitoredCmdableFactory to create
-// monitored redis.Client objects that implement failover using Redis Sentinel.
-func ExampleMonitoredCmdableFactory_sentinel() {
-	// variables should be properly initialized in production code
-	var tracer *tracing.Tracer
-	// Create service with a factory
-	svc := Service{
+	// Create service with a factory using a redis.Client that implements failover
+	// with Redis Sentinel.
+	svc = Service{
 		RedisFactory: redisbp.NewMonitoredClientFactory(
 			"redis",
 			redis.NewFailoverClient(&redis.FailoverOptions{
@@ -104,27 +70,24 @@ func ExampleMonitoredCmdableFactory_sentinel() {
 			}),
 		),
 	}
-	// Get a context object and a server Span, with the server Span set on the
-	// context
-	//
-	// In production, this will be handled by service middleware rather than
-	// being called manually.
-	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
-	// Calls to this endpoint will use the factory to create a new client and
-	// inject it into the actual implementation
-	//
-	// In production, the service framework will call these endpoints in
-	// response to requests from clients rather than you calling it manually.
+	ctx, _ = tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
 	svc.Endpoint(ctx)
-}
 
-// This example demonstrates how to use a MonitoredCmdableFactory to create
-// monitored redis.Ring objects.
-func ExampleMonitoredCmdableFactory_ring() {
-	// variables should be properly initialized in production code
-	var tracer *tracing.Tracer
-	// Create service with a factory
-	svc := Service{
+	// Create service with a factory using a redis.ClusterClient to connect to
+	// Redis Cluster.
+	svc = Service{
+		RedisFactory: redisbp.NewMonitoredClusterFactory(
+			"redis",
+			redis.NewClusterClient(&redis.ClusterOptions{
+				Addrs: []string{":7000", ":7001", ":7002"},
+			}),
+		),
+	}
+	ctx, _ = tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	svc.Endpoint(ctx)
+
+	// Create service with a factory using a redis.Ring client.
+	svc = Service{
 		RedisFactory: redisbp.NewMonitoredRingFactory(
 			"redis",
 			redis.NewRing(&redis.RingOptions{
@@ -136,16 +99,6 @@ func ExampleMonitoredCmdableFactory_ring() {
 			}),
 		),
 	}
-	// Get a context object and a server Span, with the server Span set on the
-	// context
-	//
-	// In production, this will be handled by service middleware rather than
-	// being called manually.
-	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
-	// Calls to this endpoint will use the factory to create a new client and
-	// inject it into the actual implementation
-	//
-	// In production, the service framework will call these endpoints in
-	// response to requests from clients rather than you calling it manually.
+	ctx, _ = tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
 	svc.Endpoint(ctx)
 }

--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -1,4 +1,4 @@
-package integrations
+package redisbp
 
 import (
 	"context"
@@ -10,37 +10,37 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-// RedisSpanHook is a redis.Hook for wrapping Redis commands and pipelines
+// SpanHook is a redis.Hook for wrapping Redis commands and pipelines
 // in Client Spans and metrics.
-type RedisSpanHook struct {
+type SpanHook struct {
 	ClientName string
 }
 
-var _ redis.Hook = RedisSpanHook{}
+var _ redis.Hook = SpanHook{}
 
 // BeforeProcess starts a client Span before processing a Redis command and
 // starts a timer to record how long the command took.
-func (h RedisSpanHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
+func (h SpanHook) BeforeProcess(ctx context.Context, cmd redis.Cmder) (context.Context, error) {
 	return h.startChildSpan(ctx, cmd.Name()), nil
 }
 
 // AfterProcess ends the client Span started by BeforeProcess, publishes the
 // time the Redis command took to complete, and a metric indicating whether the
 // command was a "success" or "fail"
-func (h RedisSpanHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
+func (h SpanHook) AfterProcess(ctx context.Context, cmd redis.Cmder) error {
 	return h.endChildSpan(ctx, cmd.Err())
 }
 
 // BeforeProcessPipeline starts a client span before processing a Redis pipeline
 // and starts a timer to record how long the pipeline took.
-func (h RedisSpanHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
+func (h SpanHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder) (context.Context, error) {
 	return h.startChildSpan(ctx, "pipeline"), nil
 }
 
 // AfterProcessPipeline ends the client span started by BeforeProcessPipeline,
 // publishes the time the Redis pipeline took to complete, and a metric
 // indicating whether the pipeline was a "success" or "fail"
-func (h RedisSpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
+func (h SpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
 	var errs batcherror.BatchError
 	for _, cmd := range cmds {
 		errs.Add(cmd.Err())
@@ -48,7 +48,7 @@ func (h RedisSpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cm
 	return h.endChildSpan(ctx, errs.Compile())
 }
 
-func (h RedisSpanHook) startChildSpan(ctx context.Context, cmdName string) context.Context {
+func (h SpanHook) startChildSpan(ctx context.Context, cmdName string) context.Context {
 	// Get the current span tracing the work being done by ctx.  Try to get a
 	// sub-span first and fall back to the server span if we are not currently
 	// in a sub-span.
@@ -67,7 +67,7 @@ func (h RedisSpanHook) startChildSpan(ctx context.Context, cmdName string) conte
 	return ctx
 }
 
-func (h RedisSpanHook) endChildSpan(ctx context.Context, err error) error {
+func (h SpanHook) endChildSpan(ctx context.Context, err error) error {
 	if span := tracing.GetActiveSpan(ctx); span != nil {
 		return span.Stop(ctx, err)
 	}

--- a/redisbp/hooks_test.go
+++ b/redisbp/hooks_test.go
@@ -1,4 +1,4 @@
-package integrations_test
+package redisbp_test
 
 import (
 	"context"
@@ -6,13 +6,13 @@ import (
 
 	"github.com/go-redis/redis/v7"
 
-	"github.com/reddit/baseplate.go/integrations"
+	"github.com/reddit/baseplate.go/redisbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-func TestRedisSpanHook(t *testing.T) {
+func TestSpanHook(t *testing.T) {
 	ctx, _ := tracing.StartSpanFromThriftContext(context.Background(), "foo")
-	hooks := integrations.RedisSpanHook{ClientName: "redis"}
+	hooks := redisbp.SpanHook{ClientName: "redis"}
 	cmd := redis.NewStatusCmd("ping")
 
 	t.Run(

--- a/redisbp/monitored_client.go
+++ b/redisbp/monitored_client.go
@@ -1,0 +1,99 @@
+package redisbp
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v7"
+)
+
+// MonitoredCmdable wraps the redis.Cmdable interface and adds additional methods
+// to support integrating with baseplate.go SpanHooks.
+type MonitoredCmdable interface {
+	redis.Cmdable
+
+	// AddHook adds a hook onto the object.
+	//
+	// Note most redis.Cmdable objects already implement this but it is not a
+	// part of the redis.Cmdable interface.
+	AddHook(hook redis.Hook)
+
+	// WithMonitoredContext returns a clone of the MonitoredCmdable with its
+	// context set to the provided one.
+	//
+	// This is similar to the WithContext method that many redis.Cmdable objects
+	// implement, but this returns a MonitoredCmdable rather than a pointer to
+	// the exact type.  Also note that WithContext is not a part of the
+	// redis.Cmdable interface.
+	WithMonitoredContext(ctx context.Context) MonitoredCmdable
+}
+
+type monitoredClient struct {
+	*redis.Client
+}
+
+func (c *monitoredClient) WithMonitoredContext(ctx context.Context) MonitoredCmdable {
+	return &monitoredClient{Client: c.Client.WithContext(ctx)}
+}
+
+type monitoredCluster struct {
+	*redis.ClusterClient
+}
+
+func (c *monitoredCluster) WithMonitoredContext(ctx context.Context) MonitoredCmdable {
+	return &monitoredCluster{ClusterClient: c.ClusterClient.WithContext(ctx)}
+}
+
+type monitoredRing struct {
+	*redis.Ring
+}
+
+func (c *monitoredRing) WithMonitoredContext(ctx context.Context) MonitoredCmdable {
+	return &monitoredRing{Ring: c.Ring.WithContext(ctx)}
+}
+
+// MonitoredCmdableFactory is used to create Redis clients that are monitored by
+// a SpanHook.
+//
+// A MonitoredCmdableFactory should be created using one of the New methods
+// provided in this package.
+type MonitoredCmdableFactory struct {
+	client MonitoredCmdable
+}
+
+func newMonitoredCmdableFactory(name string, client MonitoredCmdable) MonitoredCmdableFactory {
+	client.AddHook(SpanHook{ClientName: name})
+	return MonitoredCmdableFactory{client: client}
+}
+
+// NewMonitoredClientFactory creates a MonitoredCmdableFactory for a redis.Client
+// object.
+//
+// This may connect to a single redis instance, or be a failover client using
+// Redis Sentinel.
+func NewMonitoredClientFactory(name string, client *redis.Client) MonitoredCmdableFactory {
+	return newMonitoredCmdableFactory(name, &monitoredClient{Client: client})
+}
+
+// NewMonitoredClusterFactory creates a MonitoredCmdableFactory for a
+// redis.ClusterClient object.
+func NewMonitoredClusterFactory(name string, client *redis.ClusterClient) MonitoredCmdableFactory {
+	return newMonitoredCmdableFactory(name, &monitoredCluster{ClusterClient: client})
+}
+
+// NewMonitoredRingFactory creates a MonitoredCmdableFactory for a redis.Ring
+// object.
+func NewMonitoredRingFactory(name string, client *redis.Ring) MonitoredCmdableFactory {
+	return newMonitoredCmdableFactory(name, &monitoredRing{Ring: client})
+}
+
+// BuildClient returns a new MonitoredCmdable with its context set to the
+// provided one.
+func (f MonitoredCmdableFactory) BuildClient(ctx context.Context) MonitoredCmdable {
+	return f.client.WithMonitoredContext(ctx)
+}
+
+var (
+	_ MonitoredCmdable = (*monitoredClient)(nil)
+	_ MonitoredCmdable = (*monitoredCluster)(nil)
+	_ MonitoredCmdable = (*monitoredRing)(nil)
+)

--- a/redisbp/monitored_client.go
+++ b/redisbp/monitored_client.go
@@ -54,6 +54,10 @@ func (c *monitoredRing) WithMonitoredContext(ctx context.Context) MonitoredCmdab
 // MonitoredCmdableFactory is used to create Redis clients that are monitored by
 // a SpanHook.
 //
+// This is intended for use by a top-level Service interface where you use it on
+// each new request to build a monitored client to inject into the actual
+// request handler.
+//
 // A MonitoredCmdableFactory should be created using one of the New methods
 // provided in this package.
 type MonitoredCmdableFactory struct {


### PR DESCRIPTION
These Factory objects allow you to create new go-redis clients
that are monitored by RedisSpanHooks using the span for the
given context.

This also removes the 'integrations' package in favor of a
'redisbp' package, mostly to improve the readability of the
exported structs and functions.