### PR TITLE
edgecontext: Fix how we return LoID

### DIFF
--- a/edgecontext/edgecontext_test.go
+++ b/edgecontext/edgecontext_test.go
@@ -446,8 +446,10 @@ func TestFromHeader(t *testing.T) {
 					if loid, ok := user.LoID(); !ok {
 						t.Error("Failed to get loid from user")
 					} else {
-						if loid != expectedLoID {
-							t.Errorf("LoID expected %q, got %q", expectedLoID, loid)
+						// For logged in user,
+						// we expect LoID() to return user id instead of loid.
+						if loid != expectedUser {
+							t.Errorf("LoID expected %q, got %q", expectedUser, loid)
 						}
 					}
 					if ts, ok := user.CookieCreatedAt(); !ok {

--- a/edgecontext/user.go
+++ b/edgecontext/user.go
@@ -37,9 +37,17 @@ func (u User) IsLoggedIn() bool {
 
 // LoID returns the LoID of this user.
 func (u User) LoID() (loid string, ok bool) {
+	// First, we return the logged in user id if it's a logged in user.
+	if id, ok := u.ID(); ok {
+		return id, ok
+	}
+
+	// Then, we use the loid from the thrift payload.
 	if u.e.raw.LoID != "" {
 		return u.e.raw.LoID, true
 	}
+
+	// Finally, we fallback to the loid from the JWT token.
 	token := u.e.AuthToken()
 	if token == nil {
 		return


### PR DESCRIPTION
We should return LoID in this order (fallback to the next one if it's
empty):

1. The logged in user id from the JWT token
2. The loid from the thrift payload
3. The loid from the JWT token