### PR TITLE
Return context from baseplate.New

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -98,10 +98,6 @@ func Serve(ctx context.Context, server Server) error {
 	go runtimebp.HandleShutdown(
 		ctx,
 		func(signal os.Signal) {
-			// Initialize a context to potentially control the length of time we wait
-			// for the server to close.
-			ctx := context.Background()
-
 			// Check if the server has a StopTimeout configured.
 			//
 			// If one is set, we will only wait for that duration for the server to

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -77,8 +77,7 @@ var (
 // Baseplate HTTP service.
 func ExampleNewBaseplateServer() {
 	var cfg config
-	ctx := context.Background()
-	bp, err := baseplate.New(ctx, "example.yaml", &cfg)
+	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
 	if err != nil {
 		panic(err)
 	}

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -12,8 +12,7 @@ import (
 // This example demonstrates what a typical main function should look like for a
 // Baseplate thrift service.
 func ExampleNewBaseplateServer() {
-	ctx := context.Background()
-	bp, err := baseplate.New(ctx, "example.yaml", nil)
+	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", nil)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This is actually 2 changes around the `Context` within a Baseplate.

1. Use the context passed into `baseplate.Serve` as the base for the one used to control the timeout of stopping a service.  This will allow that step to be cancelled if the top level context is cancelled, which it currently is not.
2. Return the `Context` created in `baseplate.New`.  The intention here is that is the context that a service will use as its top level "Serve" context (and is also set up to be cancelled when the Baseplate is closed for you).  