### PR TITLE
Rename 'batcherror' to 'errorsbp' and add Suppressor

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//batchcloser:go_default_library",
-        "//batcherror:go_default_library",
         "//edgecontext:go_default_library",
+        "//errorsbp:go_default_library",
         "//log:go_default_library",
         "//metricsbp:go_default_library",
         "//runtimebp:go_default_library",

--- a/baseplate.go
+++ b/baseplate.go
@@ -11,8 +11,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/reddit/baseplate.go/batchcloser"
-	"github.com/reddit/baseplate.go/batcherror"
 	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/runtimebp"
@@ -279,7 +279,7 @@ func (bp impl) Close() error {
 	err := bp.closers.Close()
 
 	var errs []error
-	var batchErr batcherror.BatchError
+	var batchErr errorsbp.BatchError
 	if errors.As(err, &batchErr) {
 		errs = batchErr.GetErrors()
 	} else if err != nil {

--- a/batchcloser/BUILD.bazel
+++ b/batchcloser/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     ],
     importpath = "github.com/reddit/baseplate.go/batchcloser",
     visibility = ["//visibility:public"],
-    deps = ["//batcherror:go_default_library"],
+    deps = ["//errorsbp:go_default_library"],
 )
 
 go_test(

--- a/batchcloser/closers.go
+++ b/batchcloser/closers.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 // CloseError is used to wrap the errors returned by the inner closers within a
@@ -80,9 +80,9 @@ type BatchCloser struct {
 }
 
 // Close implements io.Closer and closes all of it's internal io.Closer objects,
-// batching any errors into a batcherror.BatchError.
+// batching any errors into a errorsbp.BatchError.
 func (bc *BatchCloser) Close() error {
-	var errs batcherror.BatchError
+	var errs errorsbp.BatchError
 	for _, closer := range bc.closers {
 		if err := closer.Close(); err != nil {
 			errs.Add(CloseError{

--- a/errorsbp/BUILD.bazel
+++ b/errorsbp/BUILD.bazel
@@ -5,8 +5,9 @@ go_library(
     srcs = [
         "batch.go",
         "doc.go",
+        "suppressor.go",
     ],
-    importpath = "github.com/reddit/baseplate.go/batcherror",
+    importpath = "github.com/reddit/baseplate.go/errorsbp",
     visibility = ["//visibility:public"],
 )
 
@@ -16,6 +17,7 @@ go_test(
     srcs = [
         "batch_test.go",
         "doc_test.go",
+        "suppressor_test.go",
     ],
     embed = [":go_default_library"],
 )

--- a/errorsbp/batch.go
+++ b/errorsbp/batch.go
@@ -1,4 +1,4 @@
-package batcherror
+package errorsbp
 
 import (
 	"errors"
@@ -26,7 +26,7 @@ func (be BatchError) Error() string {
 	var sb strings.Builder
 	fmt.Fprintf(
 		&sb,
-		"batcherror: total %d error(s) in this batch",
+		"errorsbp: total %d error(s) in this batch",
 		len(be.errors),
 	)
 	for i, err := range be.errors {

--- a/errorsbp/batch_test.go
+++ b/errorsbp/batch_test.go
@@ -1,15 +1,15 @@
-package batcherror_test
+package errorsbp_test
 
 import (
 	"errors"
 	"reflect"
 	"testing"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 func TestAdd(t *testing.T) {
-	var err batcherror.BatchError
+	var err errorsbp.BatchError
 	if len(err.GetErrors()) != 0 {
 		t.Errorf("A new BatchError should contain zero errors: %v", err.GetErrors())
 	}
@@ -29,7 +29,7 @@ func TestAdd(t *testing.T) {
 		t.Errorf("Expected %#v, got %#v", err0, actual)
 	}
 
-	var another batcherror.BatchError
+	var another errorsbp.BatchError
 	err.Add(another)
 	if len(err.GetErrors()) != 1 {
 		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
@@ -65,7 +65,7 @@ func TestAdd(t *testing.T) {
 		)
 	}
 
-	pointer := new(batcherror.BatchError)
+	pointer := new(errorsbp.BatchError)
 	err.Add(pointer)
 	if len(err.GetErrors()) != 0 {
 		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
@@ -84,7 +84,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddMultiple(t *testing.T) {
-	var err batcherror.BatchError
+	var err errorsbp.BatchError
 	if len(err.GetErrors()) != 0 {
 		t.Errorf("A new BatchError should contain zero errors: %v", err.GetErrors())
 	}
@@ -114,7 +114,7 @@ func TestAddMultiple(t *testing.T) {
 		t.Errorf("Expected %#v, got %#v", err1, actual1)
 	}
 
-	var another batcherror.BatchError
+	var another errorsbp.BatchError
 	err.Add(another)
 	if len(err.GetErrors()) != 2 {
 		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
@@ -150,7 +150,7 @@ func TestAddMultiple(t *testing.T) {
 }
 
 func TestCompile(t *testing.T) {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 	err0 := errors.New("foo")
 	err1 := errors.New("bar")
 	err2 := errors.New("foobar")
@@ -171,7 +171,7 @@ func TestCompile(t *testing.T) {
 	batch.Add(err1)
 	batch.Add(err2)
 	err = batch.Compile()
-	expect := "batcherror: total 3 error(s) in this batch: foo; bar; foobar"
+	expect := "errorsbp: total 3 error(s) in this batch: foo; bar; foobar"
 	if err.Error() != expect {
 		t.Errorf("Compiled error expected %#v, got %#v", expect, err)
 	}
@@ -183,7 +183,7 @@ func TestCompile(t *testing.T) {
 }
 
 func TestGetErrors(t *testing.T) {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 	err0 := errors.New("foo")
 	err1 := errors.New("bar")
 	err2 := errors.New("foobar")

--- a/errorsbp/doc.go
+++ b/errorsbp/doc.go
@@ -1,4 +1,4 @@
-// Package batcherror provides BatchError, which can be used to compile multiple
+// Package errorsbp provides BatchError, which can be used to compile multiple
 // errors into a single one.
 //
 // An example of how to use it in your functions:
@@ -18,7 +18,7 @@
 //         }
 //
 //         wg.Wait()
-//         var batch batcherror.BatchError
+//         var batch errorsbp.BatchError
 //         for err := range errChan {
 //             // nil errors will be auto skipped
 //             batch.Add(err)
@@ -31,4 +31,4 @@
 //
 // This package is not thread-safe.
 // The same batch should not be operated on different goroutines concurrently.
-package batcherror
+package errorsbp

--- a/errorsbp/doc_test.go
+++ b/errorsbp/doc_test.go
@@ -1,4 +1,4 @@
-package batcherror_test
+package errorsbp_test
 
 import (
 	"context"
@@ -7,11 +7,11 @@ import (
 	"io"
 	"os"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 func Example() {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 
 	var singleError error = batch.Compile()
 	fmt.Printf("0: %v\n", singleError)
@@ -30,7 +30,7 @@ func Example() {
 	singleError = batch.Compile()
 	fmt.Printf("2: %v\n", singleError)
 
-	var newBatch batcherror.BatchError
+	var newBatch errorsbp.BatchError
 	// Add multiple errors at once
 	newBatch.Add(
 		errors.New("fizz"),
@@ -43,13 +43,13 @@ func Example() {
 	// 0: <nil>
 	// 1: foo
 	// Nil errors are skipped: foo
-	// 2: batcherror: total 2 error(s) in this batch: foo; bar
-	// 3: batcherror: total 4 error(s) in this batch: fizz; buzz; foo; bar
+	// 2: errorsbp: total 2 error(s) in this batch: foo; bar
+	// 3: errorsbp: total 4 error(s) in this batch: fizz; buzz; foo; bar
 }
 
 // This example demonstrates how a BatchError can be inspected with errors.Is.
 func ExampleBatchError_Is() {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 
 	batch.Add(context.Canceled)
 	err := batch.Compile()
@@ -70,7 +70,7 @@ func ExampleBatchError_Is() {
 
 // This example demonstrates how a BatchError can be inspected with errors.As.
 func ExampleBatchError_As() {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 	var target *os.PathError
 
 	batch.Add(context.Canceled)

--- a/errorsbp/suppressor.go
+++ b/errorsbp/suppressor.go
@@ -1,0 +1,42 @@
+package errorsbp
+
+// Suppressor is a function that can be used to check if a given error should be
+// suppressed/ignored.
+//
+// It is not reccomended that you define a Suppressor from scratch, rather you
+// should compose one using Filters and NewSuppressor.
+//
+// Suppressors are not always necessary as what they do is fairly simple but can
+// be useful when you want to ignore a subset of the potential errors something
+// will have to handle in a way that is configurable.  For example, the metricsbp
+// package in baseplate.go uses a Suppressor to determine if a Span should be
+// considered a "failure" for the error it is passed.
+type Suppressor func(err error) bool
+
+// Filter is the building block of a Suppressor, multiple Filters are chained to
+// create a new Suppressor.
+//
+// A Filter should return whether or not the error should be suppressed/ignored.
+// If it cannot make that decision, it should call the 'next' Suppressor.
+type Filter func(err error, next Suppressor) bool
+
+func chain(f Filter, next Suppressor) Suppressor {
+	return func(err error) bool {
+		return f(err, next)
+	}
+}
+
+func fallback(err error) bool {
+	return false
+}
+
+// NewSuppressor return a Suppressor function using the given Filters.
+//
+// Filters will be executed in the order they are provided.
+func NewSuppressor(filters ...Filter) Suppressor {
+	suppressor := fallback
+	for i := len(filters) - 1; i >= 0; i-- {
+		suppressor = chain(filters[i], suppressor)
+	}
+	return suppressor
+}

--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
-        "//batcherror:go_default_library",
         "//edgecontext:go_default_library",
+        "//errorsbp:go_default_library",
         "//log:go_default_library",
         "//secrets:go_default_library",
         "//signing:go_default_library",

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -92,7 +92,10 @@ var (
 // Baseplate HTTP service.
 func ExampleNewBaseplateServer() {
 	var cfg config
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.Args{
+		Path:          "example.yaml",
+		ServiceConfig: &cfg,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	baseplate "github.com/reddit/baseplate.go"
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 var allHTTPMethods = map[string]bool{
@@ -83,7 +83,7 @@ type Endpoint struct {
 // Validate checks for input errors on the Endpoint and returns an error
 // if any exist.
 func (e Endpoint) Validate() error {
-	var err batcherror.BatchError
+	var err errorsbp.BatchError
 	if e.Name == "" {
 		err.Add(errors.New("httpbp: Endpoint.Name must be non-empty"))
 	}
@@ -153,7 +153,7 @@ type ServerArgs struct {
 // be used for testing purposes.  It is called as a part of setting up a new
 // Baseplate server.
 func (args ServerArgs) ValidateAndSetDefaults() (ServerArgs, error) {
-	inputErrors := &batcherror.BatchError{}
+	inputErrors := &errorsbp.BatchError{}
 	if args.Baseplate == nil {
 		inputErrors.Add(errors.New("argument Baseplate must be non-nil"))
 	}

--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/metricsbp",
     visibility = ["//visibility:public"],
     deps = [
+        "//errorsbp:go_default_library",
         "//log:go_default_library",
         "//randbp:go_default_library",
         "//tracing:go_default_library",
@@ -46,6 +47,7 @@ go_test(
     # is just too slow for the context switch in the sleep in TestTimer.
     flaky = True,
     deps = [
+        "//errorsbp:go_default_library",
         "//tracing:go_default_library",
         "@com_github_go_kit_kit//metrics:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -12,6 +12,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 
+	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -53,7 +54,10 @@ func TestOnCreateServerSpan(t *testing.T) {
 		metricsbp.StatsdConfig{},
 	)
 
-	hook := metricsbp.CreateServerSpanHook{Metrics: st}
+	hook := metricsbp.CreateServerSpanHook{
+		Metrics:    st,
+		Suppressor: errorsbp.NewSuppressor(),
+	}
 	tracing.RegisterCreateServerSpanHooks(hook)
 	defer tracing.ResetHooks()
 
@@ -129,7 +133,10 @@ func TestWithStartAndFinishTimes(t *testing.T) {
 		metricsbp.StatsdConfig{},
 	)
 
-	hook := metricsbp.CreateServerSpanHook{Metrics: st}
+	hook := metricsbp.CreateServerSpanHook{
+		Metrics:    st,
+		Suppressor: errorsbp.NewSuppressor(),
+	}
 	tracing.RegisterCreateServerSpanHooks(hook)
 	defer tracing.ResetHooks()
 

--- a/metricsbp/example_baseplate_hooks_test.go
+++ b/metricsbp/example_baseplate_hooks_test.go
@@ -1,6 +1,7 @@
 package metricsbp_test
 
 import (
+	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -10,7 +11,9 @@ func ExampleCreateServerSpanHook() {
 	const prefix = "service.server"
 
 	// initialize the CreateServerSpanHook
-	hook := metricsbp.CreateServerSpanHook{}
+	hook := metricsbp.CreateServerSpanHook{
+		Suppressor: errorsbp.NewSuppressor(),
+	}
 
 	// register the hook with Baseplate
 	tracing.RegisterCreateServerSpanHooks(hook)

--- a/redisbp/BUILD.bazel
+++ b/redisbp/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/redisbp",
     visibility = ["//visibility:public"],
     deps = [
-        "//batcherror:go_default_library",
+        "//errorsbp:go_default_library",
         "//tracing:go_default_library",
         "@com_github_go_redis_redis_v7//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/redisbp/example_config_test.go
+++ b/redisbp/example_config_test.go
@@ -16,7 +16,10 @@ type config struct {
 // that with `baseplate.New`.
 func ExampleClientConfig() {
 	var cfg config
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.Args{
+		Path:          "example.yaml",
+		ServiceConfig: &cfg,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/redisbp/hooks.go
+++ b/redisbp/hooks.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-redis/redis/v7"
 	opentracing "github.com/opentracing/opentracing-go"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -48,7 +48,7 @@ func (h SpanHook) BeforeProcessPipeline(ctx context.Context, cmds []redis.Cmder)
 // publishes the time the Redis pipeline took to complete, and a metric
 // indicating whether the pipeline was a "success" or "fail"
 func (h SpanHook) AfterProcessPipeline(ctx context.Context, cmds []redis.Cmder) error {
-	var errs batcherror.BatchError
+	var errs errorsbp.BatchError
 	for _, cmd := range cmds {
 		if !errors.Is(cmd.Err(), redis.Nil) {
 			errs.Add(cmd.Err())

--- a/retrybp/BUILD.bazel
+++ b/retrybp/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/retrybp",
     visibility = ["//visibility:public"],
     deps = [
-        "//batcherror:go_default_library",
         "//clientpool:go_default_library",
+        "//errorsbp:go_default_library",
         "@com_github_avast_retry_go//:go_default_library",
     ],
 )
@@ -25,8 +25,8 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//batcherror:go_default_library",
         "//clientpool:go_default_library",
+        "//errorsbp:go_default_library",
         "@com_github_avast_retry_go//:go_default_library",
     ],
 )

--- a/retrybp/retry.go
+++ b/retrybp/retry.go
@@ -7,7 +7,7 @@ import (
 
 	retry "github.com/avast/retry-go"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 func init() {
@@ -43,7 +43,7 @@ func GetOptions(ctx context.Context) (options []retry.Option, ok bool) {
 //    where you are not calling Do directly but still want to be able to
 //    configure retry behavior per-call.
 // 2. If retry.Do returns a batch of errors (retry.Error), put those in a
-//    batcherror.BatchError from baseplate.go.
+//    errorsbp.BatchError from baseplate.go.
 func Do(ctx context.Context, fn func() error, defaults ...retry.Option) error {
 	options, _ := GetOptions(ctx)
 	options = append(defaults, options...)
@@ -51,7 +51,7 @@ func Do(ctx context.Context, fn func() error, defaults ...retry.Option) error {
 
 	var retryErr retry.Error
 	if errors.As(err, &retryErr) {
-		var batchErr batcherror.BatchError
+		var batchErr errorsbp.BatchError
 		batchErr.Add(retryErr.WrappedErrors()...)
 		return batchErr.Compile()
 	}

--- a/retrybp/retry_test.go
+++ b/retrybp/retry_test.go
@@ -8,7 +8,7 @@ import (
 
 	retry "github.com/avast/retry-go"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/retrybp"
 )
 
@@ -94,7 +94,7 @@ func TestDoBatchError(t *testing.T) {
 		retry.Attempts(uint(len(errList))),
 	)
 
-	var batchErr batcherror.BatchError
+	var batchErr errorsbp.BatchError
 	if errors.As(err, &batchErr) {
 		if len(batchErr.GetErrors()) != len(errList) {
 			t.Errorf(

--- a/secrets/BUILD.bazel
+++ b/secrets/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/secrets",
     visibility = ["//visibility:public"],
     deps = [
-        "//batcherror:go_default_library",
+        "//errorsbp:go_default_library",
         "//filewatcher:go_default_library",
         "//log:go_default_library",
     ],

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/errorsbp"
 )
 
 const (
@@ -183,7 +183,7 @@ type Document struct {
 // When this function returns a non-nil error, the error is either a
 // TooManyFieldsError, or a BatchError containing multiple TooManyFieldsError.
 func (s *Document) Validate() error {
-	var batch batcherror.BatchError
+	var batch errorsbp.BatchError
 	for key, value := range s.Secrets {
 		if value.Type == SimpleType && notOnlySimpleSecret(value) {
 			batch.Add(TooManyFieldsError{

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -12,7 +12,9 @@ import (
 // This example demonstrates what a typical main function should look like for a
 // Baseplate thrift service.
 func ExampleNewBaseplateServer() {
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", nil)
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.Args{
+		Path: "example.yaml",
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -113,7 +113,7 @@ func (s *Server) Close() error {
 //		"context"
 //		"testing"
 //
-//		"github.com/reddit/baseplate.go/batcherror"
+//		"github.com/reddit/baseplate.go/errorsbp"
 //		baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 //		"github.com/reddit/baseplate.go/secrets"
 //		"github.com/reddit/baseplate.go/thriftbp/thrifttest"


### PR DESCRIPTION
Note, Suppressors are not always necessary as what they do is fairly simple but can be useful when you want to ignore a subset of the potential errors something will have to handle in a way that is configurable.

We are adding them so the `metricsbp` package has a mechanism to ignore certain errors when determining if a Span should be marked as a "failure" or not.

### Breaking changes:

* Move to using an `Args` struct in `baseplate.New`
* rename `batcherror` to `errorsbp`