### PR TITLE
experiments: Add starting point in package doc

### DIFF
--- a/experiments/doc.go
+++ b/experiments/doc.go
@@ -1,3 +1,5 @@
 // Package experiments provides implementation of experiments config parsing
 // and other experiments related features according to baseplate spec.
+//
+// For a starting point, see Experiments type and NewExperiments function,
 package experiments


### PR DESCRIPTION
This package contains a lot of types and it could be confusing for
users to figure out where to start.