### PR TITLE
Fix httpbp.InjectEdgeRequestContext middleware

### DIFF
--- a/httpbp/fixtures_test.go
+++ b/httpbp/fixtures_test.go
@@ -2,6 +2,7 @@ package httpbp_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"strings"
 	"testing"
@@ -116,7 +117,7 @@ func newRequest(t testing.TB) *http.Request {
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.Header.Add(httpbp.EdgeContextHeader, headerWithValidAuth)
+	req.Header.Add(httpbp.EdgeContextHeader, base64.StdEncoding.EncodeToString([]byte(headerWithValidAuth)))
 	req.Header.Add(httpbp.SpanSampledHeader, "1")
 	return req
 }

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -75,9 +75,9 @@ func NewEdgeContextHeaders(h http.Header) (EdgeContextHeaders, error) {
 	return EdgeContextHeaders{EdgeRequest: string(ec)}, err
 }
 
-// SetEdgeContextHeader attach EdgeRequestContext into response header
+// SetEdgeContextHeader attach EdgeRequestContext into response header.
 //
-// The base64 encoding is only for http transport
+// The base64 encoding is only for http transport.
 func SetEdgeContextHeader(ec *edgecontext.EdgeRequestContext, w http.ResponseWriter) {
 	encoded := base64.StdEncoding.EncodeToString([]byte(ec.Header()))
 	w.Header().Set(EdgeContextHeader, encoded)

--- a/httpbp/middlewares_test.go
+++ b/httpbp/middlewares_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/reddit/baseplate.go/edgecontext"
 
 	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -189,7 +190,11 @@ func TestInjectEdgeRequestContext(t *testing.T) {
 				handle := httpbp.Wrap(
 					"test",
 					newTestHandler(testHandlerPlan{}),
-					httpbp.InjectEdgeRequestContext(c.truster, impl),
+					httpbp.InjectEdgeRequestContext(httpbp.InjectEdgeRequestContextArgs{
+						EdgeContextImpl: impl,
+						TrustHandler:    c.truster,
+						Logger:          log.TestWrapper(t),
+					}),
 					edgecontextRecorderMiddleware(&recorder),
 				)
 				handle(c.request.Context(), httptest.NewRecorder(), c.request)

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -10,6 +10,7 @@ import (
 
 	baseplate "github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/batcherror"
+	"github.com/reddit/baseplate.go/log"
 )
 
 var allHTTPMethods = map[string]bool{
@@ -144,6 +145,10 @@ type ServerArgs struct {
 	//
 	// Defaults to NeverTrustHeaders.
 	TrustHandler HeaderTrustHandler
+
+	// Logger is an optional arg to be called when the InjectEdgeRequestContext
+	// middleware failed to parse the edge request header for any reason.
+	Logger log.Wrapper
 }
 
 // ValidateAndSetDefaults checks the ServerArgs for any errors and sets any
@@ -184,6 +189,7 @@ func (args ServerArgs) SetupEndpoints() (ServerArgs, error) {
 	wrappers := DefaultMiddleware(DefaultMiddlewareArgs{
 		TrustHandler:    args.TrustHandler,
 		EdgeContextImpl: args.Baseplate.EdgeContextImpl(),
+		Logger:          args.Logger,
 	})
 	wrappers = append(wrappers, args.Middlewares...)
 

--- a/httpbp/server_test.go
+++ b/httpbp/server_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -255,6 +256,7 @@ func TestServerArgsSetupEndpoints(t *testing.T) {
 					edgecontextRecorderMiddleware(&recorder),
 				},
 				TrustHandler: httpbp.AlwaysTrustHeaders{},
+				Logger:       log.TestWrapper(t),
 			}
 
 			args, err := args.SetupEndpoints()


### PR DESCRIPTION
We forgot to do base64 decoding when handling the edge request header.