### PR TITLE
log: Change caller skip level from 2 to 1

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -94,7 +94,7 @@ func InitLoggerWithConfig(logLevel Level, cfg zap.Config) error {
 		globalLogger = zap.NewNop().Sugar()
 		return nil
 	}
-	l, err := cfg.Build(zap.AddCallerSkip(2))
+	l, err := cfg.Build(zap.AddCallerSkip(1))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When it's 2, for some logs zap will be unable to get the caller, for
example the log emitted from edgecontext's jwt validator, and cause zap
itself to emit this log:

    2020-05-22 02:10:42.683894299 +0000 UTC Logger.check error: failed to get caller