### PR TITLE
signing: align interface with baseplate.py

### DIFF
--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -241,7 +241,7 @@ func (h TrustHeaderSignature) signHeaders(headers Headers, secretPath string, ex
 	}
 	return signing.Sign(signing.SignArgs{
 		Message:   headerMessage(headers),
-		Key:       secret.Current,
+		Secret:    secret,
 		ExpiresIn: expiresIn,
 	})
 }
@@ -256,7 +256,7 @@ func (h TrustHeaderSignature) verifyHeaders(headers Headers, signature string, s
 		return false, err
 	}
 
-	if err = signing.Verify(headerMessage(headers), signature, secret.GetAll()...); err != nil {
+	if err = signing.Verify(headerMessage(headers), signature, secret); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -81,6 +81,14 @@ func newSimpleSecret(secret *GenericSecret) (SimpleSecret, error) {
 	}, nil
 }
 
+// AsVersioned returns the SimpleSecret as a VersionedSecret.
+//
+// The Value of the SimpleSecret will be set as the Current value on the
+// VersionedSecret.
+func (s SimpleSecret) AsVersioned() VersionedSecret {
+	return VersionedSecret{Current: s.Value}
+}
+
 // VersionedSecret represent secrets like signing keys that can be rotated
 // gracefully.
 //

