### PR TITLE
redisbp: add config.go

### DIFF
--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//edgecontext:go_default_library",
         "//log:go_default_library",
         "//mqsend:go_default_library",
+        "//redisbp:go_default_library",
         "//secrets:go_default_library",
         "//tracing:go_default_library",
     ],

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -9,13 +9,12 @@ import (
 	baseplate "github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/redisbp"
 	"github.com/reddit/baseplate.go/secrets"
 )
 
 type config struct {
-	Redis struct {
-		Addrs []string `yaml:"addrs"`
-	} `yaml:"redis"`
+	Redis redisbp.ClusterConfig `yaml:"redis"`
 }
 
 type body struct {

--- a/redisbp/BUILD.bazel
+++ b/redisbp/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "config.go",
         "doc.go",
         "hooks.go",
         "monitored_client.go",
@@ -21,6 +22,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "config_test.go",
         "example_hooks_test.go",
         "example_monitored_client_test.go",
         "hooks_test.go",
@@ -34,5 +36,6 @@ go_test(
         "@com_github_alicebob_miniredis//:go_default_library",
         "@com_github_go_redis_redis_v7//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/redisbp/BUILD.bazel
+++ b/redisbp/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     size = "small",
     srcs = [
         "config_test.go",
+        "example_config_test.go",
         "example_hooks_test.go",
         "example_monitored_client_test.go",
         "hooks_test.go",
@@ -30,6 +31,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//:go_default_library",
         "//mqsend:go_default_library",
         "//thriftbp:go_default_library",
         "//tracing:go_default_library",

--- a/redisbp/config.go
+++ b/redisbp/config.go
@@ -76,47 +76,47 @@ func (cfg ClusterConfig) Options() *redis.ClusterOptions {
 // Can be deserialized from YAML.
 type PoolOptions struct {
 	// Maps to PoolSize on the redis-go options.
-	Size *int `yaml:"size"`
+	Size int `yaml:"size"`
 
 	// Maps to MinIdleConnections on the redis-go options.
-	MinIdleConnections *int `yaml:"minIdleConnetions"`
+	MinIdleConnections int `yaml:"minIdleConnections"`
 
 	// Maps to MaxConnAge on the redis-go options.
-	MaxConnectionAge *time.Duration `yaml:"maxConnectionAge"`
+	MaxConnectionAge time.Duration `yaml:"maxConnectionAge"`
 
 	// Maps to PoolTimeout on the redis-go options.
-	Timeout *time.Duration `yaml:"timeout"`
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 // ApplyOptions applies the PoolOptions to the redis.Options.
 func (opts PoolOptions) ApplyOptions(options *redis.Options) {
-	if opts.MinIdleConnections != nil {
-		options.MinIdleConns = *opts.MinIdleConnections
+	if opts.MinIdleConnections != 0 {
+		options.MinIdleConns = opts.MinIdleConnections
 	}
-	if opts.MaxConnectionAge != nil {
-		options.MaxConnAge = *opts.MaxConnectionAge
+	if opts.MaxConnectionAge != 0 {
+		options.MaxConnAge = opts.MaxConnectionAge
 	}
-	if opts.Size != nil {
-		options.PoolSize = *opts.Size
+	if opts.Size != 0 {
+		options.PoolSize = opts.Size
 	}
-	if opts.Timeout != nil {
-		options.PoolTimeout = *opts.Timeout
+	if opts.Timeout != 0 {
+		options.PoolTimeout = opts.Timeout
 	}
 }
 
 // ApplyClusterOptions applies the PoolOptions to the redis.ClusterOptions.
 func (opts PoolOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
-	if opts.MinIdleConnections != nil {
-		options.MinIdleConns = *opts.MinIdleConnections
+	if opts.MinIdleConnections != 0 {
+		options.MinIdleConns = opts.MinIdleConnections
 	}
-	if opts.MaxConnectionAge != nil {
-		options.MaxConnAge = *opts.MaxConnectionAge
+	if opts.MaxConnectionAge != 0 {
+		options.MaxConnAge = opts.MaxConnectionAge
 	}
-	if opts.Size != nil {
-		options.PoolSize = *opts.Size
+	if opts.Size != 0 {
+		options.PoolSize = opts.Size
 	}
-	if opts.Timeout != nil {
-		options.PoolTimeout = *opts.Timeout
+	if opts.Timeout != 0 {
+		options.PoolTimeout = opts.Timeout
 	}
 }
 
@@ -129,40 +129,40 @@ func (opts PoolOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
 // Can be deserialized from YAML.
 type RetryOptions struct {
 	// Maps to MaxRetries on the redis-go options.
-	Max *int `yaml:"max"`
+	Max int `yaml:"max"`
 
 	Backoff struct {
 		// Maps to MinRetryBackoff on the redis-go options.
-		Min *time.Duration `yaml:"min"`
+		Min time.Duration `yaml:"min"`
 
 		// Maps to MaxRetryBackoff on the redis-go options.
-		Max *time.Duration `yaml:"max"`
+		Max time.Duration `yaml:"max"`
 	} `yaml:"backoff"`
 }
 
 // ApplyOptions applies the RetryOptions to the redis.Options.
 func (opts RetryOptions) ApplyOptions(options *redis.Options) {
-	if opts.Max != nil {
-		options.MaxRetries = *opts.Max
+	if opts.Max != 0 {
+		options.MaxRetries = opts.Max
 	}
-	if opts.Backoff.Min != nil {
-		options.MinRetryBackoff = *opts.Backoff.Min
+	if opts.Backoff.Min != 0 {
+		options.MinRetryBackoff = opts.Backoff.Min
 	}
-	if opts.Backoff.Max != nil {
-		options.MaxRetryBackoff = *opts.Backoff.Max
+	if opts.Backoff.Max != 0 {
+		options.MaxRetryBackoff = opts.Backoff.Max
 	}
 }
 
 // ApplyClusterOptions applies the RetryOptions to the redis.ClusterOptions.
 func (opts RetryOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
-	if opts.Max != nil {
-		options.MaxRetries = *opts.Max
+	if opts.Max != 0 {
+		options.MaxRetries = opts.Max
 	}
-	if opts.Backoff.Min != nil {
-		options.MinRetryBackoff = *opts.Backoff.Min
+	if opts.Backoff.Min != 0 {
+		options.MinRetryBackoff = opts.Backoff.Min
 	}
-	if opts.Backoff.Max != nil {
-		options.MaxRetryBackoff = *opts.Backoff.Max
+	if opts.Backoff.Max != 0 {
+		options.MaxRetryBackoff = opts.Backoff.Max
 	}
 }
 
@@ -174,33 +174,33 @@ func (opts RetryOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
 //
 // Can be deserialized from YAML.
 type TimeoutOptions struct {
-	Dial  *time.Duration `yaml:"dial"`
-	Read  *time.Duration `yaml:"read"`
-	Write *time.Duration `yaml:"write"`
+	Dial  time.Duration `yaml:"dial"`
+	Read  time.Duration `yaml:"read"`
+	Write time.Duration `yaml:"write"`
 }
 
 // ApplyOptions applies the TimeoutOptions to the redis.Options.
 func (opts TimeoutOptions) ApplyOptions(options *redis.Options) {
-	if opts.Dial != nil {
-		options.DialTimeout = *opts.Dial
+	if opts.Dial != 0 {
+		options.DialTimeout = opts.Dial
 	}
-	if opts.Read != nil {
-		options.ReadTimeout = *opts.Read
+	if opts.Read != 0 {
+		options.ReadTimeout = opts.Read
 	}
-	if opts.Write != nil {
-		options.WriteTimeout = *opts.Write
+	if opts.Write != 0 {
+		options.WriteTimeout = opts.Write
 	}
 }
 
 // ApplyClusterOptions applies the TimeoutOptions to the redis.ClusterOptions.
 func (opts TimeoutOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
-	if opts.Dial != nil {
-		options.DialTimeout = *opts.Dial
+	if opts.Dial != 0 {
+		options.DialTimeout = opts.Dial
 	}
-	if opts.Read != nil {
-		options.ReadTimeout = *opts.Read
+	if opts.Read != 0 {
+		options.ReadTimeout = opts.Read
 	}
-	if opts.Write != nil {
-		options.WriteTimeout = *opts.Write
+	if opts.Write != 0 {
+		options.WriteTimeout = opts.Write
 	}
 }

--- a/redisbp/config.go
+++ b/redisbp/config.go
@@ -1,0 +1,206 @@
+package redisbp
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v7"
+)
+
+// ClientConfig can be used to configure a redis-go "Client".  See the docs for
+// redis.Options in redis-go for details on what each value means and what its
+// defaults are:
+// https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options
+//
+// Can be deserialized from YAML.
+type ClientConfig struct {
+	// URL is passed to redis.ParseURL to initialize the client options.
+	//
+	// https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#ParseURL
+	URL string `yaml:"url"`
+
+	Pool     PoolOptions    `yaml:"pool"`
+	Retries  RetryOptions   `yaml:"retries"`
+	Timeouts TimeoutOptions `yaml:"timeouts"`
+}
+
+// Options returns a redis.Options populated using the values from cfg.
+func (cfg ClientConfig) Options() (*redis.Options, error) {
+	options, err := redis.ParseURL(cfg.URL)
+	if err != nil {
+		return nil, fmt.Errorf("redisbp: error parsing configured redis url. %w", err)
+	}
+
+	cfg.Pool.ApplyOptions(options)
+	cfg.Retries.ApplyOptions(options)
+	cfg.Timeouts.ApplyOptions(options)
+	return options, nil
+}
+
+// ClusterConfig can be used to configure a redis-go "ClusterClient".  See the
+// docs for redis.ClusterOptions in redis-go for details on what each value
+// means and what its defaults are:
+// https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#ClusterOptions
+//
+// Can be deserialized from YAML.
+type ClusterConfig struct {
+	// Addrs is the seed list of cluster nodes in the format "host:port".
+	//
+	// Maps to Addrs on redis.ClusterClient.
+	Addrs []string `yaml:"addrs"`
+
+	Pool     PoolOptions    `yaml:"pool"`
+	Retries  RetryOptions   `yaml:"retries"`
+	Timeouts TimeoutOptions `yaml:"timeouts"`
+}
+
+// Options returns a redis.ClusterOptions populated using the values from cfg.
+func (cfg ClusterConfig) Options() *redis.ClusterOptions {
+	options := &redis.ClusterOptions{
+		Addrs: cfg.Addrs,
+	}
+
+	cfg.Pool.ApplyClusterOptions(options)
+	cfg.Retries.ApplyClusterOptions(options)
+	cfg.Timeouts.ApplyClusterOptions(options)
+	return options
+}
+
+// PoolOptions is used to configure the pool attributes of a redis-go Client or
+// ClusterClient.  If any value is not set, it will use whatever default is
+// defined by redis-go.
+//
+// See https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options for details
+// on the specific fields.
+//
+// Can be deserialized from YAML.
+type PoolOptions struct {
+	// Maps to PoolSize on the redis-go options.
+	Size *int `yaml:"size"`
+
+	// Maps to MinIdleConnections on the redis-go options.
+	MinIdleConnections *int `yaml:"minIdleConnetions"`
+
+	// Maps to MaxConnAge on the redis-go options.
+	MaxConnectionAge *time.Duration `yaml:"maxConnectionAge"`
+
+	// Maps to PoolTimeout on the redis-go options.
+	Timeout *time.Duration `yaml:"timeout"`
+}
+
+// ApplyOptions applies the PoolOptions to the redis.Options.
+func (opts PoolOptions) ApplyOptions(options *redis.Options) {
+	if opts.MinIdleConnections != nil {
+		options.MinIdleConns = *opts.MinIdleConnections
+	}
+	if opts.MaxConnectionAge != nil {
+		options.MaxConnAge = *opts.MaxConnectionAge
+	}
+	if opts.Size != nil {
+		options.PoolSize = *opts.Size
+	}
+	if opts.Timeout != nil {
+		options.PoolTimeout = *opts.Timeout
+	}
+}
+
+// ApplyClusterOptions applies the PoolOptions to the redis.ClusterOptions.
+func (opts PoolOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
+	if opts.MinIdleConnections != nil {
+		options.MinIdleConns = *opts.MinIdleConnections
+	}
+	if opts.MaxConnectionAge != nil {
+		options.MaxConnAge = *opts.MaxConnectionAge
+	}
+	if opts.Size != nil {
+		options.PoolSize = *opts.Size
+	}
+	if opts.Timeout != nil {
+		options.PoolTimeout = *opts.Timeout
+	}
+}
+
+// RetryOptions is used to configure the retry behavior of a redis-go Client or
+// ClusterClient.
+//
+// See https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options for details
+// on the specific fields.
+//
+// Can be deserialized from YAML.
+type RetryOptions struct {
+	// Maps to MaxRetries on the redis-go options.
+	Max *int `yaml:"max"`
+
+	Backoff struct {
+		// Maps to MinRetryBackoff on the redis-go options.
+		Min *time.Duration `yaml:"min"`
+
+		// Maps to MaxRetryBackoff on the redis-go options.
+		Max *time.Duration `yaml:"max"`
+	} `yaml:"backoff"`
+}
+
+// ApplyOptions applies the RetryOptions to the redis.Options.
+func (opts RetryOptions) ApplyOptions(options *redis.Options) {
+	if opts.Max != nil {
+		options.MaxRetries = *opts.Max
+	}
+	if opts.Backoff.Min != nil {
+		options.MinRetryBackoff = *opts.Backoff.Min
+	}
+	if opts.Backoff.Max != nil {
+		options.MaxRetryBackoff = *opts.Backoff.Max
+	}
+}
+
+// ApplyClusterOptions applies the RetryOptions to the redis.ClusterOptions.
+func (opts RetryOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
+	if opts.Max != nil {
+		options.MaxRetries = *opts.Max
+	}
+	if opts.Backoff.Min != nil {
+		options.MinRetryBackoff = *opts.Backoff.Min
+	}
+	if opts.Backoff.Max != nil {
+		options.MaxRetryBackoff = *opts.Backoff.Max
+	}
+}
+
+// TimeoutOptions is used to configure the timeout behavior of a redis-go Client
+// or ClusterClient.
+//
+// See https://pkg.go.dev/github.com/go-redis/redis/v7?tab=doc#Options for details
+// on the specific fields.
+//
+// Can be deserialized from YAML.
+type TimeoutOptions struct {
+	Dial  *time.Duration `yaml:"dial"`
+	Read  *time.Duration `yaml:"read"`
+	Write *time.Duration `yaml:"write"`
+}
+
+// ApplyOptions applies the TimeoutOptions to the redis.Options.
+func (opts TimeoutOptions) ApplyOptions(options *redis.Options) {
+	if opts.Dial != nil {
+		options.DialTimeout = *opts.Dial
+	}
+	if opts.Read != nil {
+		options.ReadTimeout = *opts.Read
+	}
+	if opts.Write != nil {
+		options.WriteTimeout = *opts.Write
+	}
+}
+
+// ApplyClusterOptions applies the TimeoutOptions to the redis.ClusterOptions.
+func (opts TimeoutOptions) ApplyClusterOptions(options *redis.ClusterOptions) {
+	if opts.Dial != nil {
+		options.DialTimeout = *opts.Dial
+	}
+	if opts.Read != nil {
+		options.ReadTimeout = *opts.Read
+	}
+	if opts.Write != nil {
+		options.WriteTimeout = *opts.Write
+	}
+}

--- a/redisbp/config_test.go
+++ b/redisbp/config_test.go
@@ -4,15 +4,12 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-redis/redis/v7"
 	"github.com/reddit/baseplate.go/redisbp"
 	"gopkg.in/yaml.v2"
 )
-
-type clientConfig struct {
-	Redis redisbp.ClientConfig
-}
 
 func TestClientConfig(t *testing.T) {
 	t.Parallel()
@@ -26,8 +23,7 @@ func TestClientConfig(t *testing.T) {
 		{
 			name: "url-only",
 			raw: `
-redis:
- url: redis://localhost:6379
+url: redis://localhost:6379
 `,
 			expected: redisbp.ClientConfig{
 				URL: "redis://localhost:6379",
@@ -37,6 +33,70 @@ redis:
 				Addr:    "localhost:6379",
 			},
 		},
+		{
+			name: "all",
+			raw: `
+url: redis://localhost:6379
+pool:
+ size: 10
+ minIdleConnections: 5
+ maxConnectionAge: 1m
+ timeout: 10s
+retries:
+ max: 2
+ backoff:
+  min: 1ms
+  max: 10ms
+timeouts:
+ dial: 1s
+ read: 100ms
+ write: 200ms
+`,
+			expected: redisbp.ClientConfig{
+				URL: "redis://localhost:6379",
+
+				Pool: redisbp.PoolOptions{
+					Size:               10,
+					MinIdleConnections: 5,
+					MaxConnectionAge:   time.Minute,
+					Timeout:            time.Second * 10,
+				},
+
+				Retries: redisbp.RetryOptions{
+					Max: 2,
+					Backoff: struct {
+						Min time.Duration `yaml:"min"`
+						Max time.Duration `yaml:"max"`
+					}{
+						Min: time.Millisecond,
+						Max: time.Millisecond * 10,
+					},
+				},
+
+				Timeouts: redisbp.TimeoutOptions{
+					Dial:  time.Second,
+					Read:  time.Millisecond * 100,
+					Write: time.Millisecond * 200,
+				},
+			},
+			options: &redis.Options{
+				Network: "tcp",
+				Addr:    "localhost:6379",
+
+				MinIdleConns: 5,
+				MaxConnAge:   time.Minute,
+				PoolSize:     10,
+				PoolTimeout:  time.Second * 10,
+
+				MaxRetries:      2,
+				MinRetryBackoff: time.Millisecond,
+				MaxRetryBackoff: time.Millisecond * 10,
+
+				DialTimeout:  time.Second,
+				ReadTimeout:  time.Millisecond * 100,
+				WriteTimeout: time.Millisecond * 200,
+			},
+		},
 	}
 
 	for _, _c := range cases {
@@ -44,20 +104,132 @@ redis:
 		t.Run(
 			c.name,
 			func(t *testing.T) {
-				var cfg clientConfig
+				var cfg redisbp.ClientConfig
 				if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
 					t.Fatal(err)
 				}
-				if !reflect.DeepEqual(c.expected, cfg.Redis) {
-					t.Errorf("client config mismatch, expected %#v, got %#v", c.expected, cfg.Redis)
+				if !reflect.DeepEqual(c.expected, cfg) {
+					t.Errorf("client config mismatch:\n\nexpected %#v\n\ngot %#v\n\n", c.expected, cfg)
 				}
 
-				options, err := cfg.Redis.Options()
+				options, err := cfg.Options()
 				if err != nil {
 					t.Fatal(err)
 				}
 				if !reflect.DeepEqual(c.options, options) {
-					t.Errorf("client config mismatch, expected %#v, got %#v", c.options, options)
+					t.Errorf("redis.Options mismatch\n\nexpected %#v\n\ngot %#v\n\n", c.options, options)
+				}
+			},
+		)
+	}
+}
+
+func TestClusterClientConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		raw      string
+		expected redisbp.ClusterConfig
+		options  *redis.ClusterOptions
+	}{
+		{
+			name: "url-only",
+			raw: `
+addrs:
+ - localhost:6379
+ - localhost:6380
+`,
+			expected: redisbp.ClusterConfig{
+				Addrs: []string{"localhost:6379", "localhost:6380"},
+			},
+			options: &redis.ClusterOptions{
+				Addrs: []string{"localhost:6379", "localhost:6380"},
+			},
+		},
+		{
+			name: "all",
+			raw: `
+addrs:
+ - localhost:6379
+ - localhost:6380
+pool:
+ size: 10
+ minIdleConnections: 5
+ maxConnectionAge: 1m
+ timeout: 10s
+retries:
+ max: 2
+ backoff:
+  min: 1ms
+  max: 10ms
+timeouts:
+ dial: 1s
+ read: 100ms
+ write: 200ms
+`,
+			expected: redisbp.ClusterConfig{
+				Addrs: []string{"localhost:6379", "localhost:6380"},
+
+				Pool: redisbp.PoolOptions{
+					Size:               10,
+					MinIdleConnections: 5,
+					MaxConnectionAge:   time.Minute,
+					Timeout:            time.Second * 10,
+				},
+
+				Retries: redisbp.RetryOptions{
+					Max: 2,
+					Backoff: struct {
+						Min time.Duration `yaml:"min"`
+						Max time.Duration `yaml:"max"`
+					}{
+						Min: time.Millisecond,
+						Max: time.Millisecond * 10,
+					},
+				},
+
+				Timeouts: redisbp.TimeoutOptions{
+					Dial:  time.Second,
+					Read:  time.Millisecond * 100,
+					Write: time.Millisecond * 200,
+				},
+			},
+			options: &redis.ClusterOptions{
+				Addrs: []string{"localhost:6379", "localhost:6380"},
+
+				MinIdleConns: 5,
+				MaxConnAge:   time.Minute,
+				PoolSize:     10,
+				PoolTimeout:  time.Second * 10,
+
+				MaxRetries:      2,
+				MinRetryBackoff: time.Millisecond,
+				MaxRetryBackoff: time.Millisecond * 10,
+
+				DialTimeout:  time.Second,
+				ReadTimeout:  time.Millisecond * 100,
+				WriteTimeout: time.Millisecond * 200,
+			},
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				var cfg redisbp.ClusterConfig
+				if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(c.expected, cfg) {
+					t.Errorf("client config mismatch:\n\nexpected %#v\n\ngot %#v\n\n", c.expected, cfg)
+				}
+
+				options := cfg.Options()
+				if !reflect.DeepEqual(c.options, options) {
+					t.Errorf("redis.Options mismatch\n\nexpected %#v\n\ngot %#v\n\n", c.options, options)
 				}
 			},
 		)

--- a/redisbp/config_test.go
+++ b/redisbp/config_test.go
@@ -1,0 +1,65 @@
+package redisbp_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/reddit/baseplate.go/redisbp"
+	"gopkg.in/yaml.v2"
+)
+
+type clientConfig struct {
+	Redis redisbp.ClientConfig
+}
+
+func TestClientConfig(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		raw      string
+		expected redisbp.ClientConfig
+		options  *redis.Options
+	}{
+		{
+			name: "url-only",
+			raw: `
+redis:
+ url: redis://localhost:6379
+`,
+			expected: redisbp.ClientConfig{
+				URL: "redis://localhost:6379",
+			},
+			options: &redis.Options{
+				Network: "tcp",
+				Addr:    "localhost:6379",
+			},
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				var cfg clientConfig
+				if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(c.expected, cfg.Redis) {
+					t.Errorf("client config mismatch, expected %#v, got %#v", c.expected, cfg.Redis)
+				}
+
+				options, err := cfg.Redis.Options()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(c.options, options) {
+					t.Errorf("client config mismatch, expected %#v, got %#v", c.options, options)
+				}
+			},
+		)
+	}
+}

--- a/redisbp/config_test.go
+++ b/redisbp/config_test.go
@@ -44,9 +44,8 @@ pool:
  timeout: 10s
 retries:
  max: 2
- backoff:
-  min: 1ms
-  max: 10ms
+ minBackoff: 1ms
+ maxBackoff: 10ms
 timeouts:
  dial: 1s
  read: 100ms
@@ -63,14 +62,9 @@ timeouts:
 				},
 
 				Retries: redisbp.RetryOptions{
-					Max: 2,
-					Backoff: struct {
-						Min time.Duration `yaml:"min"`
-						Max time.Duration `yaml:"max"`
-					}{
-						Min: time.Millisecond,
-						Max: time.Millisecond * 10,
-					},
+					Max:        2,
+					MinBackoff: time.Millisecond,
+					MaxBackoff: time.Millisecond * 10,
 				},
 
 				Timeouts: redisbp.TimeoutOptions{
@@ -160,9 +154,8 @@ pool:
  timeout: 10s
 retries:
  max: 2
- backoff:
-  min: 1ms
-  max: 10ms
+ minBackoff: 1ms
+ maxBackoff: 10ms
 timeouts:
  dial: 1s
  read: 100ms
@@ -179,14 +172,9 @@ timeouts:
 				},
 
 				Retries: redisbp.RetryOptions{
-					Max: 2,
-					Backoff: struct {
-						Min time.Duration `yaml:"min"`
-						Max time.Duration `yaml:"max"`
-					}{
-						Min: time.Millisecond,
-						Max: time.Millisecond * 10,
-					},
+					Max:        2,
+					MinBackoff: time.Millisecond,
+					MaxBackoff: time.Millisecond * 10,
 				},
 
 				Timeouts: redisbp.TimeoutOptions{

--- a/redisbp/example_config_test.go
+++ b/redisbp/example_config_test.go
@@ -1,0 +1,31 @@
+package redisbp_test
+
+import (
+	"context"
+
+	"github.com/go-redis/redis/v7"
+	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/redisbp"
+)
+
+type config struct {
+	Redis redisbp.ClientConfig `yaml:"redis"`
+}
+
+// This example shows how you can embed a redis config in a struct and parse
+// that with `baseplate.New`.
+func ExampleClientConfig() {
+	var cfg config
+	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
+	if err != nil {
+		panic(err)
+	}
+	defer bp.Close()
+
+	factory := redisbp.NewMonitoredClientFactory(
+		"redis",
+		redis.NewClient(redisbp.OptionsMust(cfg.Redis.Options())),
+	)
+	client := factory.BuildClient(ctx)
+	client.Ping()
+}


### PR DESCRIPTION
This allows us to parse redis client configurations from a YAML file and get the `Options`/`ClusterOptions` objects that you use to create the actual redis clients.