### PR TITLE
edgecontext: Move away from singleton

### DIFF
--- a/edgecontext/edgecontext_test.go
+++ b/edgecontext/edgecontext_test.go
@@ -36,6 +36,7 @@ func TestNew(t *testing.T) {
 	ctx := context.Background()
 	e, err := edgecontext.New(
 		ctx,
+		globalTestImpl,
 		edgecontext.NewArgs{
 			LoID:          expectedLoID,
 			LoIDCreatedAt: expectedCookieTime,
@@ -64,7 +65,7 @@ func TestFromThriftContext(t *testing.T) {
 		"no-header",
 		func(t *testing.T) {
 			ctx := context.Background()
-			_, err := edgecontext.FromThriftContext(ctx)
+			_, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if !errors.Is(err, edgecontext.ErrNoHeader) {
 				t.Errorf("Expected ErrNoHeader, got %v", err)
 			}
@@ -79,7 +80,7 @@ func TestFromThriftContext(t *testing.T) {
 				thriftbp.HeaderEdgeRequest,
 				headerWithNoAuthNoDevice,
 			)
-			e, err := edgecontext.FromThriftContext(ctx)
+			e, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,7 +99,7 @@ func TestFromThriftContext(t *testing.T) {
 				thriftbp.HeaderEdgeRequest,
 				headerWithNoAuth,
 			)
-			e, err := edgecontext.FromThriftContext(ctx)
+			e, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -167,7 +168,7 @@ func TestFromThriftContext(t *testing.T) {
 				thriftbp.HeaderEdgeRequest,
 				headerWithValidAuth,
 			)
-			e, err := edgecontext.FromThriftContext(ctx)
+			e, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -236,7 +237,7 @@ func TestFromThriftContext(t *testing.T) {
 				thriftbp.HeaderEdgeRequest,
 				headerWithExpiredAuth,
 			)
-			e, err := edgecontext.FromThriftContext(ctx)
+			e, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -297,7 +298,7 @@ func TestFromThriftContext(t *testing.T) {
 				thriftbp.HeaderEdgeRequest,
 				headerWithAnonAuth,
 			)
-			e, err := edgecontext.FromThriftContext(ctx)
+			e, err := edgecontext.FromThriftContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -354,7 +355,7 @@ func TestFromHTTPContext(t *testing.T) {
 		"no-header",
 		func(t *testing.T) {
 			ctx := context.Background()
-			_, err := edgecontext.FromHTTPContext(ctx)
+			_, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if !errors.Is(err, edgecontext.ErrNoHeader) {
 				t.Errorf("Expected ErrNoHeader, got %v", err)
 			}
@@ -369,7 +370,7 @@ func TestFromHTTPContext(t *testing.T) {
 				httpbp.EdgeContextContextKey,
 				headerWithNoAuth,
 			)
-			e, err := edgecontext.FromHTTPContext(ctx)
+			e, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -430,7 +431,7 @@ func TestFromHTTPContext(t *testing.T) {
 				httpbp.EdgeContextContextKey,
 				headerWithValidAuth,
 			)
-			e, err := edgecontext.FromHTTPContext(ctx)
+			e, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -491,7 +492,7 @@ func TestFromHTTPContext(t *testing.T) {
 				httpbp.EdgeContextContextKey,
 				headerWithExpiredAuth,
 			)
-			e, err := edgecontext.FromHTTPContext(ctx)
+			e, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -552,7 +553,7 @@ func TestFromHTTPContext(t *testing.T) {
 				httpbp.EdgeContextContextKey,
 				headerWithAnonAuth,
 			)
-			e, err := edgecontext.FromHTTPContext(ctx)
+			e, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/edgecontext/example_middlewares_test.go
+++ b/edgecontext/example_middlewares_test.go
@@ -20,6 +20,7 @@ func ExampleInjectHTTPEdgeContext() {
 		DecodeIsHealthyRequest httpgk.DecodeRequestFunc
 		trustHandler           httpbp.AlwaysTrustHeaders
 		logger                 log.Wrapper
+		impl                   *edgecontext.Impl
 	)
 	handler := http.NewServeMux()
 	handler.Handle("/health", httpgk.NewServer(
@@ -28,7 +29,7 @@ func ExampleInjectHTTPEdgeContext() {
 		// easier to add more later on down the line (since you'll have to add
 		// it then anyways).
 		endpoint.Chain(
-			edgecontext.InjectHTTPEdgeContext(logger),
+			edgecontext.InjectHTTPEdgeContext(impl, logger),
 		)(IsHealthy),
 		DecodeIsHealthyRequest,
 		httpbp.EncodeJSONResponse,

--- a/edgecontext/init_test.go
+++ b/edgecontext/init_test.go
@@ -23,6 +23,8 @@ const secretStore = `
 	}
 }`
 
+var globalTestImpl *edgecontext.Impl
+
 func TestMain(m *testing.M) {
 	dir, err := ioutil.TempDir("", "edge_context_test_")
 	if err != nil {
@@ -48,6 +50,6 @@ func TestMain(m *testing.M) {
 	}
 	defer store.Close()
 
-	edgecontext.Init(edgecontext.Config{Store: store})
+	globalTestImpl = edgecontext.Init(edgecontext.Config{Store: store})
 	os.Exit(m.Run())
 }

--- a/edgecontext/middlewares.go
+++ b/edgecontext/middlewares.go
@@ -11,8 +11,8 @@ import (
 
 // InitializeEdgeContext sets an edge request context created using the given
 // ContextFactory onto the context.
-func InitializeEdgeContext(ctx context.Context, logger log.Wrapper, factory ContextFactory) context.Context {
-	if ec, err := factory(ctx); err == nil && ec != nil {
+func InitializeEdgeContext(ctx context.Context, impl *Impl, logger log.Wrapper, factory ContextFactory) context.Context {
+	if ec, err := factory(ctx, impl); err == nil && ec != nil {
 		ctx = SetEdgeContext(ctx, ec)
 	} else if !errors.Is(err, ErrNoHeader) && logger != nil {
 		logger("Error while trying to initialize edge context: " + err.Error())
@@ -22,8 +22,8 @@ func InitializeEdgeContext(ctx context.Context, logger log.Wrapper, factory Cont
 
 // InitializeHTTPEdgeContext sets an edge request context created from the HTTP
 // headers set on the context onto the context.
-func InitializeHTTPEdgeContext(ctx context.Context, logger log.Wrapper) context.Context {
-	return InitializeEdgeContext(ctx, logger, FromHTTPContext)
+func InitializeHTTPEdgeContext(ctx context.Context, impl *Impl, logger log.Wrapper) context.Context {
+	return InitializeEdgeContext(ctx, impl, logger, FromHTTPContext)
 }
 
 // InjectHTTPEdgeContext returns a go-kit endpoint.Middleware that injects an
@@ -33,18 +33,18 @@ func InitializeHTTPEdgeContext(ctx context.Context, logger log.Wrapper) context.
 // Note, this depends on the edge context headers already being set on the
 // context object.  This can be done by adding httpbp.PopulateRequestContext as
 // a ServerBefore option when setting up the request handler for an endpoint.
-func InjectHTTPEdgeContext(logger log.Wrapper) endpoint.Middleware {
+func InjectHTTPEdgeContext(impl *Impl, logger log.Wrapper) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			return next(InitializeHTTPEdgeContext(ctx, logger), request)
+			return next(InitializeHTTPEdgeContext(ctx, impl, logger), request)
 		}
 	}
 }
 
 // InitializeThriftEdgeContext sets an edge request context created from the
 // Thrift headers set on the context onto the context.
-func InitializeThriftEdgeContext(ctx context.Context, logger log.Wrapper) context.Context {
-	return InitializeEdgeContext(ctx, logger, FromThriftContext)
+func InitializeThriftEdgeContext(ctx context.Context, impl *Impl, logger log.Wrapper) context.Context {
+	return InitializeEdgeContext(ctx, impl, logger, FromThriftContext)
 }
 
 // InjectThriftEdgeContext returns a go-kit endpoint.Middleware that injects an
@@ -54,10 +54,10 @@ func InitializeThriftEdgeContext(ctx context.Context, logger log.Wrapper) contex
 // Note, this depends on the edge context headers already being set on the
 // context object.  These should be automatically injected by your
 // thrift.TSimpleServer.
-func InjectThriftEdgeContext(logger log.Wrapper) endpoint.Middleware {
+func InjectThriftEdgeContext(impl *Impl, logger log.Wrapper) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			return next(InitializeThriftEdgeContext(ctx, logger), request)
+			return next(InitializeThriftEdgeContext(ctx, impl, logger), request)
 		}
 	}
 }

--- a/edgecontext/middlewares_test.go
+++ b/edgecontext/middlewares_test.go
@@ -32,6 +32,7 @@ func TestInitializeEdgeContext(t *testing.T) {
 
 	expected, err := edgecontext.New(
 		context.Background(),
+		globalTestImpl,
 		edgecontext.NewArgs{
 			LoID:          expectedLoID,
 			LoIDCreatedAt: expectedCookieTime,
@@ -86,7 +87,7 @@ func TestInitializeEdgeContext(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				ctx := edgecontext.InitializeEdgeContext(c.ctx, nil, c.factory)
+				ctx := edgecontext.InitializeEdgeContext(c.ctx, globalTestImpl, nil, c.factory)
 				ec, ok := edgecontext.GetEdgeContext(ctx)
 				if ok != c.ok {
 					t.Errorf("Ok does not match, expected %v got %v", c.ok, ok)
@@ -197,7 +198,7 @@ func TestInitializeHTTPEdgeContext(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				ctx := edgecontext.InitializeHTTPEdgeContext(c.ctx, nil)
+				ctx := edgecontext.InitializeHTTPEdgeContext(c.ctx, globalTestImpl, nil)
 				if _, ok := edgecontext.GetEdgeContext(ctx); ok != c.ok {
 					t.Errorf("Ok does not match, expected %v got %v", c.ok, ok)
 				}
@@ -235,7 +236,7 @@ func TestInitializeThriftEdgeContext(t *testing.T) {
 			func(t *testing.T) {
 				t.Parallel()
 
-				ctx := edgecontext.InitializeThriftEdgeContext(c.ctx, nil)
+				ctx := edgecontext.InitializeThriftEdgeContext(c.ctx, globalTestImpl, nil)
 				if _, ok := edgecontext.GetEdgeContext(ctx); ok != c.ok {
 					t.Errorf("Ok does not match, expected %v got %v", c.ok, ok)
 				}

--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -28,6 +28,8 @@ func HeaderTrustHandlerSigner(handler httpbp.TrustHeaderSignature, duration time
 
 // An EdgeRequestContext contains context info about an edge request.
 type EdgeRequestContext struct {
+	impl *Impl
+
 	// header and raw should always be set during initialization
 	header string
 	raw    NewArgs
@@ -43,7 +45,7 @@ type EdgeRequestContext struct {
 // If the validation failed, the error will be logged.
 func (e *EdgeRequestContext) AuthToken() *AuthenticationToken {
 	e.tokenOnce.Do(func() {
-		if token, err := ValidateToken(e.raw.AuthToken); err != nil {
+		if token, err := e.impl.ValidateToken(e.raw.AuthToken); err != nil {
 			log.Errorw("token validation failed", "err", err)
 			e.token = nil
 		} else {

--- a/edgecontext/req_context_test.go
+++ b/edgecontext/req_context_test.go
@@ -40,6 +40,7 @@ func TestAttachHTTPHeader(t *testing.T) {
 
 	e, err := edgecontext.New(
 		context.Background(),
+		globalTestImpl,
 		edgecontext.NewArgs{
 			LoID:          expectedLoID,
 			LoIDCreatedAt: expectedCookieTime,
@@ -63,7 +64,7 @@ func TestAttachHTTPHeader(t *testing.T) {
 				t.Fatal("Header was not attached.")
 			}
 			ctx := httpbp.SetHeader(context.Background(), httpbp.EdgeContextContextKey, h)
-			ec, err := edgecontext.FromHTTPContext(ctx)
+			ec, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -122,7 +123,7 @@ func TestAttachHTTPHeader(t *testing.T) {
 			}
 
 			ctx := httpbp.SetHeader(context.Background(), httpbp.EdgeContextContextKey, h)
-			ec, err := edgecontext.FromHTTPContext(ctx)
+			ec, err := edgecontext.FromHTTPContext(ctx, globalTestImpl)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/edgecontext/validator_test.go
+++ b/edgecontext/validator_test.go
@@ -2,15 +2,13 @@ package edgecontext_test
 
 import (
 	"testing"
-
-	"github.com/reddit/baseplate.go/edgecontext"
 )
 
 // copied from https://github.com/reddit/baseplate.py/blob/db9c1d7cddb1cb242546349e821cad0b0cbd6fce/tests/__init__.py#L55
 const validToken = `eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g`
 
 func TestValidToken(t *testing.T) {
-	token, err := edgecontext.ValidateToken(validToken)
+	token, err := globalTestImpl.ValidateToken(validToken)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes https://github.com/reddit/baseplate.go/issues/122.

Consider the common use case is initialize an implementation then
immediately pass that into the middleware and never worry about it
again, we no longer provide APIs for singleton usage.

This is a breaking change.