--- a/signing/doc_test.go
+++ b/signing/doc_test.go
@@ -23,12 +23,12 @@ func Example() {
 	// Sign
 	signature, _ := signing.Sign(signing.SignArgs{
 		Message:   []byte(msg),
-		Key:       secret.Current,
+		Secret:    secret,
 		ExpiresIn: time.Hour,
 	})
 
 	// Verify
-	err := signing.Verify([]byte(msg), signature, secret.GetAll()...)
+	err := signing.Verify([]byte(msg), signature, secret)
 	if err != nil {
 		metricsbp.M.Counter("invalid-signature").Add(1)
 		var e signing.VerifyError

--- a/signing/interface.go
+++ b/signing/interface.go
@@ -16,7 +16,8 @@ type SignArgs struct {
 	// The message to sign. Required.
 	Message []byte
 
-	// The secret used to sign the message. Required.
+	// The secret used to sign the message. Required.  The message will be signed
+	// using the Current secret.
 	Secret secrets.VersionedSecret
 
 	// Signature expiring time.

--- a/signing/interface.go
+++ b/signing/interface.go
@@ -17,7 +17,7 @@ type SignArgs struct {
 	Message []byte
 
 	// The secret used to sign the message. Required.
-	Key secrets.Secret
+	Secret secrets.VersionedSecret
 
 	// Signature expiring time.
 	//
@@ -40,11 +40,8 @@ type Interface interface {
 	// signature should be urlsafe base64 encoded signature, instead of the raw
 	// one.
 	//
-	// keys should contain at least one non-empty secret.
-	// multiple keys will be tried in the order they are passed in.
-	//
 	// If this function returns an error, it will be in the type of VerifyError.
-	Verify(message []byte, signature string, keys ...secrets.Secret) error
+	Verify(message []byte, signature string, secret secrets.VersionedSecret) error
 }
 
 // VerifyError is the error type returned by Version.Verify.

--- a/signing/v1_quick_test.go
+++ b/signing/v1_quick_test.go
@@ -39,9 +39,10 @@ var (
 
 func TestV1Quick(t *testing.T) {
 	f := func(msg, key randomByteSlice, expiresIn randomDuration) bool {
+		secret := secrets.VersionedSecret{Current: secrets.Secret(key)}
 		args := signing.SignArgs{
 			Message:   []byte(msg),
-			Key:       secrets.Secret(key),
+			Secret:    secret,
 			ExpiresIn: time.Duration(expiresIn),
 		}
 		signature, err := signing.V1.Sign(args)
@@ -49,7 +50,7 @@ func TestV1Quick(t *testing.T) {
 			t.Error(err)
 			return false
 		}
-		err = signing.V1.Verify([]byte(msg), signature, secrets.Secret(key))
+		err = signing.V1.Verify([]byte(msg), signature, secret)
 		if err != nil {
 			t.Error(err)
 			return false

--- a/signing/v1_test.go
+++ b/signing/v1_test.go
@@ -127,8 +127,8 @@ func TestV1(t *testing.T) {
 					"key-rotation",
 					func(t *testing.T) {
 						rotating := secrets.VersionedSecret{
-							Current: invalidSecret.Current,
-							Next:    secret.Current,
+							Current:  invalidSecret.Current,
+							Previous: secret.Current,
 						}
 						err := verify(msg, validSig, rotating)
 						if err != nil {

--- a/signing/v1_test.go
+++ b/signing/v1_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/reddit/baseplate.go/secrets"
 )
 
-type verifyFunc func(message []byte, signature string, keys ...secrets.Secret) error
+type verifyFunc func(message []byte, signature string, secret secrets.VersionedSecret) error
 
 func TestV1(t *testing.T) {
 	var e VerifyError
 
 	msg := []byte("Hello, world!")
-	key := secrets.Secret("hunter2")
-	invalidKey := secrets.Secret("hunter0")
+	secret := secrets.VersionedSecret{Current: secrets.Secret("hunter2")}
+	invalidSecret := secrets.VersionedSecret{Current: secrets.Secret("hunter0")}
 	expiration := time.Now().Add(time.Hour * 24)
 
 	var validSig string
@@ -26,7 +26,7 @@ func TestV1(t *testing.T) {
 		func(t *testing.T) {
 			sig, err := V1.Sign(SignArgs{
 				Message:   msg,
-				Key:       key,
+				Secret:    secret,
 				ExpiresAt: expiration,
 			})
 			if err != nil {
@@ -47,7 +47,7 @@ func TestV1(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = v1Verify(msg, rawSig, []secrets.Secret{key}, expiration.Add(time.Second))
+			err = v1Verify(msg, rawSig, secret.GetAll(), expiration.Add(time.Second))
 			if !errors.As(err, &e) {
 				t.Errorf("Expected VerifyError, got %v", err)
 			}
@@ -74,7 +74,7 @@ func TestV1(t *testing.T) {
 							func(t *testing.T) {
 								// This signature should still be base64 decodable.
 								sig := validSig[:V1SignatureLength-4]
-								err := verify(msg, sig, key)
+								err := verify(msg, sig, secret)
 								if !errors.As(err, &e) {
 									t.Errorf("Expected VerifyError, got %v", err)
 								}
@@ -86,7 +86,7 @@ func TestV1(t *testing.T) {
 							func(t *testing.T) {
 								// This signature should still be base64 decodable.
 								sig := validSig + "===="
-								err := verify(msg, sig, key)
+								err := verify(msg, sig, secret)
 								if !errors.As(err, &e) {
 									t.Errorf("Expected VerifyError, got %v", err)
 								}
@@ -100,7 +100,7 @@ func TestV1(t *testing.T) {
 					func(t *testing.T) {
 						// Replace the last character of validSig to "/"
 						sig := validSig[:V1SignatureLength-1] + "/"
-						err := verify(msg, sig, key)
+						err := verify(msg, sig, secret)
 						if !errors.As(err, &e) {
 							t.Errorf("Expected VerifyError, got %v", err)
 						}
@@ -113,7 +113,7 @@ func TestV1(t *testing.T) {
 				t.Run(
 					"mismatch",
 					func(t *testing.T) {
-						err := verify(msg, validSig, invalidKey)
+						err := verify(msg, validSig, invalidSecret)
 						if !errors.As(err, &e) {
 							t.Errorf("Expected VerifyError, got %v", err)
 						}
@@ -126,7 +126,11 @@ func TestV1(t *testing.T) {
 				t.Run(
 					"key-rotation",
 					func(t *testing.T) {
-						err := verify(msg, validSig, invalidKey, key)
+						rotating := secrets.VersionedSecret{
+							Current: invalidSecret.Current,
+							Next:    secret.Current,
+						}
+						err := verify(msg, validSig, rotating)
 						if err != nil {
 							t.Errorf("Expected nil error, got %v", err)
 						}
@@ -143,7 +147,7 @@ func TestV1(t *testing.T) {
 						// Change the version byte.
 						rawSig[0] = 2
 						sig := base64.URLEncoding.EncodeToString(rawSig)
-						err = verify(msg, sig, invalidKey)
+						err = verify(msg, sig, invalidSecret)
 						if !errors.As(err, &e) {
 							t.Errorf("Expected VerifyError, got %v", err)
 						}
@@ -159,7 +163,7 @@ func TestV1(t *testing.T) {
 
 func BenchmarkV1(b *testing.B) {
 	msg := []byte("Hello, world!")
-	key := secrets.Secret("hunter2")
+	secret := secrets.VersionedSecret{Current: secrets.Secret("hunter2")}
 	expiration := time.Now().Add(time.Hour * 24)
 
 	var sig string
@@ -171,7 +175,7 @@ func BenchmarkV1(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				sig, err = V1.Sign(SignArgs{
 					Message:   msg,
-					Key:       key,
+					Secret:    secret,
 					ExpiresAt: expiration,
 				})
 				if err != nil {
@@ -185,7 +189,7 @@ func BenchmarkV1(b *testing.B) {
 		"verify",
 		func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				err = V1.Verify(msg, sig, key)
+				err = V1.Verify(msg, sig, secret)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -193,17 +197,17 @@ func BenchmarkV1(b *testing.B) {
 		},
 	)
 
-	keys := []secrets.Secret{
-		secrets.Secret("hunter0"),
-		secrets.Secret("hunter1"),
-		secrets.Secret("hunter2"),
+	rotated := secrets.VersionedSecret{
+		Current:  secrets.Secret("hunter0"),
+		Previous: secrets.Secret("hunter1"),
+		Next:     secrets.Secret("hunter2"),
 	}
 
 	b.Run(
 		"verify-3keys",
 		func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				err = V1.Verify(msg, sig, keys...)
+				err = V1.Verify(msg, sig, rotated)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/signing/versions.go
+++ b/signing/versions.go
@@ -29,11 +29,8 @@ var versions = map[Version]internalVerifyFunc{
 // signature should be urlsafe base64 encoded signature, instead of the raw
 // one.
 //
-// keys should contain at least one non-empty secret.
-// multiple keys will be tried in the order they are passed in.
-//
 // If this function returns an error, it will be in the type of VerifyError.
-func Verify(message []byte, signature string, keys ...secrets.Secret) error {
+func Verify(message []byte, signature string, secret secrets.VersionedSecret) error {
 	buf, err := base64.URLEncoding.DecodeString(signature)
 	if err != nil {
 		return VerifyError{
@@ -51,5 +48,5 @@ func Verify(message []byte, signature string, keys ...secrets.Secret) error {
 		}
 	}
 
-	return verify(message, buf, keys, time.Now())
+	return verify(message, buf, secret.GetAll(), time.Now())
 }


### PR DESCRIPTION
* Require that the caller pass in a VersionedSecret for both Sign and Verify operations.
* Add a helper method to SimpleSecret to easily get a VersionedSecret.
* Update baseplate to account for this breaking change.