### PR TITLE
Move clientpool's package example to thriftclient

### DIFF
--- a/clientpool/BUILD.bazel
+++ b/clientpool/BUILD.bazel
@@ -18,12 +18,7 @@ go_test(
     srcs = [
         "bench_test.go",
         "channel_test.go",
-        "doc_test.go",
         "interface_test.go",
     ],
     embed = [":go_default_library"],
-    deps = [
-        "//thriftclient:go_default_library",
-        "@com_github_apache_thrift//lib/go/thrift:go_default_library",
-    ],
 )

--- a/clientpool/doc.go
+++ b/clientpool/doc.go
@@ -10,4 +10,11 @@
 //     BenchmarkPoolGetRelease/channel-8         	 3993308	       278 ns/op	       0 B/op	       0 allocs/op
 //     PASS
 //     ok  	github.com/reddit/baseplate.go/clientpool	2.495s
+//
+// This package is considered low level.
+// Package thriftclient provided a more useful,
+// thrift-specific wrapping to this package.
+// In most cases you would want to use that package instead if you are using the
+// pool for thrift clients.
+// See thriftclient package's doc for examples.
 package clientpool

--- a/thriftclient/BUILD.bazel
+++ b/thriftclient/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     size = "small",
     srcs = [
         "client_pool_test.go",
+        "doc_test.go",
         "example_client_test.go",
         "monitored_tclient_test.go",
         "ttl_client_test.go",

--- a/thriftclient/doc_test.go
+++ b/thriftclient/doc_test.go
@@ -1,4 +1,4 @@
-package clientpool_test
+package thriftclient_test
 
 import (
 	"context"
@@ -72,8 +72,8 @@ func callEndpoint(ctx context.Context, pool thriftclient.ClientPool) (*MyEndpoin
 	return client.MyEndpoint(ctx, &MyEndpointRequest{})
 }
 
-// This example demonstrates a typical use case of clientpool in microservice
-// code.
+// This example demonstrates a typical use case of thriftclient pool in
+// microservice code.
 func Example() {
 	pool, err := thriftclient.NewTTLClientPool(clientTTL, thriftclient.ClientPoolConfig{
 		ServiceSlug:        "my-service",


### PR DESCRIPTION
The example doesn't use anything from clientpool directly so it's more
appropriate to put it under thriftclient package. Also added package doc
to clientpool to state that it's low level and shouldn't be used
directly in most cases.