### PR TITLE
thrifttest: add 'NewBaseplateServer'

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -314,6 +314,7 @@ func NewTestBaseplate(cfg Config, store *secrets.Store) Baseplate {
 		cfg:     cfg,
 		secrets: store,
 		ecImpl:  edgecontext.Init(edgecontext.Config{Store: store}),
+		closers: batchcloser.New(),
 	}
 }
 

--- a/thriftbp/thrifttest/BUILD.bazel
+++ b/thriftbp/thrifttest/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//batcherror:go_default_library",
         "//clientpool:go_default_library",
         "//internal/gen-go/reddit/baseplate:go_default_library",
         "//secrets:go_default_library",

--- a/thriftbp/thrifttest/BUILD.bazel
+++ b/thriftbp/thrifttest/BUILD.bazel
@@ -5,11 +5,15 @@ go_library(
     srcs = [
         "doc.go",
         "mocks.go",
+        "server.go",
     ],
     importpath = "github.com/reddit/baseplate.go/thriftbp/thrifttest",
     visibility = ["//visibility:public"],
     deps = [
+        "//:go_default_library",
+        "//batcherror:go_default_library",
         "//clientpool:go_default_library",
+        "//secrets:go_default_library",
         "//thriftbp:go_default_library",
         "@com_github_apache_thrift//lib/go/thrift:go_default_library",
     ],
@@ -17,7 +21,15 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["mocks_test.go"],
+    srcs = [
+        "mocks_test.go",
+        "server_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//clientpool:go_default_library"],
+    deps = [
+        "//batcherror:go_default_library",
+        "//clientpool:go_default_library",
+        "//internal/gen-go/reddit/baseplate:go_default_library",
+        "//secrets:go_default_library",
+    ],
 )

