### PR TITLE
randbp: Use a global rander instead of side effect

### DIFF
--- a/mqsend/mqsend_test.go
+++ b/mqsend/mqsend_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"runtime"
 	"strings"
 	"syscall"
@@ -12,7 +11,7 @@ import (
 	"time"
 
 	"github.com/reddit/baseplate.go/mqsend"
-	_ "github.com/reddit/baseplate.go/randbp"
+	"github.com/reddit/baseplate.go/randbp"
 )
 
 func TestLinuxMessageQueue(t *testing.T) {
@@ -29,7 +28,7 @@ func TestLinuxMessageQueue(t *testing.T) {
 	const max = len(msg)
 	const timeout = time.Millisecond
 
-	name := fmt.Sprintf("test-mq-%d", rand.Uint64())
+	name := fmt.Sprintf("test-mq-%d", randbp.R.Uint64())
 
 	mq, err := mqsend.OpenMessageQueue(mqsend.MessageQueueConfig{
 		Name:           name,

--- a/randbp/BUILD.bazel
+++ b/randbp/BUILD.bazel
@@ -3,8 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "rand.go",
         "sample.go",
+        "seed.go",
+        "source.go",
         "string.go",
     ],
     importpath = "github.com/reddit/baseplate.go/randbp",
@@ -14,6 +17,9 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["sample_test.go"],
+    srcs = [
+        "rand_test.go",
+        "sample_test.go",
+    ],
     embed = [":go_default_library"],
 )

--- a/randbp/doc.go
+++ b/randbp/doc.go
@@ -1,0 +1,5 @@
+// Package randbp provides some random generator related features:
+//
+// 1. A thread-safe, properly seeded global *math/rand.Rand implementation.
+// 2. Helper functions for common use cases.
+package randbp

--- a/randbp/rand.go
+++ b/randbp/rand.go
@@ -1,22 +1,103 @@
-// Package randbp provides some random generator related features:
-//
-// 1. Proper seed the global math/rand generator.
-// 2. Helper functions for common use cases.
-//
-// For users using only 1 (e.g. you use the global math/rand generator for
-// things other than the helper functions provided by this package),
-// you should blank import this package in your main package, e.g.
-//
-//     import (
-//       _ "github.com/reddit/baseplate.go/randbp"
-//     )
 package randbp
 
 import (
 	"math/rand"
-	"time"
+	"sync"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
+var readerPool = sync.Pool{
+	New: func() interface{} {
+		return rand.New(rand.NewSource(1))
+	},
+}
+
+// R is a global thread-safe rng.
+//
+// It embeds *math/rand.Rand, but properly seeded and safe for concurrent use.
+//
+// It should be used instead of the global functions inside math/rand package.
+//
+// For example, instead of this:
+//
+//     import "math/rand"
+//     i := rand.Uint64()
+//
+// Use this:
+//
+//     import "github.com/reddit/baseplate.go/randbp"
+//     i := randbp.R.Uint64()
+//
+// NOTE: Its Read function has worse performance comparing to rand's global
+// rander or rand.Rand created with non-thread-safe source for small buffers.
+// See the doc of Rand.Read for more details.
+// All other functions (Uint64, Float64, etc.) have comparable performance to
+// math/rand's implementations.
+var R = New(GetSeed())
+
+// Rand embeds *math/rand.Rand.
+//
+// All functions besides Read are directly calling the embedded rand.Rand.
+// When initialized with New(), all functions are safe for concurrent use,
+// and have comparable performance to the top level math/rand functions.
+//
+// See the doc of Read function for more details on that one.
+type Rand struct {
+	*rand.Rand
+}
+
+// Read overrides math/rand's Read implementation with thread-safety.
+//
+// It's safe for concurrent use and always returns len(p) with nil error.
+//
+// Compare to math/rand.Read (the top level one) performance-wise,
+// it has a constant ~1us overhead,
+// which is significant when len(p) is small,
+// but less significant when len(p) grows larger,
+// and starts to outperform math/rand.Read when len(p) is very large because it
+// only need to lock once.
+// See the following sample benchmark result:
+//
+//     $ go test -bench Rand/Read -benchmem
+//     goos: darwin
+//     goarch: amd64
+//     pkg: github.com/reddit/baseplate.go/randbp
+//     BenchmarkRand/Read/size-16/math/rand-8         	 8213564	       138 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-16/crypto/rand-8       	 9739500	       123 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-16/randbp-8            	  979442	      1329 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-64/math/rand-8         	 5289319	       227 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-64/crypto/rand-8       	 6050103	       197 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-64/randbp-8            	  911760	      1301 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-256/math/rand-8        	 4223463	       274 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-256/crypto/rand-8      	 2263252	       534 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-256/randbp-8           	  940459	      1333 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-512/math/rand-8        	 2455426	       481 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-512/crypto/rand-8      	 1000000	      1008 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-512/randbp-8           	  885555	      1445 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1024/math/rand-8       	 1275535	       925 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1024/crypto/rand-8     	  636202	      1980 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1024/randbp-8          	  800511	      1630 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-4096/math/rand-8       	  310982	      3765 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-4096/crypto/rand-8     	  159490	      7538 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-4096/randbp-8          	  511124	      2319 ns/op	       0 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1048576/math/rand-8    	    1341	    860809 ns/op	    6255 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1048576/crypto/rand-8  	     838	   1349225 ns/op	   10016 B/op	       0 allocs/op
+//     BenchmarkRand/Read/size-1048576/randbp-8       	    5330	    238657 ns/op	    1582 B/op	       0 allocs/op
+//     PASS
+//     ok  	github.com/reddit/baseplate.go/randbp	29.982s
+//
+// Regardless performance, it's never suitable for security purpose,
+// and you should always use crypto/rand for that instead.
+func (r Rand) Read(p []byte) (int, error) {
+	reader := readerPool.Get().(*rand.Rand)
+	defer readerPool.Put(reader)
+
+	reader.Seed(int64(r.Uint64()))
+	return reader.Read(p)
+}
+
+// New initializes a thread-safe, properly seeded Rand.
+func New(seed int64) Rand {
+	return Rand{
+		Rand: rand.New(NewLockedSource64(rand.NewSource(seed))),
+	}
 }

--- a/randbp/rand_test.go
+++ b/randbp/rand_test.go
@@ -1,0 +1,398 @@
+package randbp_test
+
+import (
+	crand "crypto/rand"
+	"fmt"
+	"math"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+
+	"github.com/reddit/baseplate.go/randbp"
+)
+
+func swap(slice []byte) func(i, j int) {
+	return func(i, j int) {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+}
+
+func seedBoth() {
+	seed := randbp.GetSeed()
+	rand.Seed(seed)
+	randbp.R.Seed(seed)
+}
+
+func TestSameResult(t *testing.T) {
+	seedBoth()
+
+	const epsilon = 1e-9
+	equalFloat64 := func(a, b float64) bool {
+		return math.Abs(a-b) < epsilon
+	}
+
+	t.Run(
+		"Uint64",
+		func(t *testing.T) {
+			f := func() bool {
+				u64math := rand.Uint64()
+				u64bp := randbp.R.Uint64()
+				if u64math != u64bp {
+					t.Errorf(
+						"math/rand.Uint64() returned %d while randbp.R.Uint64() returned %d",
+						u64math,
+						u64bp,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+
+	t.Run(
+		"Float64",
+		func(t *testing.T) {
+			f := func() bool {
+				f64math := rand.Float64()
+				f64bp := randbp.R.Float64()
+				if !equalFloat64(f64math, f64bp) {
+					t.Errorf(
+						"math/rand.Float64() returned %v while randbp.R.Float64() returned %v",
+						f64math,
+						f64bp,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+
+	t.Run(
+		"NormFloat64",
+		func(t *testing.T) {
+			f := func() bool {
+				f64math := rand.NormFloat64()
+				f64bp := randbp.R.NormFloat64()
+				if !equalFloat64(f64math, f64bp) {
+					t.Errorf(
+						"math/rand.NormFloat64() returned %v while randbp.R.NormFloat64() returned %v",
+						f64math,
+						f64bp,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+
+	t.Run(
+		"ExpFloat64",
+		func(t *testing.T) {
+			f := func() bool {
+				f64math := rand.ExpFloat64()
+				f64bp := randbp.R.ExpFloat64()
+				if !equalFloat64(f64math, f64bp) {
+					t.Errorf(
+						"math/rand.ExpFloat64() returned %v while randbp.R.ExpFloat64() returned %v",
+						f64math,
+						f64bp,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+
+	t.Run(
+		"Shuffle",
+		func(t *testing.T) {
+			f := func(s string) bool {
+				mathSlice := make([]byte, len(s))
+				bpSlice := make([]byte, len(s))
+				copy(mathSlice, []byte(s))
+				copy(bpSlice, []byte(s))
+				rand.Shuffle(len(s), swap(mathSlice))
+				randbp.R.Shuffle(len(s), swap(bpSlice))
+				if !reflect.DeepEqual(mathSlice, bpSlice) {
+					t.Errorf(
+						"math/rand.Shuffle() returned %x while randbp.R.Shuffle() returned %x",
+						mathSlice,
+						bpSlice,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+
+	t.Run(
+		"Perm",
+		func(t *testing.T) {
+			f := func(smalln uint8) bool {
+				n := int(smalln)
+				mathSlice := rand.Perm(n)
+				bpSlice := randbp.R.Perm(n)
+				if !reflect.DeepEqual(mathSlice, bpSlice) {
+					t.Errorf(
+						"math/rand.Shuffle() returned %v while randbp.R.Shuffle() returned %v",
+						mathSlice,
+						bpSlice,
+					)
+				}
+				return !t.Failed()
+			}
+			if err := quick.Check(f, nil); err != nil {
+				t.Error(err)
+			}
+		},
+	)
+}
+
+func BenchmarkRand(b *testing.B) {
+	sizes := []int{16, 64, 256, 512, 1024, 4096, 1024 * 1024}
+	seedBoth()
+
+	b.Run(
+		"Read",
+		func(b *testing.B) {
+			for _, size := range sizes {
+				b.Run(
+					fmt.Sprintf("size-%d", size),
+					func(b *testing.B) {
+						b.Run(
+							"math/rand",
+							func(b *testing.B) {
+								b.RunParallel(func(pb *testing.PB) {
+									buf := make([]byte, size)
+									for pb.Next() {
+										rand.Read(buf)
+									}
+								})
+							},
+						)
+
+						b.Run(
+							"crypto/rand",
+							func(b *testing.B) {
+								b.RunParallel(func(pb *testing.PB) {
+									buf := make([]byte, size)
+									for pb.Next() {
+										if _, err := crand.Read(buf); err != nil {
+											b.Fatal(err)
+										}
+									}
+								})
+							},
+						)
+
+						b.Run(
+							"randbp",
+							func(b *testing.B) {
+								b.RunParallel(func(pb *testing.PB) {
+									buf := make([]byte, size)
+									for pb.Next() {
+										randbp.R.Read(buf)
+									}
+								})
+							},
+						)
+					},
+				)
+			}
+		},
+	)
+
+	b.Run(
+		"Uint64",
+		func(b *testing.B) {
+			b.Run(
+				"math/rand",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							rand.Uint64()
+						}
+					})
+				},
+			)
+
+			b.Run(
+				"randbp",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							randbp.R.Uint64()
+						}
+					})
+				},
+			)
+		},
+	)
+
+	b.Run(
+		"Float64",
+		func(b *testing.B) {
+			b.Run(
+				"math/rand",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							rand.Float64()
+						}
+					})
+				},
+			)
+
+			b.Run(
+				"randbp",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							randbp.R.Float64()
+						}
+					})
+				},
+			)
+		},
+	)
+
+	b.Run(
+		"NormFloat64",
+		func(b *testing.B) {
+			b.Run(
+				"math/rand",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							rand.NormFloat64()
+						}
+					})
+				},
+			)
+
+			b.Run(
+				"randbp",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							randbp.R.NormFloat64()
+						}
+					})
+				},
+			)
+		},
+	)
+
+	b.Run(
+		"ExpFloat64",
+		func(b *testing.B) {
+			b.Run(
+				"math/rand",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							rand.ExpFloat64()
+						}
+					})
+				},
+			)
+
+			b.Run(
+				"randbp",
+				func(b *testing.B) {
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							randbp.R.ExpFloat64()
+						}
+					})
+				},
+			)
+		},
+	)
+
+	b.Run(
+		"Shuffle",
+		func(b *testing.B) {
+			for _, size := range sizes {
+				b.Run(
+					fmt.Sprintf("size-%d", size),
+					func(b *testing.B) {
+						b.Run(
+							"math/rand",
+							func(b *testing.B) {
+								slice := make([]byte, size)
+								b.RunParallel(func(pb *testing.PB) {
+									for pb.Next() {
+										rand.Shuffle(size, swap(slice))
+									}
+								})
+							},
+						)
+
+						b.Run(
+							"randbp",
+							func(b *testing.B) {
+								slice := make([]byte, size)
+								b.RunParallel(func(pb *testing.PB) {
+									for pb.Next() {
+										randbp.R.Shuffle(size, swap(slice))
+									}
+								})
+							},
+						)
+					},
+				)
+			}
+		},
+	)
+
+	b.Run(
+		"Perm",
+		func(b *testing.B) {
+			for _, size := range sizes {
+				b.Run(
+					fmt.Sprintf("size-%d", size),
+					func(b *testing.B) {
+						b.Run(
+							"math/rand",
+							func(b *testing.B) {
+								b.RunParallel(func(pb *testing.PB) {
+									for pb.Next() {
+										rand.Perm(size)
+									}
+								})
+							},
+						)
+
+						b.Run(
+							"randbp",
+							func(b *testing.B) {
+								b.RunParallel(func(pb *testing.PB) {
+									for pb.Next() {
+										randbp.R.Perm(size)
+									}
+								})
+							},
+						)
+					},
+				)
+			}
+		},
+	)
+}

