### PR TITLE
[httpbp]base64 encoding decoding edgecontext

### DIFF
--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -1,12 +1,14 @@
 package httpbp
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/reddit/baseplate.go/edgecontext"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/signing"
 )
@@ -66,10 +68,24 @@ type EdgeContextHeaders struct {
 
 // NewEdgeContextHeaders returns a new EdgeContextHeaders object from the given
 // HTTP headers.
+//
+// The edge context header using base64 encoding for http transport, so it needs decode first
 func NewEdgeContextHeaders(h http.Header) EdgeContextHeaders {
-	return EdgeContextHeaders{
-		EdgeRequest: h.Get(EdgeContextHeader),
+	ec, err := base64.StdEncoding.DecodeString(h.Get(EdgeContextHeader))
+	if err != nil {
+		ec = []byte("")
 	}
+	return EdgeContextHeaders{
+		EdgeRequest: string(ec),
+	}
+}
+
+// AttachEdgeContextHeaders attach EdgeRequestContext into request/response header
+//
+// The base64 encoding is only for http transport
+func AttachEdgeContextHeaders(ec *edgecontext.EdgeRequestContext, h http.Header) {
+	ecencoded := base64.StdEncoding.EncodeToString([]byte(ec.Header()))
+	h.Set(EdgeContextHeader, ecencoded)
 }
 
 // AsMap returns the EdgeContextHeaders as a map of header keys to header

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -75,7 +75,7 @@ func NewEdgeContextHeaders(h http.Header) (EdgeContextHeaders, error) {
 	return EdgeContextHeaders{EdgeRequest: string(ec)}, err
 }
 
-// SetEdgeContextHeader attach EdgeRequestContext into request/response header
+// SetEdgeContextHeader attach EdgeRequestContext into response header
 //
 // The base64 encoding is only for http transport
 func SetEdgeContextHeader(ec *edgecontext.EdgeRequestContext, w http.ResponseWriter) {

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -83,9 +83,9 @@ func NewEdgeContextHeaders(h http.Header) EdgeContextHeaders {
 // AttachEdgeContextHeaders attach EdgeRequestContext into request/response header
 //
 // The base64 encoding is only for http transport
-func AttachEdgeContextHeaders(ec *edgecontext.EdgeRequestContext, h http.Header) {
+func AttachEdgeContextHeaders(ec *edgecontext.EdgeRequestContext, w http.ResponseWriter) {
 	ecencoded := base64.StdEncoding.EncodeToString([]byte(ec.Header()))
-	h.Set(EdgeContextHeader, ecencoded)
+	w.Header().Set(EdgeContextHeader, ecencoded)
 }
 
 // AsMap returns the EdgeContextHeaders as a map of header keys to header

--- a/httpbp/headers_test.go
+++ b/httpbp/headers_test.go
@@ -1,6 +1,7 @@
 package httpbp_test
 
 import (
+	"encoding/base64"
 	"net/http"
 	"os"
 	"testing"
@@ -16,8 +17,10 @@ const (
 	spanID      = "90123"
 	flags       = "0"
 	sampled     = "1"
-	edgeContext = "edge-context"
+	edgeContext = "edge-context!?$*&()'-=@~"
 )
+
+var b64EdgeContext = base64.StdEncoding.EncodeToString([]byte(edgeContext))
 
 func getHeaders() http.Header {
 	headers := make(http.Header)
@@ -27,7 +30,7 @@ func getHeaders() http.Header {
 		httpbp.SpanIDHeader:      spanID,
 		httpbp.SpanFlagsHeader:   flags,
 		httpbp.SpanSampledHeader: sampled,
-		httpbp.EdgeContextHeader: edgeContext,
+		httpbp.EdgeContextHeader: b64EdgeContext,
 	} {
 		headers.Add(k, v)
 	}
@@ -183,6 +186,7 @@ func TestNewEdgeContextHeaders(t *testing.T) {
 		)
 	}
 }
+
 func TestAlwaysTrustHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/httpbp/headers_test.go
+++ b/httpbp/headers_test.go
@@ -289,6 +289,7 @@ func TestTrustHeaderSignatureSignAndVerify(t *testing.T) {
 		},
 	)
 }
+
 func TestInvalidEdgeContextHeader(t *testing.T) {
 	store, dir := newSecretsStore(t)
 	defer os.RemoveAll(dir)
@@ -312,6 +313,7 @@ func TestInvalidEdgeContextHeader(t *testing.T) {
 		t.Error("trust mismatch, expected False, got True")
 	}
 }
+
 func TestTrustHeaderSignature(t *testing.T) {
 	t.Parallel()
 

--- a/httpbp/headers_test.go
+++ b/httpbp/headers_test.go
@@ -132,7 +132,10 @@ func TestNewEdgeContextHeaders(t *testing.T) {
 	t.Parallel()
 
 	headers := getHeaders()
-	edgeContextHeaders := httpbp.NewEdgeContextHeaders(headers)
+	edgeContextHeaders, err := httpbp.NewEdgeContextHeaders(headers)
+	if err != nil {
+		t.Fatalf("Got an unexpected error while getting new edge context header: %v", err)
+	}
 
 	cases := []struct {
 		name     string
@@ -229,16 +232,20 @@ func TestTrustHeaderSignatureSignAndVerify(t *testing.T) {
 		func(t *testing.T) {
 			request := http.Request{Header: getHeaders()}
 			trustHandler := getTrustHeaderSignature(store)
+			ech, _ := httpbp.NewEdgeContextHeaders(request.Header)
 			signature, err := trustHandler.SignEdgeContextHeader(
-				httpbp.NewEdgeContextHeaders(request.Header),
+				ech,
 				time.Minute,
 			)
 			if err != nil {
 				t.Fatalf("Got an unexpected error while trying to sign headers: %v", err)
 			}
-
+			ech, err = httpbp.NewEdgeContextHeaders(request.Header)
+			if err != nil {
+				t.Errorf("Got an unexpected error while decoding the edge context: %w", err)
+			}
 			ok, err := trustHandler.VerifyEdgeContextHeader(
-				httpbp.NewEdgeContextHeaders(request.Header),
+				ech,
 				signature,
 			)
 			if err != nil {
@@ -282,7 +289,29 @@ func TestTrustHeaderSignatureSignAndVerify(t *testing.T) {
 		},
 	)
 }
+func TestInvalidEdgeContextHeader(t *testing.T) {
+	store, dir := newSecretsStore(t)
+	defer os.RemoveAll(dir)
+	defer store.Close()
 
+	invalidEdgeContextHeader := &http.Request{Header: getHeaders()}
+	invalidEdgeContextHeader.Header.Set(httpbp.EdgeContextHeader, "==")
+
+	truster := getTrustHeaderSignature(store)
+	_, err := httpbp.NewEdgeContextHeaders(invalidEdgeContextHeader.Header)
+	if err == nil {
+		t.Fatal("Not raising expected decoding error")
+	}
+	ecSignature, err := truster.SignEdgeContextHeader(
+		httpbp.EdgeContextHeaders{EdgeRequest: "=="},
+		time.Minute,
+	)
+	invalidEdgeContextHeader.Header.Set(httpbp.EdgeContextSignatureHeader, ecSignature)
+
+	if truster.TrustEdgeContext(invalidEdgeContextHeader) {
+		t.Error("trust mismatch, expected False, got True")
+	}
+}
 func TestTrustHeaderSignature(t *testing.T) {
 	t.Parallel()
 
@@ -293,8 +322,12 @@ func TestTrustHeaderSignature(t *testing.T) {
 	baseRequest := &http.Request{Header: getHeaders()}
 
 	truster := getTrustHeaderSignature(store)
+	ech, err := httpbp.NewEdgeContextHeaders(baseRequest.Header)
+	if err != nil {
+		t.Fatalf("Got an unexpected error while getting new edge context header: %v", err)
+	}
 	ecSignature, err := truster.SignEdgeContextHeader(
-		httpbp.NewEdgeContextHeaders(baseRequest.Header),
+		ech,
 		time.Minute,
 	)
 	if err != nil {


### PR DESCRIPTION
## Description
Since our current edgecontext header transfer is using base64encoded so we need to keep it consistent to attach to the header with base64 format
👓 @pacejackson @fishy 