### PR TITLE
thriftbp: reorder default client middleware

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -17,15 +17,15 @@ import (
 //
 // Currently they are (in order):
 //
-// 1. MonitorClient
+// 1. ForwardEdgeRequestContext
 //
-// 2. ForwardEdgeRequestContext
+// 2. MonitorClient
 //
 // 3. SetDeadlineBudget
 func BaseplateDefaultClientMiddlewares() []thrift.ClientMiddleware {
 	return []thrift.ClientMiddleware{
-		MonitorClient,
 		ForwardEdgeRequestContext,
+		MonitorClient,
 		SetDeadlineBudget,
 	}
 }

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -167,14 +167,12 @@ func SingleAddressGenerator(addr string) AddressGenerator {
 // passed into this function.
 func NewBaseplateClientPool(cfg ClientPoolConfig, middlewares ...thrift.ClientMiddleware) (ClientPool, error) {
 	defaults := BaseplateDefaultClientMiddlewares()
-	wrappers := make([]thrift.ClientMiddleware, 0, len(defaults)+len(middlewares))
-	wrappers = append(wrappers, defaults...)
-	wrappers = append(wrappers, middlewares...)
+	middlewares = append(middlewares, defaults...)
 	return NewCustomClientPool(
 		cfg,
 		SingleAddressGenerator(cfg.Addr),
 		thrift.NewTHeaderProtocolFactory(),
-		wrappers...,
+		middlewares...,
 	)
 }
 


### PR DESCRIPTION
Put the default middleware at the end of the client middlewares.  We want these to happen just before the call, that way if we do things like retry requests using middleware, things like spans are triggered twice.