### PR TITLE
Convert all span tags to strings

### DIFF
--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"math/rand"
+	"strconv"
 	"time"
 
 	"github.com/reddit/baseplate.go/timebp"
@@ -64,6 +65,9 @@ func (t *trace) addCounter(key string, delta float64) {
 }
 
 func (t *trace) setTag(key string, value interface{}) {
+	if v, ok := value.(bool); ok {
+		value = interface{}(strconv.FormatBool(v))
+	}
 	t.tags[key] = value
 }
 

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -65,13 +65,7 @@ func (t *trace) addCounter(key string, delta float64) {
 }
 
 func (t *trace) setTag(key string, value interface{}) {
-	var valStr string
-	if v, ok := value.(string); !ok {
-		valStr = fmt.Sprintf("%v", value)
-	} else {
-		valStr = v
-	}
-	t.tags[key] = valStr
+	t.tags[key] = fmt.Sprintf("%v", value)
 }
 
 func (t *trace) toZipkinSpan() ZipkinSpan {

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -66,7 +66,7 @@ func (t *trace) addCounter(key string, delta float64) {
 
 func (t *trace) setTag(key string, value interface{}) {
 	if v, ok := value.(bool); ok {
-		value = interface{}(strconv.FormatBool(v))
+		value = strconv.FormatBool(v)
 	}
 	t.tags[key] = value
 }

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -2,8 +2,8 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
-	"strconv"
 	"time"
 
 	"github.com/reddit/baseplate.go/timebp"
@@ -38,7 +38,7 @@ type trace struct {
 	stop                     time.Time
 
 	counters map[string]float64
-	tags     map[string]interface{}
+	tags     map[string]string
 }
 
 func newTrace(tracer *Tracer, name string) *trace {
@@ -54,7 +54,7 @@ func newTrace(tracer *Tracer, name string) *trace {
 		start:   time.Now(),
 
 		counters: make(map[string]float64),
-		tags: map[string]interface{}{
+		tags: map[string]string{
 			ZipkinBinaryAnnotationKeyComponent: baseplateComponent,
 		},
 	}
@@ -65,10 +65,13 @@ func (t *trace) addCounter(key string, delta float64) {
 }
 
 func (t *trace) setTag(key string, value interface{}) {
-	if v, ok := value.(bool); ok {
-		value = strconv.FormatBool(v)
+	var valStr string
+	if v, ok := value.(string); !ok {
+		valStr = fmt.Sprintf("%v", value)
+	} else {
+		valStr = v
 	}
-	t.tags[key] = value
+	t.tags[key] = valStr
 }
 
 func (t *trace) toZipkinSpan() ZipkinSpan {


### PR DESCRIPTION
Our current system for storing trace data only supports string values for binary annotations so we want to also encode boolean values as lower case strings.