### PR TITLE
Implement TClient with ClientPool

### DIFF
--- a/clientpool/interface.go
+++ b/clientpool/interface.go
@@ -9,8 +9,6 @@ import (
 // TTransport interface in thrift satisfies Client interface,
 // so embedding the TTransport used by the actual client is a common way to
 // implement the ClientOpener for thrift Clients.
-// thriftclient.TTLClient also implements it, with an additional TTL to
-// the transport.
 type Client interface {
 	io.Closer
 

--- a/thriftbp/example_client_test.go
+++ b/thriftbp/example_client_test.go
@@ -24,10 +24,13 @@ func ExampleMonitorClient() {
 	// Create an actual service client
 	client := baseplate.NewBaseplateServiceClient(
 		// Use MonitoredClient to wrap a standard thrift client
-		thriftbp.NewWrappedTClientFactory(
-			thriftbp.StandardTClientFactory,
+		thrift.WrapClient(
+			thrift.NewTStandardClient(
+				factory.GetProtocol(transport),
+				factory.GetProtocol(transport),
+			),
 			thriftbp.MonitorClient,
-		)(transport, factory),
+		),
 	)
 	// Create a context with a server span
 	_, ctx := opentracing.StartSpanFromContext(

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -1,10 +1,8 @@
-package thriftbp_test
+package thriftbp
 
 import (
 	"testing"
 	"time"
-
-	"github.com/reddit/baseplate.go/thriftbp"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )
@@ -18,7 +16,7 @@ func TestTTLClient(t *testing.T) {
 	)
 	ttl := time.Millisecond
 
-	client := thriftbp.NewTTLClient(trans, tc, ttl)
+	client := newTTLClient(trans, tc, ttl)
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}


### PR DESCRIPTION
The big change in this PR is updating `thriftbp.ClientPool` to implement `TClient`.  It pulls a client from it's pool to make the actual `Call` and releases is after the call finishes.  This allows you to pass a `ClientPool` in to a thrift client as the `TClient` and avoid the boilerplate of getting a client from a pool and releasing it before each call.

This PR also allows us to trim down the exported interface in `thriftbp`.

1. Don't export `ttlClient`.
2. Update `ttlClient` to allow you to keep a client in a pool indefinetly and configure it using the `ClientPoolConfig`.
3. Remove all the Factory methods that were used to create a ClientPool.
4. Don't export `getClient` or `releaseClient`.