### PR TITLE
thriftbp: Avoid reusing bad client in ClientPool.Call

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -10,8 +10,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_apache_thrift",
         importpath = "github.com/apache/thrift",
-        sum = "h1:04kEvSCwxMrq83hsb8YRHAbuQ4bMV32PXK+kFa3b+jo=",
-        version = "v0.13.1-0.20200430141240-5cffef964a08",
+        sum = "h1:x70WaAIoNG8R+jPFR0Fj6EgplgQyc/4Lww7cbv3zRPc=",
+        version = "v0.13.1-0.20200514072844-be3f7321cf0b",
     )
     go_repository(
         name = "com_github_burntsushi_toml",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/apache/thrift v0.13.1-0.20200430141240-5cffef964a08
+	github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b
 	github.com/getsentry/sentry-go v0.6.0
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMw
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
-github.com/apache/thrift v0.13.1-0.20200430141240-5cffef964a08 h1:04kEvSCwxMrq83hsb8YRHAbuQ4bMV32PXK+kFa3b+jo=
-github.com/apache/thrift v0.13.1-0.20200430141240-5cffef964a08/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b h1:x70WaAIoNG8R+jPFR0Fj6EgplgQyc/4Lww7cbv3zRPc=
+github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=


### PR DESCRIPTION
When releasing the client back to the pool, check the error returned by
Call, and close the client to avoid reusing if the error is caused by
network error.