### PR TITLE
thriftbp: wrap the ClientPool Call method

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -315,8 +315,8 @@ func (p *clientPool) wrapCalls(middlewares ...thrift.ClientMiddleware) {
 	}, middlewares...)
 }
 
-// pooledCall gets a Client from the inner clientpool.Pool and "Calls" that,
-// returning the result and returning the client to the pool afterwards.
+// pooledCall gets a Client from the inner clientpool.Pool and "Calls" it,
+// returning the result and releasing the client back to the pool afterwards.
 //
 // This is not called directly, but is rather the inner "call" wrapped by
 // wrapCalls, so it runs after all of the middleware.

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -291,24 +291,24 @@ type clientPool struct {
 	poolExhaustedCounter metrics.Counter
 	releaseErrorCounter  metrics.Counter
 
-	wrappedCall thrift.TClient
+	wrappedClient thrift.TClient
 }
 
 func (p *clientPool) Call(ctx context.Context, method string, args, result thrift.TStruct) (err error) {
 	// A clientPool needs to be set up properly before it can be used,
-	// specifically, ouse p.wrapCalls to set up p.wrappedCall before using it.
+	// specifically use p.wrapCalls to set up p.wrappedClient before using it.
 	//
 	// newClientPool already takes care of this for you.
-	return p.wrappedCall.Call(ctx, method, args, result)
+	return p.wrappedClient.Call(ctx, method, args, result)
 }
 
-// wrapCalls wraps p.pooledCall in the given middleware and sets p.wrappedCall
+// wrapCalls wraps p.pooledCall in the given middleware and sets p.wrappedClient
 // to the resulting thrift.TClient.
 //
 // This must be called before the clientPool can be used, but newClientPool
 // already takes care of this for you.
 func (p *clientPool) wrapCalls(middlewares ...thrift.ClientMiddleware) {
-	p.wrappedCall = thrift.WrapClient(thrift.WrappedTClient{
+	p.wrappedClient = thrift.WrapClient(thrift.WrappedTClient{
 		Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) error {
 			return p.pooledCall(ctx, method, args, result)
 		},

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -318,7 +318,7 @@ func (p *clientPool) wrapCalls(middlewares ...thrift.ClientMiddleware) {
 // pooledCall gets a Client from the inner clientpool.Pool and "Calls" it,
 // returning the result and releasing the client back to the pool afterwards.
 //
-// This is not called directly, but is rather the inner "call" wrapped by
+// This is not called directly, but is rather the inner "Call" wrapped by
 // wrapCalls, so it runs after all of the middleware.
 func (p *clientPool) pooledCall(ctx context.Context, method string, args, result thrift.TStruct) (err error) {
 	client, err := p.getClient()

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -223,6 +223,8 @@ func newClientPool(
 			labels,
 		)
 	}
+
+	// create the base clientPool, this is not ready for use.
 	pooledClient := &clientPool{
 		Pool: pool,
 
@@ -233,6 +235,10 @@ func newClientPool(
 			cfg.ServiceSlug + ".pool-release-error",
 		).With(labels...),
 	}
+	// finish setting up the clientPool by wrapping the inner "Call" with the
+	// given middleware.
+	//
+	// pooledClient is now ready for use.
 	pooledClient.wrapCalls(middlewares...)
 	return pooledClient, nil
 }


### PR DESCRIPTION
This is mainly so we apply middleware before getting a client from the pool, this lets us do things like use a new client if we trigger a retry due to a bad client in middleware.  It also has the side effect of only calling Wrap once rather than every time a new Client object is built.