### PR TITLE
Add prefix to error messages

### DIFF
--- a/clientpool/errors.go
+++ b/clientpool/errors.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ErrExhausted is the error returned by Get when the pool is exhausted.
-var ErrExhausted = errors.New("client pool exhausted")
+var ErrExhausted = errors.New("clientpool: exhausted")
 
 // ConfigError is the error type returned when trying to open a new
 // client pool, but the configuration values passed in won't work.

--- a/edgecontext/validator.go
+++ b/edgecontext/validator.go
@@ -17,13 +17,17 @@ const (
 	jwtAlg                         = "RS256"
 )
 
+// ErrNoPublicKeysLoaded is an error returned by ValidateToken indicates that
+// the function is called before any public keys are loaded from secrets.
+var ErrNoPublicKeysLoaded = errors.New("edgecontext.ValidateToken: no public keys loaded")
+
 // ValidateToken parses and validates a jwt token, and return the decoded
 // AuthenticationToken.
 func ValidateToken(token string) (*AuthenticationToken, error) {
 	keys, ok := keysValue.Load().(keysType)
 	if !ok {
 		// This would only happen when all previous middleware parsing failed.
-		return nil, errors.New("no public keys loaded")
+		return nil, ErrNoPublicKeysLoaded
 	}
 
 	tok, err := jwt.ParseWithClaims(

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -83,7 +83,10 @@ func (e *Experiments) experiment(name string) (Experiment, error) {
 		return NewSimpleExperiment(experiment)
 	}
 	// TODO handle this according to baseplate.py
-	return nil, fmt.Errorf("unknown experiment %s", experiment.Type)
+	return nil, fmt.Errorf(
+		"experiments.Experiments.Variant: unknown experiment %s",
+		experiment.Type,
+	)
 }
 
 // ParsedExperiment represents the experiment and configures the available
@@ -240,7 +243,11 @@ func (e *SimpleExperiment) Variant(args map[string]interface{}) (string, error) 
 	}
 	args = lowerArguments(args)
 	if value, ok := args[e.bucketVal]; !ok || value == "" {
-		return "", fmt.Errorf("must specify %s in call to variant for experiment %s", e.bucketVal, e.name)
+		return "", fmt.Errorf(
+			"experiment.SimpleExperiment.Variant: must specify %s in call to variant for experiment %s",
+			e.bucketVal,
+			e.name,
+		)
 	}
 	for _, override := range e.overrides {
 		for variant, targeting := range override {
@@ -254,7 +261,10 @@ func (e *SimpleExperiment) Variant(args map[string]interface{}) (string, error) 
 	}
 	bucketVal, ok := args[e.bucketVal].(string)
 	if !ok {
-		return "", fmt.Errorf("expected bucket val to be a string, actual: %T", args[e.bucketVal])
+		return "", fmt.Errorf(
+			"experiment.SimpleExperiment.Variant: expected bucket val to be a string, actual: %T",
+			args[e.bucketVal],
+		)
 	}
 
 	bucket := e.calculateBucket(bucketVal)
@@ -311,7 +321,7 @@ type Variant struct {
 type UnknownExperimentError string
 
 func (name UnknownExperimentError) Error() string {
-	return fmt.Sprintf("experiment with name %s unknown", name)
+	return fmt.Sprintf("experiments: experiment with name %s unknown", name)
 }
 
 func isSimpleExperiment(experimentType string) bool {

--- a/experiments/experiments_test.go
+++ b/experiments/experiments_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -265,8 +266,8 @@ func TestNoBucketVal(t *testing.T) {
 	}
 	result, err := experiment.Variant(map[string]interface{}{"not_user_id": "t2_1"})
 	expectedErr := "must specify user_id in call to variant for experiment test_experiment"
-	if err != nil && err.Error() != expectedErr {
-		t.Errorf("expected error %s but was: %v", expectedErr, err)
+	if err != nil && !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error %q but was: %v", expectedErr, err)
 	}
 	if result != "" {
 		t.Errorf("expected result to be empty but was %s", result)
@@ -278,8 +279,8 @@ func TestNoBucketVal(t *testing.T) {
 	}
 	result, err = experiment.Variant(map[string]interface{}{"not_user_id": ""})
 	expectedErr = "must specify user_id in call to variant for experiment test_experiment"
-	if err != nil && err.Error() != expectedErr {
-		t.Errorf("expected error %s but was: %v", expectedErr, err)
+	if err != nil && !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error %q but was: %v", expectedErr, err)
 	}
 	if result != "" {
 		t.Errorf("expected result to be empty but was %s", result)

--- a/experiments/targeting.go
+++ b/experiments/targeting.go
@@ -305,9 +305,9 @@ func lessThan(i, j float64) bool      { return i < j }
 func lessEquals(i, j float64) bool    { return i <= j }
 func notEqual(i, j float64) bool      { return i != j }
 
-func mapOperatorNode(name string, value interface{}) (Targeting, error) {
-	name = strings.ToLower(name)
-	switch name {
+func mapOperatorNode(operator string, value interface{}) (Targeting, error) {
+	operator = strings.ToLower(operator)
+	switch operator {
 	case "any":
 		return NewAnyNode(value)
 	case "all":
@@ -329,7 +329,7 @@ func mapOperatorNode(name string, value interface{}) (Targeting, error) {
 	case "ne":
 		return NewComparisonNode(value.(map[string]interface{}), notEqual)
 	}
-	return nil, UnknownTargetingOperatorError(fmt.Sprintf("unrecognized operator while constructing targeting tree: %s", name))
+	return nil, UnknownTargetingOperatorError(operator)
 }
 
 // TargetingNodeError is returned when there was an inconsistency in the
@@ -338,13 +338,13 @@ func mapOperatorNode(name string, value interface{}) (Targeting, error) {
 type TargetingNodeError string
 
 func (cause TargetingNodeError) Error() string {
-	return string(cause)
+	return "experiments: " + string(cause)
 }
 
 // UnknownTargetingOperatorError is returned when the parsed operator is not
 // known.
 type UnknownTargetingOperatorError string
 
-func (cause UnknownTargetingOperatorError) Error() string {
-	return string(cause)
+func (operator UnknownTargetingOperatorError) Error() string {
+	return "experiments: unrecognized operator while constructing targeting tree: " + string(operator)
 }

--- a/experiments/variants.go
+++ b/experiments/variants.go
@@ -240,5 +240,5 @@ func (v *RangeVariantSet) ChooseVariant(bucket int) string {
 type VariantValidationError string
 
 func (cause VariantValidationError) Error() string {
-	return string(cause)
+	return "experiments: " + string(cause)
 }

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -93,18 +93,18 @@ func numCPUSharesFallback() (n float64) {
 func readNumberFromFile(path string, buf []byte) (float64, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to open %s: %w", path, err)
 	}
 	defer file.Close()
 
 	n, err := file.Read(buf)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to read %s: %w", path, err)
 	}
 
 	f, err := strconv.ParseInt(strings.TrimSpace(string(buf[:n])), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to parse %s: %w", path, err)
 	}
 	return float64(f), nil
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -267,7 +267,10 @@ func NewSecrets(r io.Reader) (*Secrets, error) {
 			}
 			secrets.credentialSecrets[key] = credential
 		default:
-			return nil, fmt.Errorf("encountered unknown secret type %s", secret.Type)
+			return nil, fmt.Errorf(
+				"secrets.NewSecrets: encountered unknown secret type %s",
+				secret.Type,
+			)
 		}
 	}
 	return secrets, nil

--- a/tracing/errors.go
+++ b/tracing/errors.go
@@ -17,7 +17,7 @@ var _ error = (*InvalidSpanTypeError)(nil)
 
 func (e *InvalidSpanTypeError) Error() string {
 	return fmt.Sprintf(
-		"span.spanType: expected (%v) != actual (%v)",
+		"span.SpanType: expected (%v) != actual (%v)",
 		e.ExpectedSpanType,
 		e.ActualSpanType,
 	)

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -145,8 +145,7 @@ func (s *Span) AddHooks(hooks ...interface{}) {
 			s.LogError(
 				"AddHooks error: ",
 				fmt.Errorf(
-					"attempting to add non-SpanHook object %T into span's hook registry: %#v",
-					hook,
+					"tracing.Span.AddHooks: attempting to add non-SpanHook object into span's hook registry: %#v",
 					hook,
 				),
 			)


### PR DESCRIPTION
For all errors returned by the libraries, make sure that we always
prefix them with "package_name: ", or even "package_name.FunctionName:".