### PR TITLE
Revert "metricsbp: Add total counter to span hook"

### DIFF
--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -37,7 +37,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//set:go_default_library",
         "//tracing:go_default_library",
         "@com_github_go_kit_kit//metrics:go_default_library",
     ],

--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -9,7 +9,6 @@ import (
 const (
 	success = "success"
 	fail    = "fail"
-	total   = "total"
 )
 
 // CreateServerSpanHook registers each Server Span with a MetricsSpanHook.
@@ -70,7 +69,6 @@ func (h spanHook) OnPreStop(span *tracing.Span, err error) error {
 		statusMetricPath = fmt.Sprintf("%s.%s", h.name, success)
 	}
 	h.metrics.Counter(statusMetricPath).Add(1)
-	h.metrics.Counter(fmt.Sprintf("%s.%s", h.name, total)).Add(1)
 	return nil
 }
 


### PR DESCRIPTION
This reverts commit ee15a9795136a9ade6ccb025ee9dbfcf9d4054fc.

The lack of atomic metrics writing between success/fail and total
counters caused the current implementation not really useful in real
world scenarios. When using success/total as the success rate in
dashboards, we can often see it to be above 1. Reverting the change to
discourage that usage and still use success/(success+fail) instead. We
might want to revisit this idea in the future when we can make sure that
success/fail + total can be counted atomically.