### PR TITLE
Better way to run bazel tests in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,1 @@
-test --features=race
+test --features=race --test_output=errors

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,7 +48,7 @@ steps:
   image: l.gcr.io/google/bazel:2.2.0
   pull: if-not-exists
   commands:
-  - ./scripts/ci-run-bazel-test.sh
+  - bazel --bazelrc=.bazelrc.ci test //...:all
   when:
     branch:
     - master

--- a/scripts/ci-run-bazel-test.sh
+++ b/scripts/ci-run-bazel-test.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-bazel --bazelrc=.bazelrc.ci test //...:all
-
-if [ $? -ne 0 ]; then
-  # Test failed, print out all test logs then exit with non-zero code.
-  find bazel-testlogs/ -name "test.xml" -print -exec grep -C 1 Failed {} \;
-  exit 1
-fi


### PR DESCRIPTION
We have --test_output=errors so there's no need to print out test logs
in a shell script.