### PR TITLE
log: Better way to fallback Wrapper

### DIFF
--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gofrs/uuid"
 
 	"github.com/reddit/baseplate.go/experiments"
-	"github.com/reddit/baseplate.go/log"
 )
 
 // An EdgeRequestContext contains context info about an edge request.
@@ -33,7 +32,7 @@ func (e *EdgeRequestContext) AuthToken() *AuthenticationToken {
 		if token, err := e.impl.ValidateToken(e.raw.AuthToken); err != nil {
 			// empty jwt token is considered "normal", no need to spam them in logs.
 			if !errors.Is(err, ErrEmptyToken) {
-				log.FallbackWrapper(e.impl.logger)("token validation failed: " + err.Error())
+				e.impl.logger.Log("token validation failed: " + err.Error())
 			}
 			e.token = nil
 		} else {
@@ -122,7 +121,7 @@ func (e *EdgeRequestContext) UpdateExperimentEvent(ee *experiments.ExperimentEve
 		ee.DeviceID, err = uuid.FromString(deviceID)
 		if err != nil {
 			ee.DeviceID = uuid.Nil
-			log.FallbackWrapper(e.impl.logger)(fmt.Sprintf(
+			e.impl.logger.Log(fmt.Sprintf(
 				"Failed to parse device id %q into uuid: %v",
 				deviceID,
 				err,

--- a/edgecontext/validator.go
+++ b/edgecontext/validator.go
@@ -7,7 +7,6 @@ import (
 
 	jwt "github.com/reddit/jwt-go/v3"
 
-	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/secrets"
 )
 
@@ -78,7 +77,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 
 		versioned, err := sec.GetVersionedSecret(authenticationPubKeySecretPath)
 		if err != nil {
-			log.FallbackWrapper(impl.logger)(fmt.Sprintf(
+			impl.logger.Log(fmt.Sprintf(
 				"Failed to get secrets %q: %v",
 				authenticationPubKeySecretPath,
 				err,
@@ -91,7 +90,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 		for i, v := range all {
 			key, err := jwt.ParseRSAPublicKeyFromPEM([]byte(v))
 			if err != nil {
-				log.FallbackWrapper(impl.logger)(fmt.Sprintf(
+				impl.logger.Log(fmt.Sprintf(
 					"Failed to parse key #%d: %v",
 					i,
 					err,
@@ -102,7 +101,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 		}
 
 		if len(keys) == 0 {
-			log.FallbackWrapper(impl.logger)("No valid keys in secrets store.")
+			impl.logger.Log("No valid keys in secrets store.")
 			return
 		}
 

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -90,7 +90,7 @@ func (r *Result) watcherLoop(
 			return
 
 		case err := <-watcher.Errors:
-			log.FallbackWrapper(logger)("watcher error: " + err.Error())
+			logger.Log("watcher error: " + err.Error())
 
 		case ev := <-watcher.Events:
 			if filepath.Base(ev.Name) != file {
@@ -105,12 +105,12 @@ func (r *Result) watcherLoop(
 				func() {
 					f, err := os.Open(path)
 					if err != nil {
-						log.FallbackWrapper(logger)("parser error: " + err.Error())
+						logger.Log("parser error: " + err.Error())
 					}
 					defer f.Close()
 					d, err := parser(f)
 					if err != nil {
-						log.FallbackWrapper(logger)("parser error: " + err.Error())
+						logger.Log("parser error: " + err.Error())
 					} else {
 						r.data.Store(d)
 					}

--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     srcs = [
         "kit_wrapper_test.go",
         "log_test.go",
+        "wrapper_test.go",
     ],
     embed = [":go_default_library"],
     deps = ["@com_github_go_kit_kit//log:go_default_library"],

--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -60,18 +60,18 @@ import (
 // interchangeably (sometimes a typecasting is needed).
 type Wrapper func(msg string)
 
-// NopWrapper is a Wrapper implementation that does nothing.
-func NopWrapper(msg string) {}
-
-// FallbackWrapper is the nil-safe wrapper.
-//
-// It returns NopWrapper when logger is nil, otherwise it return logger as-is.
-func FallbackWrapper(logger Wrapper) Wrapper {
-	if logger != nil {
-		return logger
+// Log is the nil-safe way of calling a log.Wrapper.
+func (w Wrapper) Log(msg string) {
+	if w != nil {
+		w(msg)
 	}
-	return NopWrapper
 }
+
+// NopWrapper is a Wrapper implementation that does nothing.
+//
+// In most cases you don't need to use it directly.
+// The zero value of log.Wrapper is essentially a NopWrapper.
+func NopWrapper(msg string) {}
 
 // StdWrapper wraps stdlib log package into a Wrapper.
 func StdWrapper(logger *stdlog.Logger) Wrapper {

--- a/log/wrapper_test.go
+++ b/log/wrapper_test.go
@@ -1,0 +1,13 @@
+package log_test
+
+import (
+	"testing"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+func TestLogWrapperNilSafe(t *testing.T) {
+	// Just make sure log.Wrapper.Log is nil-safe, no real tests
+	var logger log.Wrapper
+	logger.Log("Hello, world!")
+}

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -73,7 +73,7 @@ func AsSpan(s opentracing.Span) *Span {
 	if span, ok := s.(*Span); ok && span != nil {
 		return span
 	}
-	globalTracer.getLogger()(fmt.Sprintf(
+	globalTracer.logger.Log(fmt.Sprintf(
 		"Failed to cast opentracing.Span %#v back to *tracing.Span.",
 		s,
 	))
@@ -167,7 +167,7 @@ func (s Span) StopTime() time.Time {
 // This uses the the logger provided by the underlying tracing.Tracer used to
 // publish the Span.
 func (s Span) logError(msg string, err error) {
-	s.trace.tracer.getLogger()(msg + err.Error())
+	s.trace.tracer.logger.Log(msg + err.Error())
 }
 
 // AddHooks adds hooks into the Span.
@@ -502,7 +502,7 @@ func (h Headers) ParseTraceID() (id uint64, ok bool) {
 	var err error
 	id, err = strconv.ParseUint(h.TraceID, 10, 64)
 	if err != nil {
-		globalTracer.getLogger()(fmt.Sprintf(
+		globalTracer.logger.Log(fmt.Sprintf(
 			"Malformed trace id in http ctx: %q, %v",
 			h.TraceID,
 			err,
@@ -528,7 +528,7 @@ func (h Headers) ParseSpanID() (id uint64, ok bool) {
 	var err error
 	id, err = strconv.ParseUint(h.SpanID, 10, 64)
 	if err != nil {
-		globalTracer.getLogger()(fmt.Sprintf(
+		globalTracer.logger.Log(fmt.Sprintf(
 			"Malformed span id in http ctx: %q, %v",
 			h.SpanID,
 			err,
@@ -554,7 +554,7 @@ func (h Headers) ParseFlags() (flags int64, ok bool) {
 	var err error
 	flags, err = strconv.ParseInt(h.Flags, 10, 64)
 	if err != nil {
-		globalTracer.getLogger()(fmt.Sprintf(
+		globalTracer.logger.Log(fmt.Sprintf(
 			"Malformed flags in http ctx: %q, %v",
 			h.Flags,
 			err,
@@ -652,6 +652,6 @@ var nopHub = sentry.NewHub(nil, sentry.NewScope())
 func getNopHub() *sentry.Hub {
 	// Whenever this function is called, it means we had a bug that didn't
 	// initialize the spans correctly.
-	globalTracer.getLogger()("getNopHub called.")
+	globalTracer.logger.Log("getNopHub called.")
 	return nopHub
 }

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -284,10 +284,6 @@ func (t *Tracer) Extract(format interface{}, carrier interface{}) (opentracing.S
 	return nil, opentracing.ErrInvalidCarrier
 }
 
-func (t *Tracer) getLogger() log.Wrapper {
-	return log.FallbackWrapper(t.logger)
-}
-
 func findFirstParentReference(refs []opentracing.SpanReference) *Span {
 	for _, s := range refs {
 		if s.Type == opentracing.ChildOfRef {


### PR DESCRIPTION
This technically is a breaking change as we removed log.FallbackWrapper,
but that function is only supposed to be used by code in this repo so it
should be fine. I can also just leave log.FallbackWrapper and mark it as
deprecated, but I fell that's kinda overkill.