### PR TITLE
metricsbp: Make the timer test less flaky

### DIFF
--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -39,6 +39,9 @@ go_test(
         "timer_test.go",
     ],
     embed = [":go_default_library"],
+    # This test is marked as flaky as sometimes the running environment in drone
+    # is just too slow for the context switch in the sleep in TestTimer.
+    flaky = True,
     deps = [
         "//tracing:go_default_library",
         "@com_github_go_kit_kit//metrics:go_default_library",

--- a/metricsbp/timer_test.go
+++ b/metricsbp/timer_test.go
@@ -28,10 +28,10 @@ func (m *mockHistogram) Observe(v float64) {
 }
 
 func TestTimer(t *testing.T) {
-	const sleep = time.Millisecond
+	const sleep = time.Millisecond * 100
 	h := mockHistogram{
 		t:        t,
-		expected: 1,
+		expected: float64(sleep / time.Millisecond),
 	}
 	timer := metricsbp.NewTimer(&h)
 	time.Sleep(sleep)


### PR DESCRIPTION
Add sleep time to 100ms to make it less likely to fail, also mark the
test as flaky in Bazel.