### PR TITLE
httpbp: refactor v1

### DIFF
--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "example_handler_test.go",
         "fixtures_test.go",
         "handler_test.go",
         "headers_test.go",

--- a/httpbp/example_handler_test.go
+++ b/httpbp/example_handler_test.go
@@ -1,0 +1,75 @@
+package httpbp_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/log"
+)
+
+type body struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+}
+
+type errorResponse struct {
+	Reason  string `json:"reason"`
+	Message string `json:"message,omitempty"`
+}
+
+func home(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	response := httpbp.Response{
+		Body: body{
+			X: 1,
+			Y: 2,
+		},
+	}
+	return httpbp.WriteJSON(w, response)
+}
+
+func err(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	body := errorResponse{
+		Reason:  "BAD_REQUEST",
+		Message: "this endpoint always returns an error",
+	}
+	return httpbp.NewJSONError(http.StatusBadRequest, body, errors.New("example"))
+}
+
+func loggingMiddleware(next httpbp.HandlerFunc) httpbp.HandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+		log.Infof("Request: %#v", r)
+		return next(ctx, w, r)
+	}
+}
+
+var (
+	_ httpbp.HandlerFunc = home
+	_ httpbp.Middleware  = loggingMiddleware
+)
+
+func ExampleBaseplateHandlerFactory() {
+	var (
+		ecImpl       *edgecontext.Impl
+		logger       log.Wrapper
+		trustHandler httpbp.HeaderTrustHandler
+	)
+	handlerFactory := httpbp.BaseplateHandlerFactory{
+		// arg struct for http.DefaultMiddleware
+		Args: httpbp.DefaultMiddlewareArgs{
+			TrustHandler:    trustHandler,
+			EdgeContextImpl: ecImpl,
+			Logger:          logger,
+		},
+		// Middleware that will be applied to each endpoint created by this factory
+		Middlewares: []httpbp.Middleware{
+			loggingMiddleware,
+		},
+	}
+	handler := http.NewServeMux()
+	handler.Handle("/", handlerFactory.NewHandler("home", home))
+	handler.Handle("/err", handlerFactory.NewHandler("err", err))
+	log.Fatal(http.ListenAndServe(":8080", handler))
+}


### PR DESCRIPTION
This PR trims down the `httpbp` package to be less framework-y and more just a small shim around `net/http` to handle errors in a simple way and one that lets us report them to spans/etc as well as some helpers to simplify writing HTTP responses.