### PR TITLE
thriftbp: Minor doc comment fix

### DIFF
--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -39,7 +39,7 @@ type DefaultProcessorMiddlewaresArgs struct {
 }
 
 // BaseplateDefaultProcessorMiddlewares returns the default processor
-//  middlewares that should be used by a baseplate Thrift service.
+// middlewares that should be used by a baseplate Thrift service.
 //
 // Currently they are (in order):
 //


### PR DESCRIPTION
Currently it's wrongly rendered as code block because of the extra
space [1].

[1] https://pkg.go.dev/github.com/reddit/baseplate.go/thriftbp@v0.3.1?tab=doc#BaseplateDefaultProcessorMiddlewares