### PR TITLE
Ignore redis nil errors

### DIFF
--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/go-redis/redis/v7"
 	opentracing "github.com/opentracing/opentracing-go"
 
@@ -69,7 +70,7 @@ func (h SpanHook) startChildSpan(ctx context.Context, cmdName string) context.Co
 	return ctx
 }
 
-func (h SpanHook) endChildSpan(ctx context.Context, err error)  {
+func (h SpanHook) endChildSpan(ctx context.Context, err error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil {
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,

--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -2,6 +2,7 @@ package redisbp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-redis/redis/v7"
@@ -44,7 +45,7 @@ func (h SpanHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder)
 func (h SpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
 	var errs batcherror.BatchError
 	for _, cmd := range cmds {
-		if cmd.Err() != redis.Nil {
+		if !errors.Is(cmd.Err(), redis.Nil) {
 			errs.Add(cmd.Err())
 		}
 	}

--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"github.com/go-redis/redis/v7"
 	opentracing "github.com/opentracing/opentracing-go"
 
@@ -49,7 +48,10 @@ func (h SpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) 
 			errs.Add(cmd.Err())
 		}
 	}
-	return h.endChildSpan(ctx, errs.Compile())
+	_ = h.endChildSpan(ctx, errs.Compile())
+	// NOTE: returning non-nil error from the hook changes the error the caller gets, and that's something we want to avoid.
+	// see: https://github.com/go-redis/redis/blob/v7.2.0/redis.go#L101
+	return nil
 }
 
 func (h SpanHook) startChildSpan(ctx context.Context, cmdName string) context.Context {

--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -44,7 +44,9 @@ func (h SpanHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder)
 func (h SpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
 	var errs batcherror.BatchError
 	for _, cmd := range cmds {
-		errs.Add(cmd.Err())
+		if cmd.Err() != redis.Nil {
+			errs.Add(cmd.Err())
+		}
 	}
 	return h.endChildSpan(ctx, errs.Compile())
 }


### PR DESCRIPTION
Baseplate adds a pipeline hook to batch Redis pipeline errors.
The problem is that Redis returns `redis.Nil` error in some cases, e.g. key absence.
These errors should be ignored.
Also, the fix doesn't return errors from the hook in order not to change the default go-redis client error.