### PR TITLE
Metrics hook stop options

### DIFF
--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
     deps = [
         "//tracing:go_default_library",
         "@com_github_go_kit_kit//metrics:go_default_library",
+        "@com_github_opentracing_opentracing_go//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",
     ],
 )

--- a/metricsbp/config.go
+++ b/metricsbp/config.go
@@ -45,6 +45,6 @@ func InitFromConfig(ctx context.Context, cfg Config) io.Closer {
 		Address:             cfg.Endpoint,
 		LogLevel:            log.ErrorLevel,
 	})
-	tracing.RegisterCreateServerSpanHooks(CreateServerSpanHook{})
+	tracing.RegisterCreateServerSpanHooks(CreateServerSpanHook{Metrics: M})
 	return M
 }

--- a/metricsbp/timer.go
+++ b/metricsbp/timer.go
@@ -47,9 +47,16 @@ func (t *Timer) ObserveDuration() {
 	if t == nil || t.Histogram == nil || t.start.IsZero() {
 		return
 	}
-	d := float64(time.Since(t.start)) / timerUnit
+	recordDuration(t.Histogram, time.Since(t.start))
+}
+
+func recordDuration(h metrics.Histogram, duration time.Duration) {
+	if h == nil {
+		return
+	}
+	d := float64(duration) / timerUnit
 	if d < 0 {
 		d = 0
 	}
-	t.Histogram.Observe(d)
+	h.Observe(d)
 }

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 	"testing/quick"
+	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 
@@ -677,5 +678,25 @@ func TestHeadersParseSampled(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+func TestStartAndFinishTimes(t *testing.T) {
+	startTime := time.Unix(1, 0)
+	stopTime := startTime.Add(time.Second)
+	span := AsSpan(opentracing.StartSpan(
+		"test",
+		opentracing.StartTime(startTime),
+	))
+	if !span.StartTime().Equal(startTime) {
+		t.Fatalf("start time mismatch, expected %v, got %v", startTime, span.StartTime())
+	}
+	if !span.StopTime().IsZero() {
+		t.Fatalf("stop time should be zero, got %v", span.StopTime())
+	}
+
+	span.FinishWithOptions(opentracing.FinishOptions{FinishTime: stopTime})
+	if !span.StopTime().Equal(stopTime) {
+		t.Fatalf("start time mismatch, expected %v, got %v", stopTime, span.StopTime())
 	}
 }


### PR DESCRIPTION
This PR adds support for the `FinishTime` option to override the stop time of a span.

Along with this, we also export these times as functions and use those when they are set in the metricsbp span hook.

There are 2 reasons for doing this:

1. Not silently ignoring valid options to the `opentracing` functions used to start/stop spans.
2. Some libraries (such as [gocql](https://github.com/gocql/gocql)) support "observing" work by triggering a call _after_ the work is done and reports the start and finish times rather than having hooks before and after the work is done.