### PR TITLE
tracing: Migrate to opentracing API

### DIFF
--- a/redisbp/hooks_test.go
+++ b/redisbp/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/go-redis/redis/v7"
+	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/redisbp"
 	"github.com/reddit/baseplate.go/tracing"
@@ -22,12 +23,12 @@ func TestSpanHook(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
-			activeSpan := tracing.GetActiveSpan(ctx)
+			activeSpan := opentracing.SpanFromContext(ctx)
 			if activeSpan == nil {
 				t.Fatalf("'activeSpan' is 'nil'")
 			}
-			if activeSpan.Name() != "redis.ping" {
-				t.Fatalf("Incorrect span name %q", activeSpan.Name())
+			if name := tracing.AsSpan(activeSpan).Name(); name != "redis.ping" {
+				t.Fatalf("Incorrect span name %q", name)
 			}
 
 			if err = hooks.AfterProcess(ctx, cmd); err != nil {
@@ -44,12 +45,12 @@ func TestSpanHook(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected error: %s", err)
 			}
-			activeSpan := tracing.GetActiveSpan(ctx)
+			activeSpan := opentracing.SpanFromContext(ctx)
 			if activeSpan == nil {
 				t.Fatalf("'activeSpan' is 'nil'")
 			}
-			if activeSpan.Name() != "redis.pipeline" {
-				t.Fatalf("Incorrect span name %q", activeSpan.Name())
+			if name := tracing.AsSpan(activeSpan).Name(); name != "redis.pipeline" {
+				t.Fatalf("Incorrect span name %q", name)
 			}
 
 			if err = hooks.AfterProcessPipeline(ctx, cmds); err != nil {

--- a/thriftclient/example_client_test.go
+++ b/thriftclient/example_client_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/apache/thrift/lib/go/thrift"
-
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/thriftclient"
@@ -16,7 +16,6 @@ func ExampleMonitoredClient() {
 	var (
 		transport thrift.TTransport
 		factory   thrift.TProtocolFactory
-		tracer    *tracing.Tracer
 	)
 	// Create an actual service client
 	client := baseplate.NewBaseplateServiceClient(
@@ -24,7 +23,11 @@ func ExampleMonitoredClient() {
 		thriftclient.NewMonitoredClientFromFactory(transport, factory),
 	)
 	// Create a context with a server span
-	ctx, _ := tracing.CreateServerSpanForContext(context.Background(), tracer, "test")
+	_, ctx := opentracing.StartSpanFromContext(
+		context.Background(),
+		"test",
+		tracing.SpanTypeOption{Type: tracing.SpanTypeServer},
+	)
 	// Calls should be automatically wrapped using client spans
 	healthy, err := client.IsHealthy(ctx)
 	log.Debug("%v, %s", healthy, err)

--- a/tracing/example_middlewares_test.go
+++ b/tracing/example_middlewares_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	httpgk "github.com/go-kit/kit/transport/http"
-
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/tracing"

--- a/tracing/log.go
+++ b/tracing/log.go
@@ -1,0 +1,26 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+// TestWrapper is a log.Wrapper implementation can be used in tests.
+//
+// It's similar to but different from log.TestWrapper.
+// In InitGlobalTracer call logger could be called once for unable to find ip,
+// and we don't want to fail the tests because of that.
+// So in this implementation,
+// initially this logger just print the message but don't fail the test,
+// and only start failing the test after startFailing is called.
+func TestWrapper(tb testing.TB) (logger log.Wrapper, startFailing func()) {
+	logf := tb.Logf
+	logger = func(msg string) {
+		logf("logger called with msg: %q", msg)
+	}
+	startFailing = func() {
+		logf = tb.Errorf
+	}
+	return
+}

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -43,7 +43,7 @@ type trace struct {
 
 func newTrace(tracer *Tracer, name string) *trace {
 	if tracer == nil {
-		tracer = &GlobalTracer
+		tracer = &globalTracer
 	}
 	return &trace{
 		tracer: tracer,
@@ -84,7 +84,7 @@ func (t *trace) toZipkinSpan() ZipkinSpan {
 
 	var endpoint ZipkinEndpointInfo
 	if t.tracer != nil {
-		endpoint = t.tracer.Endpoint
+		endpoint = t.tracer.endpoint
 	}
 
 	if t.timeAnnotationReceiveKey != "" {


### PR DESCRIPTION
This is a breaking change.

Remove some of the tracing API in favor of opentracing API, in details
(this is not an exhaustive list):

- GlobalTracer is no longer exported, use opentracing.GlobalTracer()
  instead.
- No longer provide *WithTracer APIs, always use the global tracer.
- Remove CreateServerSpan* APIs, use opentracing.StartSpan with
  SpanTypeServer as a SpanTypeOption instead.
- Remove Tracer.NewTrace API, use opentracing.StartSpan without parent
  instead.
- Remove Span.Create*Child API, use opentracing.StartSpan instead.

Added APIs:

- tracing.AsSpan() to convert opentracing.Span into *tracing.Span.
- tracing.TestWrapper() for special case of tracing related testing.
- tracing.CloseTracer() to stop the global tracer from reporting.