### PR TITLE
Fix span hook metrics path

### DIFF
--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -34,7 +34,7 @@ type spanHook struct {
 }
 
 func newSpanHook(metrics *Statsd, span *tracing.Span) spanHook {
-	name := fmt.Sprintf("%v.%s", span.SpanType(), span.Name())
+	name := span.Component() + "." + span.Name()
 	return spanHook{
 		Name:    name,
 		Metrics: metrics,

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -186,6 +186,25 @@ func (s *Span) AddCounter(key string, delta float64) {
 	}
 }
 
+// Component returns the local component name of this span, with special cases.
+//
+// For local spans,
+// this returns the component name set while starting the span,
+// or "local" if it's empty.
+// For client spans, this returns "clients".
+// For all other span types, this returns the string version of the span type.
+func (s *Span) Component() string {
+	switch s.spanType {
+	case SpanTypeClient:
+		return "clients"
+	case SpanTypeLocal:
+		if s.component != "" {
+			return s.component
+		}
+	}
+	return s.spanType.String()
+}
+
 func (s Span) initChildSpan(child *Span) {
 	child.trace.parentID = s.trace.spanID
 	child.trace.traceID = s.trace.traceID


### PR DESCRIPTION
In baseplate.py, we use "clients" (instead of "client") for client
spans and the component name for local spans. This makes baseplate.go's
behavior the same.

Also add Span.Component() API to support that.