--- a/thriftbp/thrifttest/BUILD.bazel
+++ b/thriftbp/thrifttest/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
-        "//batcherror:go_default_library",
+        "//batchcloser:go_default_library",
         "//clientpool:go_default_library",
         "//secrets:go_default_library",
         "//thriftbp:go_default_library",

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -1,0 +1,141 @@
+package thrifttest
+
+import (
+	"context"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/secrets"
+	"github.com/reddit/baseplate.go/thriftbp"
+)
+
+const loopbackAddr = "127.0.0.1:0"
+
+// ServerConfig can be used to pass in custom configuration options for the
+// server and/or client created by NewBaseplateServer.
+type ServerConfig struct {
+	// ServerConfig is an optional value, sane defaults will be chosen where
+	// appropriate.
+	//
+	// ServerConfig.Socket will always be replaced with one created in
+	// NewBaseplateServer using the local loopback address.
+	ServerConfig baseplate.Config
+
+	// ClientConfig is an optional value, sane defaults will be chosen where
+	// appropriate.
+	//
+	// Addr will always be set to the address of the test server.
+	// ReportPoolStats will always be set to false.
+	// InitialConnections will always be set to 0 since the test server will not
+	// be started yet.
+	// MaxConnections will be 10 if it is not set.
+	ClientConfig thriftbp.ClientPoolConfig
+
+	// Optional, additional ClientMiddleware to wrap the client with.
+	ClientMiddlewares []thrift.ClientMiddleware
+
+	// Optional, additional ProcessorMiddleware to wrap the server with.
+	ProcessorMiddlewares []thrift.ProcessorMiddleware
+}
+
+// Server is a test server returned by NewBaseplateServer.  It contains both
+// the baseplate.Server and a ClientPool to use to interact with the server.
+//
+// Server implements baseplate.Server.
+type Server struct {
+	baseplate.Server
+
+	// ClientPool provides a thriftbp.ClientPool that connects to this Server and
+	// can be used for making Thrift client objects to interact with this Server.
+	ClientPool thriftbp.ClientPool
+}
+
+// Start starts the server using baseplate.Serve in a background goroutine and
+// waits for a short period of time to give the server time to start up.
+//
+// The server can be closed manually, with shutdown commands, or by cancelling
+// the given context.
+func (s *Server) Start(ctx context.Context) {
+	go baseplate.Serve(ctx, s)
+	time.Sleep(10 * time.Millisecond)
+}
+
+// Close both the underying baseplate.Server and thriftbp.ClientPool
+func (s *Server) Close() error {
+	var errs batcherror.BatchError
+	if err := s.Server.Close(); err != nil {
+		errs.Add(err)
+	}
+	if s.ClientPool != nil {
+		if err := s.ClientPool.Close(); err != nil {
+			errs.Add(err)
+		}
+	}
+	return errs.Compile()
+}
+
+// NewBaseplateServer returns a new, Baseplate thrift server listening on the
+// local loopback interface and a Baseplate ClientPool for use with that server.
+//
+// This is inspired by httptest.NewServer from the go standard library and can
+// be used to test a thrift service.
+//
+// "cfg" may be nil, if it is, sane defaults will be chosen.
+// The server and pool that are returned should be closed when done, but the
+// Baseplate used by the server does not need to be.
+func NewBaseplateServer(
+	store *secrets.Store,
+	processor thrift.TProcessor,
+	cfg *ServerConfig,
+) (*Server, error) {
+	if cfg == nil {
+		cfg = &ServerConfig{}
+	}
+
+	socket, err := thrift.NewTServerSocket(loopbackAddr)
+	if err != nil {
+		return nil, err
+	}
+	// Call listen to reserve a port and check for any issues early
+	if err := socket.Listen(); err != nil {
+		return nil, err
+	}
+
+	cfg.ServerConfig.Addr = socket.Addr().String()
+	bp := baseplate.NewTestBaseplate(cfg.ServerConfig, store)
+	middlewares := thriftbp.BaseplateDefaultProcessorMiddlewares(bp.EdgeContextImpl())
+	middlewares = append(middlewares, cfg.ProcessorMiddlewares...)
+	serverCfg := thriftbp.ServerConfig{
+		Socket: socket,
+		Logger: thrift.NopLogger,
+	}
+
+	srv, err := thriftbp.NewServer(serverCfg, processor, middlewares...)
+	if err != nil {
+		return nil, err
+	}
+	server := &Server{Server: thriftbp.ApplyBaseplate(bp, srv)}
+
+	cfg.ClientConfig.Addr = server.Baseplate().Config().Addr
+	cfg.ClientConfig.ReportPoolStats = false
+	cfg.ClientConfig.InitialConnections = 0
+	if cfg.ClientConfig.SocketTimeout == 0 {
+		cfg.ClientConfig.SocketTimeout = 10 * time.Millisecond
+	}
+	if cfg.ClientConfig.ServiceSlug == "" {
+		cfg.ClientConfig.ServiceSlug = "testing"
+	}
+	if cfg.ClientConfig.MaxConnections == 0 {
+		cfg.ClientConfig.MaxConnections = 10
+	}
+	pool, err := thriftbp.NewBaseplateClientPool(cfg.ClientConfig, cfg.ClientMiddlewares...)
+	if err != nil {
+		server.Close()
+		return nil, err
+	}
+	server.ClientPool = pool
+	return server, nil
+}

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -107,6 +107,54 @@ func (s *Server) Close() error {
 // "cfg" may be nil, if it is, sane defaults will be chosen.
 // The server and pool that are returned should be closed when done, but the
 // Baseplate used by the server does not need to be.
+//
+// Here is an example usage of NewBaseplateServer:
+//
+//	import (
+//		"context"
+//		"testing"
+//
+//		"github.com/reddit/baseplate.go/batcherror"
+//		baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+//		"github.com/reddit/baseplate.go/secrets"
+//		"github.com/reddit/baseplate.go/thriftbp/thrifttest"
+//	)
+//
+//	type BaseplateService struct {
+//		Fail bool
+//		Err  error
+//	}
+//
+//	func (srv BaseplateService) IsHealthy(ctx context.Context) (r bool, err error) {
+//		return !srv.Fail, srv.Err
+//	}
+//
+//	func TestService(t *testing.T){
+//		// Initialize this properly in a real test
+//		var secrets *secrets.Store
+//
+//		ctx, cancel := context.WithCancel(context.Background())
+//		defer cancel()
+//
+//		processor := baseplatethrift.NewBaseplateServiceProcessor(BaseplateService{})
+//		server, err := thrifttest.NewBaseplateServer(store, processor, nil)
+//		if err != nil {
+//			t.Fatal(err)
+//		}
+//		// cancelling the context will close the server.
+//		server.Start(ctx)
+//
+//		client := baseplatethrift.NewBaseplateServiceClient(server.ClientPool)
+//		success, err := client.IsHealthy(ctx)
+//
+//		if err != nil {
+//			t.Errorf("expected no error, got %v", err)
+//		}
+//
+//		if !success {
+// 			t.Errorf("result mismatch, expected %v, got %v", c.expected.result, result)
+//		}
+//	}
 func NewBaseplateServer(
 	store *secrets.Store,
 	processor thrift.TProcessor,

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -104,7 +104,7 @@ func (s *Server) Close() error {
 // This is inspired by httptest.NewServer from the go standard library and can
 // be used to test a thrift service.
 //
-// "cfg" may be nil, if it is, sane defaults will be chosen.
+// "cfg" may be empty, if it is, sane defaults will be chosen.
 // The server and pool that are returned should be closed when done, but the
 // Baseplate used by the server does not need to be.
 //
@@ -137,7 +137,7 @@ func (s *Server) Close() error {
 //		defer cancel()
 //
 //		processor := baseplatethrift.NewBaseplateServiceProcessor(BaseplateService{})
-//		server, err := thrifttest.NewBaseplateServer(store, processor, nil)
+//		server, err := thrifttest.NewBaseplateServer(store, processor, thrifttest.ServerConfig{})
 //		if err != nil {
 //			t.Fatal(err)
 //		}
@@ -158,12 +158,8 @@ func (s *Server) Close() error {
 func NewBaseplateServer(
 	store *secrets.Store,
 	processor thrift.TProcessor,
-	cfg *ServerConfig,
+	cfg ServerConfig,
 ) (*Server, error) {
-	if cfg == nil {
-		cfg = &ServerConfig{}
-	}
-
 	socket, err := thrift.NewTServerSocket(loopbackAddr)
 	if err != nil {
 		return nil, err

--- a/thriftbp/thrifttest/server_test.go
+++ b/thriftbp/thrifttest/server_test.go
@@ -1,0 +1,165 @@
+package thrifttest_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/reddit/baseplate.go/batcherror"
+	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/secrets"
+	"github.com/reddit/baseplate.go/thriftbp/thrifttest"
+)
+
+// pubkey copied from https://github.com/reddit/baseplate.py/blob/db9c1d7cddb1cb242546349e821cad0b0cbd6fce/tests/__init__.py#L12
+const secretStore = `
+{
+	"secrets": {
+		"secret/authentication/public-key": {
+			"type": "versioned",
+			"current": "foobar",
+			"previous": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtzMnDEQPd75QZByogNlB\nNY2auyr4sy8UNTDARs79Edq/Jw5tb7ub412mOB61mVrcuFZW6xfmCRt0ILgoaT66\nTp1RpuEfghD+e7bYZ+Q2pckC1ZaVPIVVf/ZcCZ0tKQHoD8EpyyFINKjCh516VrCx\nKuOm2fALPB/xDwDBEdeVJlh5/3HHP2V35scdvDRkvr2qkcvhzoy0+7wUWFRZ2n6H\nTFrxMHQoHg0tutAJEkjsMw9xfN7V07c952SHNRZvu80V5EEpnKw/iYKXUjCmoXm8\ntpJv5kXH6XPgfvOirSbTfuo+0VGqVIx9gcomzJ0I5WfGTD22dAxDiRT7q7KZnNgt\nTwIDAQAB\n-----END PUBLIC KEY-----"
+		}
+	}
+}`
+
+type BaseplateService struct {
+	Fail bool
+	Err  error
+}
+
+func (srv BaseplateService) IsHealthy(ctx context.Context) (r bool, err error) {
+	return !srv.Fail, srv.Err
+}
+
+type Closer struct {
+	Closers []func() error
+}
+
+func (c *Closer) Add(closer func() error) {
+	c.Closers = append(c.Closers, closer)
+}
+
+func (c *Closer) Close() error {
+	var errs batcherror.BatchError
+	for _, closer := range c.Closers {
+		if err := closer(); err != nil {
+			errs.Add(err)
+		}
+	}
+	return errs.Compile()
+}
+
+func newSecrets(t testing.TB) (*secrets.Store, io.Closer) {
+	t.Helper()
+
+	closer := &Closer{}
+	dir, err := ioutil.TempDir("", "thifttest-server-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	closer.Add(func() error {
+		return os.RemoveAll(dir)
+	})
+
+	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
+	if err != nil {
+		closer.Close()
+		t.Fatal(err)
+	}
+
+	tmpPath := tmpFile.Name()
+	if _, err := tmpFile.Write([]byte(secretStore)); err != nil {
+		closer.Close()
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		closer.Close()
+		t.Fatal(err)
+	}
+
+	store, err := secrets.NewStore(context.Background(), tmpPath, nil)
+	if err != nil {
+		closer.Close()
+		t.Fatal(err)
+	}
+	closer.Add(store.Close)
+	return store, closer
+}
+
+func TestNewBaseplateServer(t *testing.T) {
+	store, closer := newSecrets(t)
+	defer closer.Close()
+
+	testErr := errors.New("test")
+
+	type expectation struct {
+		result bool
+		hasErr bool
+	}
+	cases := []struct {
+		name     string
+		handler  BaseplateService
+		expected expectation
+	}{
+		{
+			name:    "success/no-err",
+			handler: BaseplateService{},
+			expected: expectation{
+				result: true,
+				hasErr: false,
+			},
+		},
+		{
+			name:    "fail/no-err",
+			handler: BaseplateService{Fail: true},
+			expected: expectation{
+				result: false,
+				hasErr: false,
+			},
+		},
+		{
+			name:    "fail/err",
+			handler: BaseplateService{Fail: true, Err: testErr},
+			expected: expectation{
+				result: false,
+				hasErr: true,
+			},
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(
+			c.name,
+			func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				processor := baseplatethrift.NewBaseplateServiceProcessor(c.handler)
+				server, err := thrifttest.NewBaseplateServer(store, processor, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// cancelling the context will close the server.
+				server.Start(ctx)
+
+				client := baseplatethrift.NewBaseplateServiceClient(server.ClientPool)
+				result, err := client.IsHealthy(ctx)
+
+				if c.expected.hasErr && err == nil {
+					t.Error("expected an error, got nil")
+				} else if !c.expected.hasErr && err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+
+				if result != c.expected.result {
+					t.Errorf("result mismatch, expected %v, got %v", c.expected.result, result)
+				}
+			},
+		)
+	}
+}

--- a/thriftbp/thrifttest/server_test.go
+++ b/thriftbp/thrifttest/server_test.go
@@ -3,28 +3,12 @@ package thrifttest_test
 import (
 	"context"
 	"errors"
-	"io"
-	"io/ioutil"
-	"os"
 	"testing"
 
-	"github.com/reddit/baseplate.go/batcherror"
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/thriftbp/thrifttest"
 )
-
-// pubkey copied from https://github.com/reddit/baseplate.py/blob/db9c1d7cddb1cb242546349e821cad0b0cbd6fce/tests/__init__.py#L12
-const secretStore = `
-{
-	"secrets": {
-		"secret/authentication/public-key": {
-			"type": "versioned",
-			"current": "foobar",
-			"previous": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtzMnDEQPd75QZByogNlB\nNY2auyr4sy8UNTDARs79Edq/Jw5tb7ub412mOB61mVrcuFZW6xfmCRt0ILgoaT66\nTp1RpuEfghD+e7bYZ+Q2pckC1ZaVPIVVf/ZcCZ0tKQHoD8EpyyFINKjCh516VrCx\nKuOm2fALPB/xDwDBEdeVJlh5/3HHP2V35scdvDRkvr2qkcvhzoy0+7wUWFRZ2n6H\nTFrxMHQoHg0tutAJEkjsMw9xfN7V07c952SHNRZvu80V5EEpnKw/iYKXUjCmoXm8\ntpJv5kXH6XPgfvOirSbTfuo+0VGqVIx9gcomzJ0I5WfGTD22dAxDiRT7q7KZnNgt\nTwIDAQAB\n-----END PUBLIC KEY-----"
-		}
-	}
-}`
 
 type BaseplateService struct {
 	Fail bool
@@ -35,64 +19,22 @@ func (srv BaseplateService) IsHealthy(ctx context.Context) (r bool, err error) {
 	return !srv.Fail, srv.Err
 }
 
-type Closer struct {
-	Closers []func() error
-}
-
-func (c *Closer) Add(closer func() error) {
-	c.Closers = append(c.Closers, closer)
-}
-
-func (c *Closer) Close() error {
-	var errs batcherror.BatchError
-	for _, closer := range c.Closers {
-		if err := closer(); err != nil {
-			errs.Add(err)
-		}
-	}
-	return errs.Compile()
-}
-
-func newSecrets(t testing.TB) (*secrets.Store, io.Closer) {
+func newSecrets(t testing.TB) *secrets.Store {
 	t.Helper()
 
-	closer := &Closer{}
-	dir, err := ioutil.TempDir("", "thifttest-server-test-")
+	store, _, err := secrets.NewTestSecrets(
+		context.Background(),
+		make(map[string]secrets.GenericSecret),
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	closer.Add(func() error {
-		return os.RemoveAll(dir)
-	})
-
-	tmpFile, err := ioutil.TempFile(dir, "secrets.json")
-	if err != nil {
-		closer.Close()
-		t.Fatal(err)
-	}
-
-	tmpPath := tmpFile.Name()
-	if _, err := tmpFile.Write([]byte(secretStore)); err != nil {
-		closer.Close()
-		t.Fatal(err)
-	}
-	if err := tmpFile.Close(); err != nil {
-		closer.Close()
-		t.Fatal(err)
-	}
-
-	store, err := secrets.NewStore(context.Background(), tmpPath, nil)
-	if err != nil {
-		closer.Close()
-		t.Fatal(err)
-	}
-	closer.Add(store.Close)
-	return store, closer
+	return store
 }
 
 func TestNewBaseplateServer(t *testing.T) {
-	store, closer := newSecrets(t)
-	defer closer.Close()
+	store := newSecrets(t)
+	defer store.Close()
 
 	testErr := errors.New("test")
 

--- a/thriftbp/thrifttest/server_test.go
+++ b/thriftbp/thrifttest/server_test.go
@@ -140,7 +140,7 @@ func TestNewBaseplateServer(t *testing.T) {
 				defer cancel()
 
 				processor := baseplatethrift.NewBaseplateServiceProcessor(c.handler)
-				server, err := thrifttest.NewBaseplateServer(store, processor, nil)
+				server, err := thrifttest.NewBaseplateServer(store, processor, thrifttest.ServerConfig{})
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
This is inspired by httptest.NewServer and allows you to create a new Thrift server listening using the local loopback interface as well as a ClientPool for creating a client to talk to that server.
    
This can be used to test your thrift service in automated testing.
    
It _can_ also be used to create fake services for testing your integration, although you might also be served by using the Mocks available in 'thrifttest' for that.