### PR TITLE
Add experiment logging by adding an Expose method

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ http_archive(
     sha256 = "d8c45ee70ec39a57e7a05e5027c32b1576cc7f16d9dd37135b0eddde45cf1b10",
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,10 +43,3 @@ load("//:external.bzl", "go_dependencies")
 
 # gazelle:repository_macro external.bzl%go_dependencies
 go_dependencies()
-
-go_repository(
-    name = "com_github_gofrs_uuid",
-    importpath = "github.com/gofrs/uuid",
-    sum = "h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=",
-    version = "v3.2.0+incompatible",
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ http_archive(
     sha256 = "d8c45ee70ec39a57e7a05e5027c32b1576cc7f16d9dd37135b0eddde45cf1b10",
 )
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
@@ -43,3 +43,10 @@ load("//:external.bzl", "go_dependencies")
 
 # gazelle:repository_macro external.bzl%go_dependencies
 go_dependencies()
+
+go_repository(
+    name = "com_github_gofrs_uuid",
+    importpath = "github.com/gofrs/uuid",
+    sum = "h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=",
+    version = "v3.2.0+incompatible",
+)

--- a/experiments/BUILD.bazel
+++ b/experiments/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//filewatcher:go_default_library",
         "//log:go_default_library",
         "//timebp:go_default_library",
+        "@com_github_gofrs_uuid//:go_default_library",
     ],
 )
 

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -78,7 +78,9 @@ func (e *Experiments) Expose(ctx context.Context, experimentName string, event E
 		return UnknownExperimentError(experimentName)
 	}
 	event.Experiment = experiment
-	event.EventType = "EXPOSE"
+	if event.EventType == "" {
+		event.EventType = "EXPOSE"
+	}
 	return e.eventLogger.Log(ctx, event)
 }
 
