### PR TITLE
Add thriftclient package

### DIFF
--- a/thriftclient/client.go
+++ b/thriftclient/client.go
@@ -1,0 +1,58 @@
+package thriftclient
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+// MonitoredClient implements the thrift.TClient interface and can be used to
+// wrap thrift calls in a client span.
+//
+// Calls will only be wrapped in client spans if the given context has a parent
+// span (either a server or "active" local/client span) set on it.  If no such
+// span is set, then the call will still proceed, it will just not be monitored
+// by a client span.
+type MonitoredClient struct {
+	// Client is the inner thrift.TClient implementation wrapped by the
+	// MonitoredClient.
+	Client thrift.TClient
+}
+
+// NewMonitoredClientFromFactory returns a pointer to a new MonitoredClient that
+// a new TStandardClient using the provided transport and protocol factory.
+func NewMonitoredClientFromFactory(transport thrift.TTransport, factory thrift.TProtocolFactory) *MonitoredClient {
+	return &MonitoredClient{thrift.NewTStandardClient(
+		factory.GetProtocol(transport),
+		factory.GetProtocol(transport),
+	)}
+}
+
+// Call wraps the underlying thrift.TClient.Call method with a client span.
+func (c MonitoredClient) Call(ctx context.Context, method string, args, result thrift.TStruct) (err error) {
+	var span *tracing.Span
+	if span = tracing.GetActiveSpan(ctx); span == nil {
+		span = tracing.GetServerSpan(ctx)
+	}
+	var child *tracing.Span
+	if span != nil {
+		ctx, child = span.ChildAndThriftContext(ctx, method)
+	}
+	defer func() {
+		if child != nil {
+			if stopErr := child.Stop(ctx, err); stopErr != nil {
+				log.Error("Error trying to stop span: " + stopErr.Error())
+			}
+		}
+	}()
+	return c.Client.Call(ctx, method, args, result)
+}
+
+// Validate that MonitoredClient implements thrift.TClient
+var (
+	_ thrift.TClient = MonitoredClient{}
+	_ thrift.TClient = (*MonitoredClient)(nil)
+)

