### PR TITLE
mqsend: Retry EINTR error

### DIFF
--- a/mqsend/BUILD.bazel
+++ b/mqsend/BUILD.bazel
@@ -27,8 +27,21 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "mqsend_linux_test.go",
         "mqsend_mock_test.go",
+        "mqsend_other_test.go",
         "mqsend_test.go",
     ],
     embed = [":go_default_library"],
+    deps = [
+        "//randbp:go_default_library",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/mqsend/errors.go
+++ b/mqsend/errors.go
@@ -8,8 +8,10 @@ import (
 // TimedOutError is the error returned by MessageQueue.Send when the operation
 // timed out because of the queue was full.
 //
-// On linux systems it wraps syscall.ETIMEDOUT, on other systems (or with
-// MockMessageQueue) it wraps context.DeadlineExceeded.
+// On linux systems it usually wraps one of syscall.ETIMEDOUT, context.Canceled,
+// or context.DeadlineExceeded.
+// On other systems (or with MockMessageQueue) it usually wraps either
+// context.Canceled or context.DeadlineExceeded.
 type TimedOutError struct {
 	Cause error
 }

--- a/mqsend/mqsend_linux_test.go
+++ b/mqsend/mqsend_linux_test.go
@@ -1,0 +1,29 @@
+// +build linux
+
+package mqsend_test
+
+import (
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func deleteMessageQueue(t *testing.T, name string) error {
+	nameBytes, err := unix.BytePtrFromString(name)
+	if err != nil {
+		return err
+	}
+	// From MQ_UNLiNK(3) manpage:
+	// int mq_unlink(const char *name);
+	_, _, errno := unix.Syscall(
+		unix.SYS_MQ_UNLINK,
+		uintptr(unsafe.Pointer(nameBytes)), // name
+		0,                                  // unused
+		0,                                  // unused
+	)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/mqsend/mqsend_other_test.go
+++ b/mqsend/mqsend_other_test.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package mqsend_test
+
+import (
+	"testing"
+)
+
+func deleteMessageQueue(t *testing.T, _ string) error {
+	t.Logf("WARNING: deleteMessageQueue is nop on non-linux systems")
+	return nil
+}

--- a/mqsend/mqsend_test.go
+++ b/mqsend/mqsend_test.go
@@ -72,8 +72,11 @@ func TestLinuxMessageQueue(t *testing.T) {
 			if !errors.As(err, new(mqsend.TimedOutError)) {
 				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
 			}
-			if !errors.Is(err, syscall.ETIMEDOUT) {
-				t.Errorf("Expected ETIMEDOUT when the queue is full, got %v", err)
+			if !errors.Is(err, syscall.ETIMEDOUT) && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf(
+					"Expected either ETIMEDOUT or context.DeadlineExceeded when the queue is full, got %v",
+					err,
+				)
 			}
 		},
 	)


### PR DESCRIPTION
Go 1.14 will make EINTR more likely to happen [1], so add retry logic to
make sure we are handling it correctly.

[1] https://golang.org/doc/go1.14#runtime