### PR TITLE
thriftclient: Define BaseplateDefaultMiddlewares

### DIFF
--- a/thriftclient/client_pool.go
+++ b/thriftclient/client_pool.go
@@ -125,10 +125,10 @@ type TClientFactory func(thrift.TTransport, thrift.TProtocolFactory) thrift.TCli
 //
 // A baseplate ClientPool:
 //		1. Uses a TTLClientPool with the given ttl.
-//		2. Wraps the TClient objects created in MonitorClient + middlewares such
-//		   that MonitorClient is the outermost middleware.
+//		2. Wraps the TClient objects with BaseplateDefaultMiddlewares plus any
+//		   additional middlewares passed into this function.
 func NewBaseplateClientPool(cfg ClientPoolConfig, ttl time.Duration, middlewares ...Middleware) (ClientPool, error) {
-	middlewares = append([]Middleware{MonitorClient}, middlewares...)
+	middlewares = append(BaseplateDefaultMiddlewares(), middlewares...)
 	return NewCustomClientPool(
 		cfg,
 		SingleAddressGenerator(cfg.Addr),

--- a/thriftclient/middlewares.go
+++ b/thriftclient/middlewares.go
@@ -9,6 +9,17 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
+// BaseplateDefaultMiddlewares returns the default middlewares should be used by
+// a baseplate service.
+//
+// Currently it's:
+// - MonitorClient
+func BaseplateDefaultMiddlewares() []Middleware {
+	return []Middleware{
+		MonitorClient,
+	}
+}
+
 // Middleware can be passed to Wrap in order to wrap thrift.TClient calls with
 // custom middleware.
 type Middleware func(thrift.TClient) thrift.TClient


### PR DESCRIPTION
This makes service code using customized client pool easier to add all
the middlewares recommended by baseplate.