### PR TITLE
thriftbp: Change the type of ServerConfig.Logger

### DIFF
--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -72,12 +72,15 @@ func ZapWrapper(level Level) Wrapper {
 // Note that this should not be used as the logger set into thrift.TSimpleServer,
 // as that would use the logger to log network I/O errors,
 // which would be too spammy to be sent to Sentry.
-func ErrorWithSentryWrapper(msg string) {
-	Error(msg)
-	sentry.CaptureMessage(msg)
+// For this reason, it's returning a Wrapper instead of being a Wrapper itself,
+// thus forcing an extra typecasting to be used as a thrift.Logger.
+func ErrorWithSentryWrapper() Wrapper {
+	return func(msg string) {
+		Error(msg)
+		sentry.CaptureMessage(msg)
+	}
 }
 
 var (
 	_ Wrapper = NopWrapper
-	_ Wrapper = ErrorWithSentryWrapper
 )

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -3,6 +3,8 @@ package thriftbp_test
 import (
 	"time"
 
+	"github.com/apache/thrift/lib/go/thrift"
+
 	"github.com/reddit/baseplate.go/edgecontext"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
@@ -23,7 +25,7 @@ func ExampleNewServer() {
 		thriftbp.ServerConfig{
 			Addr:    "localhost:8080",
 			Timeout: time.Second,
-			Logger:  logger,
+			Logger:  thrift.Logger(logger),
 		},
 		processor,
 		thriftbp.InjectServerSpan,

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-
-	"github.com/reddit/baseplate.go/log"
 )
 
 // ServerConfig is the arg struct for NewServer.
@@ -17,7 +15,12 @@ type ServerConfig struct {
 	Timeout time.Duration
 
 	// A log wrapper that is used by the TSimpleServer.
-	Logger log.Wrapper
+	//
+	// It's compatible with log.Wrapper (with an extra typecasting),
+	// but you should not use log.ErrorWithSentryWrapper for this one,
+	// as it would log all the network I/O errors,
+	// which would be too spammy for sentry.
+	Logger thrift.Logger
 }
 
 // NewServer returns a thrift.TSimpleServer using the THeader transport
@@ -40,6 +43,6 @@ func NewServer(
 		thrift.NewTHeaderProtocolFactory(),
 	)
 	server.SetForwardHeaders(HeadersToForward)
-	server.SetLogger(thrift.Logger(cfg.Logger))
+	server.SetLogger(cfg.Logger)
 	return server, nil
 }


### PR DESCRIPTION
Make it more explicit and obvious that logger is only used by
thrift.TSimpleServer, and should not be set to
log.ErrorWithSentryWrapper.