### PR TITLE
thriftbp: include the client service name in the span name

### DIFF
--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -17,12 +17,15 @@ import (
 	"github.com/reddit/baseplate.go/tracing"
 )
 
-const method = "testMethod"
+const (
+	service = "testService"
+	method  = "testMethod"
+)
 
 func initClients() (*thrifttest.MockClient, *thrifttest.RecordedClient, thrift.TClient) {
 	mock := &thrifttest.MockClient{FailUnregisteredMethods: true}
 	recorder := thrifttest.NewRecordedClient(mock)
-	client := thrift.WrapClient(recorder, thriftbp.BaseplateDefaultClientMiddlewares()...)
+	client := thrift.WrapClient(recorder, thriftbp.BaseplateDefaultClientMiddlewares(service)...)
 	return mock, recorder, client
 }
 
@@ -132,9 +135,10 @@ func TestWrapMonitoredClient(t *testing.T) {
 				if s == nil {
 					t.Fatal("span was nil")
 				}
+				spanName := service + "." + method
 				span := tracing.AsSpan(s)
-				if span.Name() != method {
-					t.Errorf("span name mismatch, expected %q, got %q", method, span.Name())
+				if span.Name() != spanName {
+					t.Errorf("span name mismatch, expected %q, got %q", spanName, span.Name())
 				}
 				if span.SpanType() != tracing.SpanTypeClient {
 					t.Errorf("span type mismatch, expected %s, got %s", tracing.SpanTypeClient, span.SpanType())

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -166,7 +166,7 @@ func SingleAddressGenerator(addr string) AddressGenerator {
 // BaseplateDefaultClientMiddlewares plus any additional client middlewares
 // passed into this function.
 func NewBaseplateClientPool(cfg ClientPoolConfig, middlewares ...thrift.ClientMiddleware) (ClientPool, error) {
-	defaults := BaseplateDefaultClientMiddlewares()
+	defaults := BaseplateDefaultClientMiddlewares(cfg.ServiceSlug)
 	middlewares = append(middlewares, defaults...)
 	return NewCustomClientPool(
 		cfg,

--- a/thriftbp/example_client_test.go
+++ b/thriftbp/example_client_test.go
@@ -29,7 +29,7 @@ func ExampleMonitorClient() {
 				factory.GetProtocol(transport),
 				factory.GetProtocol(transport),
 			),
-			thriftbp.MonitorClient,
+			thriftbp.MonitorClient("service"),
 		),
 	)
 	// Create a context with a server span


### PR DESCRIPTION
Right now we are not including this so the metrics just look like `client.${method}` when they should be `client.${service}.${method}`