--- a/thriftclient/client_test.go
+++ b/thriftclient/client_test.go
@@ -1,0 +1,178 @@
+package thriftclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/reddit/baseplate.go/mqsend"
+	"github.com/reddit/baseplate.go/runtimebp"
+	"github.com/reddit/baseplate.go/thriftclient"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+const (
+	method = "foo"
+)
+
+func initClients() (*thriftclient.MockClient, *thriftclient.RecordedClient, *thriftclient.MonitoredClient) {
+	mock := &thriftclient.MockClient{}
+	recorder := thriftclient.NewRecordedClient(mock)
+	client := &thriftclient.MonitoredClient{Client: recorder}
+	return mock, recorder, client
+}
+
+func initServerSpan(ctx context.Context) (context.Context, *tracing.Tracer) {
+	ip, _ := runtimebp.GetFirstIPv4()
+	tracer := &tracing.Tracer{
+		SampleRate: 1.0,
+		Endpoint: tracing.ZipkinEndpointInfo{
+			ServiceName: "test-service",
+			IPv4:        ip,
+		},
+	}
+	tracer.Recorder = mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
+		MaxQueueSize:   100,
+		MaxMessageSize: 1024,
+	})
+
+	ctx, span := tracing.CreateServerSpanForContext(ctx, tracer, "test-service")
+	span.SetDebug(true)
+	return ctx, tracer
+}
+
+func initLocalSpan(ctx context.Context) (context.Context, *tracing.Tracer) {
+	ctx, tracer := initServerSpan(ctx)
+	span := tracing.GetServerSpan(ctx)
+	if span == nil {
+		panic("server span was nill")
+	}
+	ctx, _ = span.CreateLocalChildForContext(ctx, "local-test", "")
+	return ctx, tracer
+}
+
+func drainTracer(t *tracing.Tracer) ([]byte, error) {
+	mmq := t.Recorder.(*mqsend.MockMessageQueue)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	return mmq.Receive(ctx)
+}
+
+func TestMonitoredClientNilSpan(t *testing.T) {
+	t.Parallel()
+
+	_, recorder, client := initClients()
+	if err := client.Call(context.Background(), method, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	call := recorder.Calls()[0]
+	span := tracing.GetActiveSpan(call.Ctx)
+	if span != nil {
+		t.Errorf("expected nil span, got %#v", span)
+	}
+	if call.Method != method {
+		t.Errorf("method mismatch, expected %q, got %q", method, call.Method)
+	}
+}
+
+func TestMonitoredClient(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		call          thriftclient.MockCall
+		errorExpected bool
+		initSpan      func(context.Context) (context.Context, *tracing.Tracer)
+	}{
+		{
+			name: "server span: success",
+			call: func(ctx context.Context, args, result thrift.TStruct) error {
+				return nil
+			},
+			errorExpected: false,
+			initSpan:      initServerSpan,
+		},
+		{
+			name: "server span: error",
+			call: func(ctx context.Context, args, result thrift.TStruct) error {
+				return errors.New("test error")
+			},
+			errorExpected: true,
+			initSpan:      initServerSpan,
+		},
+		{
+			name: "local span: success",
+			call: func(ctx context.Context, args, result thrift.TStruct) error {
+				return nil
+			},
+			errorExpected: false,
+			initSpan:      initLocalSpan,
+		},
+		{
+			name: "local span: error",
+			call: func(ctx context.Context, args, result thrift.TStruct) error {
+				return errors.New("test error")
+			},
+			errorExpected: true,
+			initSpan:      initLocalSpan,
+		},
+	}
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				mock, recorder, client := initClients()
+				mock.AddMockCall(method, c.call)
+
+				ctx, tracer := c.initSpan(context.Background())
+				if err := client.Call(ctx, method, nil, nil); !c.errorExpected && err != nil {
+					t.Fatal(err)
+				} else if c.errorExpected && err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+				call := recorder.Calls()[0]
+				span := tracing.GetActiveSpan(call.Ctx)
+				if span == nil {
+					t.Fatal("span was nil")
+				}
+				if span.Name() != method {
+					t.Errorf("span name mismatch, expected %q, got %q", method, span.Name())
+				}
+				if span.SpanType() != tracing.SpanTypeClient {
+					t.Errorf("span type mismatch, expected %s, got %s", tracing.SpanTypeClient, span.SpanType())
+				}
+				if call.Method != method {
+					t.Errorf("method mismatch, expected %q, got %q", method, call.Method)
+				}
+
+				msg, err := drainTracer(tracer)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var trace tracing.ZipkinSpan
+				err = json.Unmarshal(msg, &trace)
+				if err != nil {
+					t.Fatal(err)
+				}
+				hasError := false
+				for _, annotation := range trace.BinaryAnnotations {
+					if annotation.Key == "error" {
+						hasError = true
+					}
+				}
+				if !c.errorExpected && hasError {
+					t.Error("error binary annotation present")
+				} else if c.errorExpected && !hasError {
+					t.Error("error binary annotation not present")
+				}
+			},
+		)
+	}
+}

--- a/thriftclient/doc.go
+++ b/thriftclient/doc.go
@@ -1,0 +1,4 @@
+// Package thriftclient provides a thrift.TClient implementation that wraps a
+// thrift call in a client span as well as implementations to help with unit
+// testing thrift client code.
+package thriftclient

--- a/thriftclient/example_client_test.go
+++ b/thriftclient/example_client_test.go
@@ -1,0 +1,31 @@
+package thriftclient_test
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/thriftclient"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+func ExampleMonitoredClient() {
+	// variables should be properly initialized in production code
+	var (
+		transport thrift.TTransport
+		factory   thrift.TProtocolFactory
+		tracer    *tracing.Tracer
+	)
+	// Create an actual service client
+	client := baseplate.NewBaseplateServiceClient(
+		// Use MonitoredClient to wrap a standard thrift client
+		thriftclient.NewMonitoredClientFromFactory(transport, factory),
+	)
+	// Create a context with a server span
+	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	// Calls should be automatically wrapped using client spans
+	healthy, err := client.IsHealthy(ctx)
+	log.Debug("%v, %s", healthy, err)
+}

