### PR TITLE
metricsbp: Add total counter to span hooks

### DIFF
--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -9,6 +9,7 @@ import (
 const (
 	success = "success"
 	fail    = "fail"
+	total   = "total"
 )
 
 // CreateServerSpanHook registers each Server Span with a MetricsSpanHook.
@@ -69,6 +70,7 @@ func (h spanHook) OnPreStop(span *tracing.Span, err error) error {
 		statusMetricPath = fmt.Sprintf("%s.%s", h.name, success)
 	}
 	h.metrics.Counter(statusMetricPath).Add(1)
+	h.metrics.Counter(fmt.Sprintf("%s.%s", h.name, total)).Add(1)
 	return nil
 }
 

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -3,6 +3,7 @@ package metricsbp_test
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounter string, histogram string, err error) {
+func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, statusCounters []string, histogram string, err error) {
 	ctx, span := tracing.StartSpanFromHeaders(context.Background(), "foo", tracing.Headers{})
 	time.Sleep(time.Millisecond)
 	span.AddCounter("bar.count", 1.0)
@@ -23,8 +24,8 @@ func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounte
 		return
 	}
 	stats := strings.Split(sb.String(), "\n")
-	if len(stats) != 4 {
-		err = fmt.Errorf("Expected 3 stats, got %d\n%v", len(stats)-1, stats)
+	if len(stats) != 5 {
+		err = fmt.Errorf("Expected 4 stats, got %d\n%v", len(stats)-1, stats)
 		return
 	}
 
@@ -32,7 +33,7 @@ func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, successCounte
 		if strings.HasSuffix(stat, "|c") && strings.Contains(stat, "bar") {
 			counter = stat
 		} else if strings.HasSuffix(stat, "|c") {
-			successCounter = stat
+			statusCounters = append(statusCounters, stat)
 		} else if strings.HasSuffix(stat, "|ms") {
 			histogram = stat
 		}
@@ -58,7 +59,7 @@ func TestOnCreateServerSpan(t *testing.T) {
 	t.Run(
 		"success",
 		func(t *testing.T) {
-			counter, statusCounter, histogram, err := runSpan(st, nil)
+			counter, statusCounters, histogram, err := runSpan(st, nil)
 			if err != nil {
 				t.Fatalf("Got error: %s", err)
 			}
@@ -68,9 +69,21 @@ func TestOnCreateServerSpan(t *testing.T) {
 				t.Errorf("Expected counter: %s\nGot: %s", expected, counter)
 			}
 
-			expected = "server.foo.success:1.000000|c"
-			if statusCounter != expected {
-				t.Errorf("Expected status counter: %s\nGot: %s", expected, statusCounter)
+			expected1 := []string{
+				"server.foo.success:1.000000|c",
+				"server.foo.total:1.000000|c",
+			}
+			expected2 := []string{
+				"server.foo.total:1.000000|c",
+				"server.foo.success:1.000000|c",
+			}
+			if !reflect.DeepEqual(statusCounters, expected1) && !reflect.DeepEqual(statusCounters, expected2) {
+				t.Errorf(
+					"Expected status counters: %+v or %+v, got: %+v",
+					expected1,
+					expected2,
+					statusCounters,
+				)
 			}
 
 			if !histogramRegex.MatchString(histogram) {
@@ -82,7 +95,7 @@ func TestOnCreateServerSpan(t *testing.T) {
 	t.Run(
 		"fail",
 		func(t *testing.T) {
-			counter, statusCounter, histogram, err := runSpan(st, fmt.Errorf("test error"))
+			counter, statusCounters, histogram, err := runSpan(st, fmt.Errorf("test error"))
 			if err != nil {
 				t.Fatalf("Got error: %s", err)
 			}
@@ -92,9 +105,21 @@ func TestOnCreateServerSpan(t *testing.T) {
 				t.Errorf("Expected counter: %s\nGot: %s", expected, counter)
 			}
 
-			expected = "server.foo.fail:1.000000|c"
-			if statusCounter != expected {
-				t.Errorf("Expected status counter: %s\nGot: %s", expected, statusCounter)
+			expected1 := []string{
+				"server.foo.fail:1.000000|c",
+				"server.foo.total:1.000000|c",
+			}
+			expected2 := []string{
+				"server.foo.total:1.000000|c",
+				"server.foo.fail:1.000000|c",
+			}
+			if !reflect.DeepEqual(statusCounters, expected1) && !reflect.DeepEqual(statusCounters, expected2) {
+				t.Errorf(
+					"Expected status counters: %+v or %+v, got: %+v",
+					expected1,
+					expected2,
+					statusCounters,
+				)
 			}
 
 			if !histogramRegex.MatchString(histogram) {


### PR DESCRIPTION
We only need 2 of fail, success, and total. Before this change we use
fail and success, and eventually I think we would want to use fail and
total instead, but keep success for now for backward compatibility.

The reason success and total won't work is that there's no way to
guarantee that the success and total counter gets reported atomically,
so it would lead to situations that success reported a slightly higher
rate than total, which screws up the rate calculating. Although
theoretically this is also an issue with fail+total (or fail+success),
they are much more tolerable than success+total.