### PR TITLE
thriftpool: Fix a bug on active connection counting

### DIFF
--- a/thriftpool/interface_test.go
+++ b/thriftpool/interface_test.go
@@ -234,7 +234,7 @@ func testPool(t *testing.T, pool thriftpool.Pool, openerCalled *int32, min, max 
 				t.Errorf("pool.Release returned error: %v", err)
 			}
 
-			checkActiveAndAllocated(t, pool, 0, max)
+			checkActiveAndAllocated(t, pool, -1, max)
 
 			if !c.closed {
 				t.Error("pool.Release did not close extra released client")


### PR DESCRIPTION
Previously we only decrease number of active connections when we
successfully returned the client to the pool, which means when there are
errors (usually when Close reported error, or when we try to open
a new client in Release and the opener returned an error), we don't
decrease the number, even though semantically the client is returned to
the pool. That leads to the pool reporting exhausted when even we tried
to return every client we got from the pool.