### PR TITLE
baseplate: default StopTimeout to 30 seconds

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -33,7 +33,7 @@ type Config struct {
 
 	// StopTimeout is the timeout for the Stop command for the service.
 	//
-	// If this is not set, then a default value of 30 seconds will be used.
+	// If this is not set, then a default value of 10 seconds will be used.
 	// If this is less than 0, then no timeout will be set on the Stop command.
 	StopTimeout time.Duration `yaml:"stopTimeout"`
 
@@ -105,9 +105,9 @@ func Serve(ctx context.Context, server Server) error {
 			// stop gracefully and will exit after the deadline is exceeded.
 			timeout := server.Baseplate().Config().StopTimeout
 
-			// Default to 30 seconds if not set.
+			// Default to 10 seconds if not set.
 			if timeout == 0 {
-				timeout = time.Second * 30
+				timeout = time.Second * 10
 			}
 
 			// If timeout is < 0, we will wait indefinetly for the server to close.

--- a/baseplate.go
+++ b/baseplate.go
@@ -33,7 +33,7 @@ type Config struct {
 
 	// StopTimeout is the timeout for the Stop command for the service.
 	//
-	// If this is not set, then a default value of 10 seconds will be used.
+	// If this is not set, then a default value of 30 seconds will be used.
 	// If this is less than 0, then no timeout will be set on the Stop command.
 	StopTimeout time.Duration `yaml:"stopTimeout"`
 
@@ -105,9 +105,9 @@ func Serve(ctx context.Context, server Server) error {
 			// stop gracefully and will exit after the deadline is exceeded.
 			timeout := server.Baseplate().Config().StopTimeout
 
-			// Default to 10 seconds if not set.
+			// Default to 30 seconds if not set.
 			if timeout == 0 {
-				timeout = time.Second * 10
+				timeout = time.Second * 30
 			}
 
 			// If timeout is < 0, we will wait indefinetly for the server to close.

--- a/baseplate.go
+++ b/baseplate.go
@@ -33,7 +33,8 @@ type Config struct {
 
 	// StopTimeout is the timeout for the Stop command for the service.
 	//
-	// If this is not set, then no timeout will be set on the Stop command.
+	// If this is not set, then a default value of 30 seconds will be used.
+	// If this is less than 0, then no timeout will be set on the Stop command.
 	StopTimeout time.Duration `yaml:"stopTimeout"`
 
 	Log     log.Config       `yaml:"log"`
@@ -102,8 +103,14 @@ func Serve(ctx context.Context, server Server) error {
 			//
 			// If one is set, we will only wait for that duration for the server to
 			// stop gracefully and will exit after the deadline is exceeded.
-			// If one is not set, we will wait indefinetly for the server to stop.
 			timeout := server.Baseplate().Config().StopTimeout
+
+			// Default to 30 seconds if not set.
+			if timeout == 0 {
+				timeout = time.Second * 30
+			}
+
+			// If timeout is < 0, we will wait indefinetly for the server to close.
 			if timeout > 0 {
 				// Declare cancel in advance so we can just use `=` when calling
 				// context.WithTimeout.  If we used `:=` it would bind `ctx` to the scope


### PR DESCRIPTION
You can still use negative numbers to indicate that you should wait indefinitely, but we don't want that to be the "default".