### PR TITLE
Make httpbp.Response a little nicer to use

### DIFF
--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -29,13 +29,7 @@ type Handlers struct {
 }
 
 func (h Handlers) Home(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	response := httpbp.Response{
-		Body: body{
-			X: 1,
-			Y: 2,
-		},
-	}
-	return httpbp.WriteJSON(w, response)
+	return httpbp.WriteJSON(w, httpbp.NewResponse(body{X: 1, Y: 2}))
 }
 
 func (h Handlers) ServerErr(ctx context.Context, w http.ResponseWriter, r *http.Request) error {

--- a/httpbp/response.go
+++ b/httpbp/response.go
@@ -40,6 +40,12 @@ type ContentWriter interface {
 	WriteBody(w io.Writer, v interface{}) error
 }
 
+// NewResponse returns a new Response with the given body and default status
+// code.
+func NewResponse(body interface{}) Response {
+	return Response{Body: body}
+}
+
 // Response is the non-header content to be written in an HTTP response.
 type Response struct {
 	// Body is the response body to write using a ContentWriter.  You should
@@ -50,6 +56,22 @@ type Response struct {
 	// Code is the status code to set on the response, this is optional and only
 	// should be set if you want to return something other than http.StatusOK (200).
 	Code int
+}
+
+// WithCode can be used to set the Code on a Response in a way that can be
+// chained in a call to one of the Write methods.
+//
+// Ex:
+//	httpbp.WriteRawContent(
+//		w,
+//		httpbp.NewResponse(nil).WithCode(http.StatusAccepted),
+//		httpbp.PlainTextContentType,
+//	)
+//
+// This is provided as syntactic sugar and is not required to set Code.
+func (r Response) WithCode(code int) Response {
+	r.Code = code
+	return r
 }
 
 // WriteResponse writes the given Response to the given ResponseWriter using the

--- a/httpbp/response.go
+++ b/httpbp/response.go
@@ -166,6 +166,8 @@ func RawContentWriter(contentType string) ContentWriter {
 				r = strings.NewReader(b)
 			case []byte:
 				r = bytes.NewReader(b)
+			case nil:
+				r = strings.NewReader("")
 			}
 			_, err := io.Copy(w, r)
 			return err

--- a/httpbp/response_test.go
+++ b/httpbp/response_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -250,5 +251,19 @@ func TestRawContentWriterFactory(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+func TestResponseWithCode(t *testing.T) {
+	t.Parallel()
+
+	r := httpbp.NewResponse("test")
+	if r.Code != 0 {
+		t.Errorf("wrong code, expected %d, got %d", 0, r.Code)
+	}
+
+	r = r.WithCode(http.StatusAccepted)
+	if r.Code != http.StatusAccepted {
+		t.Errorf("wrong code, expected %d, got %d", http.StatusAccepted, r.Code)
 	}
 }

--- a/httpbp/response_test.go
+++ b/httpbp/response_test.go
@@ -220,6 +220,11 @@ func TestRawContentWriterFactory(t *testing.T) {
 			expected: expectation{body: content},
 		},
 		{
+			name:     "nil",
+			body:     nil,
+			expected: expectation{body: ""},
+		},
+		{
 			name:     "wrong-type",
 			body:     1,
 			expected: expectation{err: true},


### PR DESCRIPTION
Adds 2 new functions/methods to make using httpbp.Response a little
nicer:

* NewResponse is a nicer way to make a new response for the typical
  case where you are not setting a status code.
* Response.WithCode uses the same builder pattern as we used in the
  errors code to add some syntactic sugare to make it nicer to set
  a custom status code on your Responses.

Note, this also has a small update where you can also now use a `nil` body with the Raw content writer and it will just use an empty string as the body.