--- a/thriftclient/testing.go
+++ b/thriftclient/testing.go
@@ -1,0 +1,103 @@
+package thriftclient
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+)
+
+// MockCall is a mock function that can be registered to a method in a MockClient
+type MockCall func(ctx context.Context, args, result thrift.TStruct) error
+
+// MockClient implements thrift.TClient and can be used to mock out thrift calls
+// in testing by using it as the base client rather than a real client.
+//
+// If a MockCall is registered to a method, then Call will return the result of
+// that MockCall when that method is Call-ed.  If no MockCall is registered to a
+// method, Call will simply return nil.
+//
+// MockClient is provided to help with unit testing and should not be used in
+// production code.
+type MockClient struct {
+	methods map[string]MockCall
+}
+
+// AddMockCall registers the given MockCall to the given method.
+//
+// If a mock is already registered to that method, it will be replaced with the
+// new mock.
+//
+// AddMockCall is not thread-safe.
+func (c *MockClient) AddMockCall(method string, mock MockCall) {
+	if c.methods == nil {
+		c.methods = make(map[string]MockCall)
+	}
+	c.methods[method] = mock
+}
+
+// Call fufills the thrift.TClient interface. It will return the result of the
+// MockCall registered to method if one exists, otherwise it returns nil.
+func (c *MockClient) Call(ctx context.Context, method string, args, result thrift.TStruct) error {
+	if m, ok := c.methods[method]; ok {
+		return m(ctx, args, result)
+	}
+	return nil
+}
+
+// Call records the inputs passed to RecordedClient.Call.
+type Call struct {
+	Ctx    context.Context
+	Method string
+	args   thrift.TStruct
+	result thrift.TStruct
+}
+
+// RecordedClient implements the thrift.TClient interface and records the inputs
+// to each Call.
+//
+// RecordedClient is provided to help with unit testing and should not be used
+// in production code.
+//
+// RecordedClient is not thread-safe.
+type RecordedClient struct {
+	client thrift.TClient
+
+	calls []Call
+}
+
+// NewRecordedClient returns a pointer to a new RecordedClient that wraps the
+// provided client.
+func NewRecordedClient(c thrift.TClient) *RecordedClient {
+	return &RecordedClient{client: c}
+}
+
+// Calls returns a copy of all of recorded Calls.
+//
+// Calls is not thread-safe and may panic if used across threads if the number
+// of calls changes between the copy buffer being intialized and copied.
+func (c RecordedClient) Calls() []Call {
+	calls := make([]Call, len(c.calls))
+	copy(calls, c.calls)
+	return calls
+}
+
+// Call fufills the thrift.TClient interface. It will record the inputs to Call
+// and either return the result of the inner client.Call or nil if the inner
+// client is nil.
+func (c *RecordedClient) Call(ctx context.Context, method string, args, result thrift.TStruct) error {
+	c.calls = append(c.calls, Call{
+		Ctx:    ctx,
+		Method: method,
+		args:   args,
+		result: result,
+	})
+	if c.client != nil {
+		return c.client.Call(ctx, method, args, result)
+	}
+	return nil
+}
+
+var (
+	_ thrift.TClient = (*MockClient)(nil)
+	_ thrift.TClient = (*RecordedClient)(nil)
+)


### PR DESCRIPTION
This package adds a `MonitoredClient`, which is an implementation of `thrift.TClient` that wraps the `Call` to an internal client in a thrift client span.

This is in it's own package because it has to import from `tracing` which currently imports from `tracingbp`.

It also adds 2 other `thrift.TClient` implementations that can be used to mock out clients and help with unit testing.