### PR TITLE
Fix infinite recursion in unknown experiment error

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -357,7 +357,7 @@ type Variant struct {
 type UnknownExperimentError string
 
 func (name UnknownExperimentError) Error() string {
-	return "experiments: experiment with name" + string(name) + " unknown"
+	return "experiments: experiment with name " + string(name) + " unknown"
 }
 
 func isSimpleExperiment(experimentType string) bool {

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -357,7 +357,7 @@ type Variant struct {
 type UnknownExperimentError string
 
 func (name UnknownExperimentError) Error() string {
-	return fmt.Sprintf("experiments: experiment with name %s unknown", name)
+	return "experiments: experiment with name" + string(name) + " unknown"
 }
 
 func isSimpleExperiment(experimentType string) bool {


### PR DESCRIPTION
The existing error string construction results in a recursive invocation to itself. This fixes it.