### PR TITLE
thriftbp: Fix timeouts

### DIFF
--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -40,7 +40,8 @@ func TestNewBaseplateClientPool(t *testing.T) {
 			InitialConnections: 1,
 			MaxConnections:     5,
 			MaxConnectionAge:   time.Minute,
-			SocketTimeout:      time.Millisecond * 10,
+			ConnectTimeout:     time.Millisecond * 10,
+			SocketTimeout:      time.Minute,
 		},
 	); err != nil {
 		t.Fatal(err)

--- a/thriftbp/doc_client_test.go
+++ b/thriftbp/doc_client_test.go
@@ -11,8 +11,8 @@ import (
 
 // In real code these should be coming from either config file or flags instead.
 const (
-	remoteAddr    = "host:port"
-	socketTimeout = time.Millisecond * 10
+	remoteAddr     = "host:port"
+	connectTimeout = time.Millisecond * 10
 
 	initialConnections = 50
 	maxConnections     = 100
@@ -66,7 +66,8 @@ func Example_clientPool() {
 			InitialConnections: initialConnections,
 			MaxConnections:     maxConnections,
 			MaxConnectionAge:   clientTTL,
-			SocketTimeout:      socketTimeout,
+			ConnectTimeout:     connectTimeout,
+			SocketTimeout:      clientTTL,
 			ReportPoolStats:    true,
 			PoolGaugeInterval:  poolGaugeInterval,
 		},

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -18,6 +18,9 @@ type ServerConfig struct {
 
 	// The timeout for the underlying thrift.TServerSocket transport.
 	//
+	// If your clients are using client pools,
+	// you usually want this timeout to be long in order to keep clients alive.
+	//
 	// This is ignored if Socket is non-nil.
 	Timeout time.Duration
 


### PR DESCRIPTION
On client side, separate ConnectTimeout and SocketTimeout, and clarify
in the doc comment that ConnectTimeout usually should be short and
SocketTimeout usually should be long. On server side, add doc comment to
clarify that the Timeout usually should be long.