### PR TITLE
metricsbp: Make sure Timer.Start is nil-safe

### DIFF
--- a/metricsbp/timer.go
+++ b/metricsbp/timer.go
@@ -30,8 +30,12 @@ func NewTimer(h metrics.Histogram) *Timer {
 }
 
 // Start records the start time for the Timer.
+//
+// If t is nil, it will be no-op.
 func (t *Timer) Start() {
-	t.start = time.Now()
+	if t != nil {
+		t.start = time.Now()
+	}
 }
 
 // ObserveDuration reports the time elapsed via the wrapped histogram.


### PR DESCRIPTION
We mentioned in the doc of Timer that it's nil-safe, so make sure that
Timer.Start is also nil-safe. :)