### PR TITLE
Update shuffle_version to int instead of string

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -111,7 +111,7 @@ func (e *Experiments) experiment(name string) (*SimpleExperiment, error) {
 // variants.
 type Experiment struct {
 	ExperimentVersion int                          `json:"experiment_version"`
-	ShuffleVersion    string                       `json:"shuffle_version"`
+	ShuffleVersion    int                          `json:"shuffle_version"`
 	BucketVal         string                       `json:"bucket_val"`
 	Variants          []Variant                    `json:"variants"`
 	BucketSeed        string                       `json:"bucket_seed"`
@@ -193,10 +193,6 @@ type SimpleExperiment struct {
 // NewSimpleExperiment returns a new instance of SimpleExperiment. Default
 // values if not otherwise provided by the ExperimentConfig will be assumed.
 func NewSimpleExperiment(experiment *ExperimentConfig) (*SimpleExperiment, error) {
-	shuffleVersion := experiment.Experiment.ShuffleVersion
-	if shuffleVersion == "" {
-		shuffleVersion = "None"
-	}
 	bucketVal := experiment.Experiment.BucketVal
 	if bucketVal == "" {
 		bucketVal = "user_id"
@@ -207,7 +203,7 @@ func NewSimpleExperiment(experiment *ExperimentConfig) (*SimpleExperiment, error
 	}
 	bucketSeed := experiment.Experiment.BucketSeed
 	if experiment.Experiment.BucketSeed == "" {
-		bucketSeed = fmt.Sprintf("%d.%s.%s", experiment.ID, experiment.Name, shuffleVersion)
+		bucketSeed = fmt.Sprintf("%d.%s.%d", experiment.ID, experiment.Name, experiment.Experiment.ShuffleVersion)
 	}
 	variantSet, err := FromExperimentType(experiment.Type, experiment.Experiment.Variants, 0)
 	if err != nil {

--- a/experiments/experiments_test.go
+++ b/experiments/experiments_test.go
@@ -43,7 +43,7 @@ func TestCalculateBucketValue(t *testing.T) {
 		config         *ExperimentConfig
 		id             string
 		name           string
-		shuffleVersion string
+		shuffleVersion int
 		expectedBucket int
 	}{
 		{
@@ -51,7 +51,7 @@ func TestCalculateBucketValue(t *testing.T) {
 				ID:   1,
 				Name: "test_experiment",
 				Experiment: Experiment{
-					ShuffleVersion: "",
+					ShuffleVersion: 0,
 					BucketSeed:     "some new seed",
 					Variants: []Variant{
 						{
@@ -307,7 +307,7 @@ func TestExperimentDisabled(t *testing.T) {
 func TestChangeShuffleVersionChangesBucketing(t *testing.T) {
 	shuffleConfig := *simpleConfig
 	shuffleConfig.Experiment.BucketSeed = ""
-	shuffleConfig.Experiment.ShuffleVersion = "2"
+	shuffleConfig.Experiment.ShuffleVersion = 2
 
 	experiment1, err := NewSimpleExperiment(simpleConfig)
 	if err != nil {


### PR DESCRIPTION
The `shuffle_version` in experiment json is actually `int`, instead of `string`.

Saw error when parsing experiments:
```
"err":"json: cannot unmarshal number into Go struct field Experiment.experiment.shuffle_version of type string"
```