### PR TITLE
Add method to attach the Request Context header to HTTP headers

### DIFF
--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -2,8 +2,10 @@ package edgecontext
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
+	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/set"
 	"github.com/reddit/baseplate.go/thriftbp"
@@ -45,6 +47,11 @@ func (e *EdgeRequestContext) AttachToContext(ctx context.Context) context.Contex
 	headers.Add(thriftbp.HeaderEdgeRequest)
 	ctx = thrift.SetWriteHeaderList(ctx, headers.ToSlice())
 	return ctx
+}
+
+// AttachHTTPHeader attaches the header to the http Headers
+func (e *EdgeRequestContext) AttachHTTPHeader(h http.Header) {
+	h.Add(httpbp.EdgeContextHeader, e.header)
 }
 
 // SessionID returns the session id of this request.

--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
@@ -15,6 +16,15 @@ import (
 
 // Signer is used to return a signature of the given string.
 type Signer func(s string) (string, error)
+
+// HeaderTrustHandlerSigner returns a Signer that can be used to sign an
+// edge context HTTP header using TrustHeaderSignature.SignEdgeContextHeader.
+func HeaderTrustHandlerSigner(handler httpbp.TrustHeaderSignature, duration time.Duration) Signer {
+	return func(s string) (string, error) {
+		h := httpbp.EdgeContextHeaders{EdgeRequest: s}
+		return handler.SignEdgeContextHeader(h, duration)
+	}
+}
 
 // An EdgeRequestContext contains context info about an edge request.
 type EdgeRequestContext struct {

--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
+// Signer is used to return a signature of the given string.
 type Signer func(s string) (string, error)
 
 // An EdgeRequestContext contains context info about an edge request.

--- a/edgecontext/req_context_test.go
+++ b/edgecontext/req_context_test.go
@@ -1,0 +1,50 @@
+package edgecontext_test
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/reddit/baseplate.go/httpbp"
+
+	"github.com/reddit/baseplate.go/edgecontext"
+)
+
+func TestAttachHTTPHeader(t *testing.T) {
+	t.Parallel()
+
+	e, err := edgecontext.New(
+		context.Background(),
+		edgecontext.NewArgs{
+			LoID:          expectedLoID,
+			LoIDCreatedAt: expectedCookieTime,
+			SessionID:     expectedSessionID,
+			AuthToken:     validToken,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run(
+		"AttachHTTPHeader",
+		func(t *testing.T) {
+			headers := make(http.Header)
+			e.AttachHTTPHeader(headers)
+			h := headers.Get(httpbp.EdgeContextHeader)
+			if h == "" {
+				t.Fatal("Header was not attached.")
+			}
+			ctx := httpbp.SetHeader(context.Background(), httpbp.EdgeContextContextKey, h)
+			ec, err := edgecontext.FromHTTPContext(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(e, ec) {
+				t.Fatalf("Expected %#v, got %#v", e, ec)
+			}
+		},
+	)
+}

--- a/edgecontext/req_context_test.go
+++ b/edgecontext/req_context_test.go
@@ -2,14 +2,40 @@ package edgecontext_test
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/secrets"
 
 	"github.com/reddit/baseplate.go/httpbp"
 
 	"github.com/reddit/baseplate.go/edgecontext"
 )
+
+const secretsFile = `{
+	"secrets": {
+		"secret/http/edge-context-signature": {
+			"type": "versioned",
+			"current": "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU=",
+			"previous": "aHVudGVyMg==",
+			"encoding": "base64"
+		},
+		"secret/http/span-signature": {
+			"type": "versioned",
+			"current": "Y2RvVXhNMVdsTXJma3BDaHRGZ0dPYkVGSg==",
+			"encoding": "base64"
+		}
+	},
+	"vault": {
+		"url": "vault.reddit.ue1.snooguts.net",
+		"token": "17213328-36d4-11e7-8459-525400f56d04"
+	}
+}`
 
 func TestAttachHTTPHeader(t *testing.T) {
 	t.Parallel()
@@ -30,6 +56,8 @@ func TestAttachHTTPHeader(t *testing.T) {
 	t.Run(
 		"AttachHTTPHeader",
 		func(t *testing.T) {
+			t.Parallel()
+
 			headers := make(http.Header)
 			e.AttachHTTPHeader(headers)
 			h := headers.Get(httpbp.EdgeContextHeader)
@@ -44,6 +72,75 @@ func TestAttachHTTPHeader(t *testing.T) {
 
 			if !reflect.DeepEqual(e, ec) {
 				t.Fatalf("Expected %#v, got %#v", e, ec)
+			}
+		},
+	)
+
+	t.Run(
+		"AttachSignedHTTPHeader",
+		func(t *testing.T) {
+			t.Parallel()
+
+			dir, err := ioutil.TempDir("", "secret_test_")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+
+			tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			tmpPath := tmpFile.Name()
+			if _, err = tmpFile.Write([]byte(secretsFile)); err != nil {
+				t.Fatal(err)
+			}
+			if err := tmpFile.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			store, err := secrets.NewStore(context.Background(), tmpPath, log.TestWrapper(t))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+
+			handler := httpbp.NewTrustHeaderSignature(httpbp.TrustHeaderSignatureArgs{
+				SecretsStore:          store,
+				EdgeContextSecretPath: "secret/http/edge-context-signature",
+				SpanSecretPath:        "secret/http/span-signature",
+			})
+
+			signer := edgecontext.HeaderTrustHandlerSigner(handler, time.Minute)
+
+			headers := make(http.Header)
+			if err = e.AttachSignedHTTPHeader(headers, signer); err != nil {
+				t.Fatal(err)
+			}
+
+			h := headers.Get(httpbp.EdgeContextHeader)
+			if h == "" {
+				t.Fatal("Header was not attached.")
+			}
+
+			ctx := httpbp.SetHeader(context.Background(), httpbp.EdgeContextContextKey, h)
+			ec, err := edgecontext.FromHTTPContext(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(e, ec) {
+				t.Fatalf("Expected %#v, got %#v", e, ec)
+			}
+
+			sig := headers.Get(httpbp.EdgeContextSignatureHeader)
+			if sig == "" {
+				t.Fatal("Signature was not attached.")
+			}
+
+			r := &http.Request{Header: headers}
+			if !handler.TrustEdgeContext(r) {
+				t.Fatal("Signature check failed")
 			}
 		},
 	)

--- a/edgecontext/req_context_test.go
+++ b/edgecontext/req_context_test.go
@@ -9,12 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/secrets"
-
-	"github.com/reddit/baseplate.go/httpbp"
-
-	"github.com/reddit/baseplate.go/edgecontext"
 )
 
 const secretsFile = `{


### PR DESCRIPTION
This is so we can pass the RequestContext header between HTTP services.