### PR TITLE
metricsbp: Rename MetricsLabels to Labels

### DIFF
--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "baseplate_hooks.go",
         "doc.go",
+        "labels.go",
         "nil_check.go",
         "sampled.go",
         "statsd.go",
@@ -30,6 +31,7 @@ go_test(
         "example_baseplate_hooks_test.go",
         "example_nil_check_test.go",
         "example_timer_test.go",
+        "labels_test.go",
         "nil_check_test.go",
         "sampled_test.go",
         "statsd_test.go",

--- a/metricsbp/labels.go
+++ b/metricsbp/labels.go
@@ -1,0 +1,21 @@
+package metricsbp
+
+// Labels allows you to specify labels as a convenient map and
+// provides helpers to convert them into other formats.
+type Labels map[string]string
+
+// AsStatsdLabels returns the labels in the format expected by the
+// statsd metrics client, that is a slice of strings.
+//
+// This method is nil-safe and will just return nil if the receiver is
+// nil.
+func (l Labels) AsStatsdLabels() []string {
+	if l == nil {
+		return nil
+	}
+	labels := make([]string, 0, len(l)*2)
+	for k, v := range l {
+		labels = append(labels, k, v)
+	}
+	return labels
+}

--- a/metricsbp/labels_test.go
+++ b/metricsbp/labels_test.go
@@ -1,0 +1,44 @@
+package metricsbp_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/reddit/baseplate.go/metricsbp"
+)
+
+func TestLabels(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		labels   metricsbp.Labels
+		expected []string
+	}{
+		{
+			name:     "nil",
+			labels:   nil,
+			expected: nil,
+		},
+		{
+			name:     "one",
+			labels:   metricsbp.Labels{"key": "value"},
+			expected: []string{"key", "value"},
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			asStatsd := c.labels.AsStatsdLabels()
+			if len(asStatsd) != len(c.labels)*2 {
+				t.Fatalf("wrong size: %#v", asStatsd)
+			}
+			if !reflect.DeepEqual(c.expected, asStatsd) {
+				t.Fatalf("labels do not match, expected %#v, got %#v", c.expected, asStatsd)
+			}
+		})
+	}
+}

--- a/metricsbp/statsd.go
+++ b/metricsbp/statsd.go
@@ -76,26 +76,6 @@ type Statsd struct {
 	histogramSampleRate float64
 }
 
-// MetricsLabels allows you to specify labels as a convenient map and
-// provides helpers to convert them into other formats.
-type MetricsLabels map[string]string
-
-// AsStatsdLabels returns the labels in the format expected by the
-// statsd metrics client, that is a slice of strings.
-//
-// This method is nil-safe and will just return nil if the receiver is
-// nil.
-func (l MetricsLabels) AsStatsdLabels() []string {
-	if l == nil {
-		return nil
-	}
-	labels := make([]string, 0, len(l)*2)
-	for k, v := range l {
-		labels = append(labels, k, v)
-	}
-	return labels
-}
-
 // StatsdConfig is the configs used in NewStatsd.
 type StatsdConfig struct {
 	// Prefix is the common metrics path prefix shared by all metrics managed by
@@ -133,7 +113,7 @@ type StatsdConfig struct {
 	// Labels are the labels/tags to be attached to every metrics created
 	// from this Statsd object. For labels/tags only needed by some metrics,
 	// use Counter/Gauge/Timing.With() instead.
-	Labels MetricsLabels
+	Labels Labels
 }
 
 func convertSampleRate(rate *float64) float64 {

--- a/metricsbp/statsd_test.go
+++ b/metricsbp/statsd_test.go
@@ -3,7 +3,6 @@ package metricsbp_test
 import (
 	"bytes"
 	"context"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -247,40 +246,4 @@ func BenchmarkStatsd(b *testing.B) {
 			)
 		},
 	)
-}
-
-func TestMetricsLabels(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name     string
-		labels   metricsbp.MetricsLabels
-		expected []string
-	}{
-		{
-			name:     "nil",
-			labels:   nil,
-			expected: nil,
-		},
-		{
-			name:     "one",
-			labels:   metricsbp.MetricsLabels{"key": "value"},
-			expected: []string{"key", "value"},
-		},
-	}
-
-	for _, _c := range cases {
-		c := _c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-
-			asStatsd := c.labels.AsStatsdLabels()
-			if len(asStatsd) != len(c.labels)*2 {
-				t.Fatalf("wrong size: %#v", asStatsd)
-			}
-			if !reflect.DeepEqual(c.expected, asStatsd) {
-				t.Fatalf("labels do not match, expected %#v, got %#v", c.expected, asStatsd)
-			}
-		})
-	}
 }

--- a/metricsbp/sys_stats.go
+++ b/metricsbp/sys_stats.go
@@ -24,7 +24,7 @@ func pullRuntimeStats() (cpu cpuStats, mem runtime.MemStats) {
 // RunSysStats starts a goroutine to periodically pull and report sys stats.
 //
 // Canceling the context passed into NewStatsd will stop this goroutine.
-func (st *Statsd) RunSysStats(labels MetricsLabels) {
+func (st *Statsd) RunSysStats(labels Labels) {
 	st = st.fallback()
 
 	l := labels.AsStatsdLabels()

--- a/thriftclient/client_pool.go
+++ b/thriftclient/client_pool.go
@@ -47,7 +47,7 @@ type ClientPoolConfig struct {
 
 	// Any labels that should be applied to metrics logged by the ClientPool.
 	// This includes the optional pool stats.
-	MetricsLabels metricsbp.MetricsLabels
+	MetricsLabels metricsbp.Labels
 
 	// ReportPoolStats signals to the ClientPool that it should report
 	// statistics on the underlying clientpool.Pool in a background


### PR DESCRIPTION
If the package name was metrics, then golint would warn us that the name
metrics.MetricsLabels is redundant. It didn't warn because we had -bp
suffix in the package name, but the same idea still applies.

This is a breaking change.