@@ -338,17 +340,34 @@ func isSimpleExperiment(experimentType string) bool {
 // ExperimentEvent is the playload used by Expose to log whether a user has
 // been exposed to an experimental treatment.
 type ExperimentEvent struct {
-	ID              uuid.UUID
-	CorrelationID   uuid.UUID
-	DeviceID        uuid.UUID
-	Experiment      *ExperimentConfig
-	VariantName     string
-	UserID          string
-	LoggedIn        bool
-	ClientTimestamp int64
-	CookieCreatedAt int64
-	AppName         string
-	EventType       string
+	// ID uniquely identifies the experiment event. If you pass in uuid.Nil the
+	// logger handling this event should generate a UUID v4 (optional).
+	ID uuid.UUID
+	// CorrelationID are used to track events across different services.
+	CorrelationID uuid.UUID
+	// DeviceID unique identifies the device this experiment is being logged
+	// from (optional).
+	DeviceID uuid.UUID
+	// Experiment is the experiment of the applied treatment.
+	Experiment *ExperimentConfig
+	// VariantName is the type of bucket that is being applied.
+	VariantName string
+	// UserID identifies the user who is being exposed to the experimental
+	// treatment.
+	UserID string
+	// LoggedIn indiciates whether the user is authenticated.
+	LoggedIn bool
+	// ClientTimestamp is the time when the experiment has been applied. If
+	// this is not provided the logger should generate a timestamp (optional).
+	ClientTimestamp time.Time
+	// CookieCreatedAt is the timestamp when the cookie for the user has been
+	// generated.
+	CookieCreatedAt time.Time
+	// AppName if any specifies the application (optional).
+	AppName string
+	// EventType is the type of the experiment event. Will be set to EXPOSE
+	// (optional).
+	EventType string
 }
 
 // Logger provides an interface for experiment events to be logged.

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+
 	"github.com/reddit/baseplate.go/filewatcher"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/timebp"
@@ -361,7 +362,7 @@ type ExperimentEvent struct {
 	// this is not provided the logger should generate a timestamp (optional).
 	ClientTimestamp time.Time
 	// CookieCreatedAt is the timestamp when the cookie for the user has been
-	// generated.
+	// generated (optional).
 	CookieCreatedAt time.Time
 	// AppName if any specifies the application (optional).
 	AppName string

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -344,19 +344,19 @@ type ExperimentEvent struct {
 	// ID uniquely identifies the experiment event. If you pass in uuid.Nil the
 	// logger handling this event should generate a UUID v4 (optional).
 	ID uuid.UUID
-	// CorrelationID are used to track events across different services.
+	// CorrelationID are used to track events across different services (optional).
 	CorrelationID uuid.UUID
 	// DeviceID unique identifies the device this experiment is being logged
 	// from (optional).
 	DeviceID uuid.UUID
-	// Experiment is the experiment of the applied treatment.
+	// Experiment is the experiment of the applied treatment (required).
 	Experiment *ExperimentConfig
-	// VariantName is the type of bucket that is being applied.
+	// VariantName is the type of bucket that is being applied (required).
 	VariantName string
 	// UserID identifies the user who is being exposed to the experimental
-	// treatment.
+	// treatment (optional).
 	UserID string
-	// LoggedIn indiciates whether the user is authenticated.
+	// LoggedIn indiciates whether the user is authenticated (optional).
 	LoggedIn bool
 	// ClientTimestamp is the time when the experiment has been applied. If
 	// this is not provided the logger should generate a timestamp (optional).
@@ -366,6 +366,9 @@ type ExperimentEvent struct {
 	CookieCreatedAt time.Time
 	// AppName if any specifies the application (optional).
 	AppName string
+	// IsOverride should be true if the variant shown was due to an override
+	// rather than bucketing (required).
+	IsOverride bool
 	// EventType is the type of the experiment event. Will be set to EXPOSE
 	// (optional).
 	EventType string

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -27,7 +27,7 @@ const targetAllOverride = `{"OVERRIDE": true}`
 // the cache when changed.
 type Experiments struct {
 	watcher     *filewatcher.Result
-	eventLogger Logger
+	eventLogger EventLogger
 }
 
 // NewExperiments returns a new instance of the experiments clients. The path
@@ -35,7 +35,7 @@ type Experiments struct {
 //
 // Context should come with a timeout otherwise this might block forever, i.e.
 // if the path never becomes available.
-func NewExperiments(ctx context.Context, path string, eventLogger Logger, logger log.Wrapper) (*Experiments, error) {
+func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, logger log.Wrapper) (*Experiments, error) {
 	parser := func(r io.Reader) (interface{}, error) {
 		var doc document
 		err := json.NewDecoder(r).Decode(&doc)
@@ -371,7 +371,7 @@ type ExperimentEvent struct {
 	EventType string
 }
 
-// Logger provides an interface for experiment events to be logged.
-type Logger interface {
+// EventLogger provides an interface for experiment events to be logged.
+type EventLogger interface {
 	Log(ctx context.Context, event ExperimentEvent) error
 }

--- a/experiments/experiments_test.go
+++ b/experiments/experiments_test.go
@@ -20,7 +20,7 @@ var simpleConfig = &ExperimentConfig{
 	StartTimestamp: timebp.TimestampSecondF(time.Now().Add(-30 * 24 * time.Hour)),
 	StopTimestamp:  timebp.TimestampSecondF(time.Now().Add(30 * 24 * time.Hour)),
 	Enabled:        func() *bool { b := true; return &b }(),
-	Experiment: ParsedExperiment{
+	Experiment: Experiment{
 		BucketSeed: "some new seed",
 		Variants: []Variant{
 			{
@@ -50,7 +50,7 @@ func TestCalculateBucketValue(t *testing.T) {
 			config: &ExperimentConfig{
 				ID:   1,
 				Name: "test_experiment",
-				Experiment: ParsedExperiment{
+				Experiment: Experiment{
 					ShuffleVersion: "",
 					BucketSeed:     "some new seed",
 					Variants: []Variant{
@@ -93,7 +93,7 @@ func TestCalculateBucket(t *testing.T) {
 		StartTimestamp: timebp.TimestampSecondF(time.Now().Add(-30 * 24 * time.Hour)),
 		StopTimestamp:  timebp.TimestampSecondF(time.Now().Add(30 * 24 * time.Hour)),
 		Enabled:        func() *bool { b := true; return &b }(),
-		Experiment: ParsedExperiment{
+		Experiment: Experiment{
 			Variants: []Variant{
 				{
 					Name: "variant_1",
@@ -151,7 +151,7 @@ func TestCalculateBucketWithSeed(t *testing.T) {
 		StartTimestamp: timebp.TimestampSecondF(time.Now().Add(-30 * 24 * time.Hour)),
 		StopTimestamp:  timebp.TimestampSecondF(time.Now().Add(30 * 24 * time.Hour)),
 		Enabled:        func() *bool { b := true; return &b }(),
-		Experiment: ParsedExperiment{
+		Experiment: Experiment{
 			BucketSeed: "some new seed",
 			Variants: []Variant{
 				{
@@ -349,7 +349,7 @@ func TestOverride(t *testing.T) {
 		StartTimestamp: timebp.TimestampSecondF(time.Now().Add(-30 * 24 * time.Hour)),
 		StopTimestamp:  timebp.TimestampSecondF(time.Now().Add(30 * 24 * time.Hour)),
 		Enabled:        func() *bool { b := true; return &b }(),
-		Experiment: ParsedExperiment{
+		Experiment: Experiment{
 			Variants: []Variant{
 				{
 					Name: "variant_1",

--- a/external.bzl
+++ b/external.bzl
@@ -290,3 +290,9 @@ def go_dependencies():
         sum = "h1:nR6NoDBgAf67s68NhaXbsojM+2gxp3S1hWkHDl27pVU=",
         version = "v1.13.0",
     )
+    go_repository(
+        name = "com_github_gofrs_uuid",
+        importpath = "github.com/gofrs/uuid",
+        sum = "h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=",
+        version = "v3.2.0+incompatible",
+    )

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-redis/redis/v7 v7.0.0-beta.5
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/opentracing/opentracing-go v1.1.0
 	go.uber.org/zap v1.13.0
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/go-redis/redis/v7 v7.0.0-beta.5 h1:7bdbDkv2nKZm6Tydrvmay3xOvVaxpAT4Zs
 github.com/go-redis/redis/v7 v7.0.0-beta.5/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
+github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
I have removed the unnecessary interface and added experiment logging. Experiment logging as part of bucketing seems deprecating so it is enough to include an `Expose` method that services can make use of if they want. The corresponding Python code can be found [here](https://github.com/reddit/baseplate.py/blob/master/baseplate/lib/experiments/__init__.py#L233-L266).

This resolves #3