### PR TITLE
Remove deprecated metrics

### DIFF
--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	success = "success"
-	fail    = "fail"
 	failure = "failure"
 	total   = "total"
 )
@@ -33,7 +32,7 @@ func (h CreateServerSpanHook) OnCreateServerSpan(span *tracing.Span) error {
 	return nil
 }
 
-// spanHook wraps a Span in a Timer and records a "success" or "fail"/"failure"
+// spanHook wraps a Span in a Timer and records a "total" and "success"/"failure"
 // metric when the Span ends based on whether an error was passed to `span.End`
 // or not.
 type spanHook struct {
@@ -71,9 +70,9 @@ func (h *spanHook) OnPostStart(span *tracing.Span) error {
 }
 
 // OnPreStop stops the Timer started in OnPostStart and records a metric
-// indicating if the span was a "success" or "fail".
+// indicating if the span was a "success" or "failure".
 //
-// A span is marked as "fail" if `err != nil` otherwise it is marked as
+// A span is marked as "failure" if `err != nil` otherwise it is marked as
 // "success".
 func (h *spanHook) OnPreStop(span *tracing.Span, err error) error {
 	var duration time.Duration
@@ -87,8 +86,6 @@ func (h *spanHook) OnPreStop(span *tracing.Span, err error) error {
 	var statusMetricPath string
 	if err != nil {
 		statusMetricPath = fmt.Sprintf("%s.%s", h.name, failure)
-		// temp: publish both "fail" and "failure"
-		h.metrics.Counter(fmt.Sprintf("%s.%s", h.name, fail)).Add(1)
 	} else {
 		statusMetricPath = fmt.Sprintf("%s.%s", h.name, success)
 	}

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -91,7 +91,7 @@ func TestOnCreateServerSpan(t *testing.T) {
 	)
 
 	t.Run(
-		"fail",
+		"failure",
 		func(t *testing.T) {
 			counter, statusCounters, histogram := runSpan(t, st, fmt.Errorf("test error"))
 
@@ -101,7 +101,6 @@ func TestOnCreateServerSpan(t *testing.T) {
 			}
 
 			expected := []string{
-				"server.foo.fail:1.000000|c",
 				"server.foo.failure:1.000000|c",
 				"server.foo.total:1.000000|c",
 			}

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -347,10 +347,6 @@ func newClient(
 }
 
 func reportPoolStats(ctx context.Context, prefix string, pool clientpool.Pool, tickerDuration time.Duration, tags []string) {
-	// TODO: Remove deprecated gauges
-	activeGaugeDeprecated := metricsbp.M.Gauge(prefix + ".pool-active-connections").With(tags...)
-	allocatedGaugeDeprecated := metricsbp.M.Gauge(prefix + ".pool-allocated-clients").With(tags...)
-
 	activeGauge := metricsbp.M.RuntimeGauge(prefix + ".pool-active-connections").With(tags...)
 	allocatedGauge := metricsbp.M.RuntimeGauge(prefix + ".pool-allocated-clients").With(tags...)
 
@@ -364,9 +360,7 @@ func reportPoolStats(ctx context.Context, prefix string, pool clientpool.Pool, t
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			activeGaugeDeprecated.Set(float64(pool.NumActiveClients()))
 			activeGauge.Set(float64(pool.NumActiveClients()))
-			allocatedGaugeDeprecated.Set(float64(pool.NumAllocated()))
 			allocatedGauge.Set(float64(pool.NumAllocated()))
 		}
 	}


### PR DESCRIPTION
We deprecated some metrics, but kept them for easier transition. This
change actually removes them.

This change will be merged right before the v0.5.0 release.