### PR TITLE
metricsbp: Add Statsd.Close API

### DIFF
--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//tracing:go_default_library",
         "@com_github_go_kit_kit//metrics:go_default_library",
         "@com_github_go_kit_kit//metrics/influxstatsd:go_default_library",
+        "@com_github_go_kit_kit//util/conn:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Provide a flushing API for jobs that don't run indefinitely to make sure
that their metrics are emitted before exit.