### PR TITLE
thriftpool: Change the benchmark test to parallel

### DIFF
--- a/thriftpool/bench_test.go
+++ b/thriftpool/bench_test.go
@@ -20,16 +20,20 @@ func BenchmarkPoolGetRelease(b *testing.B) {
 		b.Run(
 			label,
 			func(b *testing.B) {
-				for i := 0; i < b.N; i++ {
-					c, err := pool.Get()
-					if err != nil {
-						b.Fatalf("pool.Get returned error on run #%d: %v", i, err)
-					}
+				b.RunParallel(
+					func(pb *testing.PB) {
+						for pb.Next() {
+							c, err := pool.Get()
+							if err != nil {
+								b.Fatalf("pool.Get returned error: %v", err)
+							}
 
-					if err := pool.Release(c); err != nil {
-						b.Fatalf("pool.Release returned error on run #%d: %v", i, err)
-					}
-				}
+							if err := pool.Release(c); err != nil {
+								b.Fatalf("pool.Release returned error: %v", err)
+							}
+						}
+					},
+				)
 			},
 		)
 	}

--- a/thriftpool/doc.go
+++ b/thriftpool/doc.go
@@ -1,2 +1,13 @@
 // Package thriftpool provides implementations of thrift client pool.
+//
+// The channel implementation has roughly 300ns overhead on Get/Release pair
+// calls:
+//
+//     $ go test -bench . -benchmem
+//     goos: darwin
+//     goarch: amd64
+//     pkg: github.com/reddit/baseplate.go/thriftpool
+//     BenchmarkPoolGetRelease/channel-8         	 3993308	       278 ns/op	       0 B/op	       0 allocs/op
+//     PASS
+//     ok  	github.com/reddit/baseplate.go/thriftpool	2.495s
 package thriftpool


### PR DESCRIPTION
This is closer to how they are used in real world code.