### PR TITLE
retrybp: Exclude context.DeadlineExceeded from NetworkErrorFilter

### DIFF
--- a/retrybp/filters.go
+++ b/retrybp/filters.go
@@ -77,7 +77,7 @@ func ContextErrorFilter(err error, next retry.RetryIfFunc) bool {
 // between sending and receiving since you have no way of knowing if the callee
 // receieved and is already processing your request.
 func NetworkErrorFilter(err error, next retry.RetryIfFunc) bool {
-	if errors.As(err, new(net.Error)) {
+	if !errors.Is(err, context.DeadlineExceeded) && errors.As(err, new(net.Error)) {
 		return true
 	}
 	return next(err)

--- a/retrybp/filters_test.go
+++ b/retrybp/filters_test.go
@@ -224,6 +224,12 @@ func TestNetworkErrorFilter(t *testing.T) {
 			expected: 1,
 		},
 		{
+			// See: https://github.com/reddit/baseplate.go/issues/257
+			name:     "regression-257",
+			err:      context.DeadlineExceeded,
+			expected: 1,
+		},
+		{
 			name:     "net.AddrError",
 			err:      &net.AddrError{},
 			expected: maxAttempts,


### PR DESCRIPTION
context.DeadlineExceeded can be converted to net.Error [1], so we need
to either make sure people always use ContextErrorFilter before
NetworkErrorFilter, which is not ideal, or this.

[1]: https://play.golang.org/p/wGfQvUejHQ7