### PR TITLE
metricsbp: Add Statsd.WriteTo

### DIFF
--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -1,4 +1,4 @@
-package metricsbp
+package metricsbp_test
 
 import (
 	"context"
@@ -9,17 +9,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-func runSpan(st *Statsd, spanErr error) (counter string, statusCounters []string, histogram string, err error) {
+func runSpan(st *metricsbp.Statsd, spanErr error) (counter string, statusCounters []string, histogram string, err error) {
 	ctx, span := tracing.StartSpanFromHeaders(context.Background(), "foo", tracing.Headers{})
 	time.Sleep(time.Millisecond)
 	span.AddCounter("bar.count", 1.0)
 	span.Stop(ctx, spanErr)
 
 	var sb strings.Builder
-	if _, err = st.statsd.WriteTo(&sb); err != nil {
+	if _, err = st.WriteTo(&sb); err != nil {
 		return
 	}
 	stats := strings.Split(sb.String(), "\n")
@@ -41,12 +42,12 @@ func runSpan(st *Statsd, spanErr error) (counter string, statusCounters []string
 }
 
 func TestOnCreateServerSpan(t *testing.T) {
-	st := NewStatsd(
+	st := metricsbp.NewStatsd(
 		context.Background(),
-		StatsdConfig{},
+		metricsbp.StatsdConfig{},
 	)
 
-	hook := CreateServerSpanHook{Metrics: st}
+	hook := metricsbp.CreateServerSpanHook{Metrics: st}
 	tracing.RegisterCreateServerSpanHooks(hook)
 	defer tracing.ResetHooks()
 

--- a/metricsbp/statsd.go
+++ b/metricsbp/statsd.go
@@ -2,6 +2,7 @@ package metricsbp
 
 import (
 	"context"
+	"io"
 	"strings"
 	"time"
 
@@ -301,4 +302,13 @@ func (st *Statsd) Close() error {
 		log.KitLogger(st.cfg.LogLevel),
 	))
 	return err
+}
+
+// WriteTo calls the underlying statsd implementation's WriteTo function.
+//
+// Doing this will flush all the buffered metrics to the writer, so in most
+// cases you shouldn't be using it in production code. But it's useful in unit
+// tests to verify that you have the correct metrics you want to report.
+func (st *Statsd) WriteTo(w io.Writer) (n int64, err error) {
+	return st.fallback().statsd.WriteTo(w)
 }


### PR DESCRIPTION
This was removed in 173f703, but it's still useful for writing unit
tests.