### PR TITLE
Upgrade thrift to v0.13.1-0.20200609200738-cfbb905034c9

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -34,8 +34,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_apache_thrift",
         importpath = "github.com/apache/thrift",
-        sum = "h1:x70WaAIoNG8R+jPFR0Fj6EgplgQyc/4Lww7cbv3zRPc=",
-        version = "v0.13.1-0.20200514072844-be3f7321cf0b",
+        sum = "h1:hy6+UGGxgL+IxKzSgJBugF5C5pf5K4WsUB8xA7zV/XM=",
+        version = "v0.13.1-0.20200609200738-cfbb905034c9",
     )
     go_repository(
         name = "com_github_armon_consul_api",

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b
+	github.com/apache/thrift v0.13.1-0.20200609200738-cfbb905034c9
 	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/getsentry/sentry-go v0.6.0
 	github.com/go-kit/kit v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMw
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
-github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b h1:x70WaAIoNG8R+jPFR0Fj6EgplgQyc/4Lww7cbv3zRPc=
-github.com/apache/thrift v0.13.1-0.20200514072844-be3f7321cf0b/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.1-0.20200609200738-cfbb905034c9 h1:hy6+UGGxgL+IxKzSgJBugF5C5pf5K4WsUB8xA7zV/XM=
+github.com/apache/thrift v0.13.1-0.20200609200738-cfbb905034c9/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go v2.6.0+incompatible h1:FelcMrm7Bxacr1/RM8+/eqkDkmVN7tjlsy51dOzB3LI=
 github.com/avast/retry-go v2.6.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=


### PR DESCRIPTION
This gives us the version with socket connectivity check, which would
improve thrift client pool performance.