--- a/randbp/sample.go
+++ b/randbp/sample.go
@@ -1,9 +1,5 @@
 package randbp
 
-import (
-	"math/rand"
-)
-
 // ShouldSampleWithRate generates a random float64 in [0, 1) and check it
 // against rate.
 //
@@ -11,5 +7,5 @@ import (
 // When rate <= 0 this function always returns false;
 // When rate >= 1 this function always returns true.
 func ShouldSampleWithRate(rate float64) bool {
-	return rand.Float64() < rate
+	return R.Float64() < rate
 }

--- a/randbp/sample_test.go
+++ b/randbp/sample_test.go
@@ -12,7 +12,7 @@ func TestShouldSampleWithRate(t *testing.T) {
 		"0",
 		func(t *testing.T) {
 			if randbp.ShouldSampleWithRate(0) {
-				t.Error("rand.ShouldSplitWithProbability(0) returned true")
+				t.Error("randbp.ShouldSampleWithRate(0) returned true")
 			}
 
 			f := func() bool {
@@ -28,7 +28,7 @@ func TestShouldSampleWithRate(t *testing.T) {
 		"1",
 		func(t *testing.T) {
 			if !randbp.ShouldSampleWithRate(1) {
-				t.Error("rand.ShouldSplitWithProbability(1) returned false")
+				t.Error("randbp.ShouldSampleWithRate(1) returned false")
 			}
 
 			f := func() bool {

--- a/randbp/seed.go
+++ b/randbp/seed.go
@@ -1,0 +1,20 @@
+package randbp
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"time"
+)
+
+// GetSeed returns a seed for pseudo-random generator.
+//
+// It tries to use crypto/rand to read an int64,
+// and fallback to use current time if that fails for whatever reason.
+func GetSeed() int64 {
+	buf := make([]byte, 8)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return time.Now().UnixNano()
+	}
+	return int64(binary.BigEndian.Uint64(buf))
+}

--- a/randbp/source.go
+++ b/randbp/source.go
@@ -1,0 +1,74 @@
+package randbp
+
+import (
+	"math/rand"
+	"sync"
+)
+
+var _ rand.Source64 = (*LockedSource64)(nil)
+
+type source64 interface {
+	Uint64() uint64
+}
+
+// LockedSource64 is a thread-safe implementation of rand.Source64.
+//
+// NOTE: When using *LockedSource64 to create rand.Rand,
+// its Read function will have a much worse performance comparing to rand's
+// global rander or rand.Rand created with non-thread-safe source.
+type LockedSource64 struct {
+	src  rand.Source
+	s64  source64
+	lock sync.Mutex
+}
+
+// NewLockedSource64 creates a *LockedSource64 from the given src.
+func NewLockedSource64(src rand.Source) *LockedSource64 {
+	ls := &LockedSource64{
+		src: src,
+	}
+	ls.setS64()
+	return ls
+}
+
+func (ls *LockedSource64) setS64() {
+	s64, ok := ls.src.(source64)
+	if !ok {
+		// *rand.Rand also implements source64, and it calls Int63 twice to generate
+		// uint64 when the source isn't rand.Source64. Take advantage of that.
+		s64 = rand.New(ls.src)
+	}
+	ls.s64 = s64
+}
+
+// Int63 implements rand.Source64.
+//
+// It calls underlying source's Int63 with lock.
+func (ls *LockedSource64) Int63() (n int64) {
+	ls.lock.Lock()
+	n = ls.src.Int63()
+	ls.lock.Unlock()
+	return
+}
+
+// Uint64 implements rand.Source64.
+//
+// If the underlying source implements rand.Source64,
+// it calls its Uint64 with lock.
+// Otherwise, it calls its Int64 twice with lock.
+func (ls *LockedSource64) Uint64() (n uint64) {
+	ls.lock.Lock()
+	n = ls.s64.Uint64()
+	ls.lock.Unlock()
+	return
+}
+
+// Seed implements rand.Source64.
+//
+// It calls underlying source's Seed with lock.
+func (ls *LockedSource64) Seed(seed int64) {
+	ls.lock.Lock()
+	ls.src.Seed(seed)
+	ls.setS64()
+	ls.lock.Unlock()
+}

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -3,9 +3,9 @@ package tracing
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"time"
 
+	"github.com/reddit/baseplate.go/randbp"
 	"github.com/reddit/baseplate.go/timebp"
 )
 
@@ -49,8 +49,8 @@ func newTrace(tracer *Tracer, name string) *trace {
 		tracer: tracer,
 
 		name:    name,
-		traceID: rand.Uint64(),
-		spanID:  rand.Uint64(),
+		traceID: randbp.R.Uint64(),
+		spanID:  randbp.R.Uint64(),
 		start:   time.Now(),
 
 		counters: make(map[string]float64),

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -225,7 +224,7 @@ func (t *Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	if parent != nil {
 		parent.initChildSpan(span)
 	} else {
-		span.trace.traceID = rand.Uint64()
+		span.trace.traceID = randbp.R.Uint64()
 		span.trace.sampled = randbp.ShouldSampleWithRate(t.sampleRate)
 	}
 


### PR DESCRIPTION
Instead of relying on side effect to proper seed math/rand, use a global
rander randbp.R. This way it's more obvious to tell in code which are
properly seeded and which are not.