### PR TITLE
log: Add ctx to Wrapper API

### DIFF
--- a/breakerbp/failure_ratio.go
+++ b/breakerbp/failure_ratio.go
@@ -113,12 +113,11 @@ func (cb FailureRatioBreaker) ThriftMiddleware(next thrift.TClient) thrift.TClie
 
 // ShouldTrip checks if the circuit breaker should be tripped, based on the provided breaker counts.
 func (cb FailureRatioBreaker) shouldTrip(counts gobreaker.Counts) bool {
-
 	if counts.Requests > 0 && counts.Requests >= uint32(cb.minRequestsToTrip) {
 		failureRatio := float64(counts.TotalFailures) / float64(counts.Requests)
 		if failureRatio >= cb.failureThreshold {
 			message := fmt.Sprintf("tripping circuit breaker: name=%v, counts=%v", cb.name, counts)
-			cb.logger.Log(message)
+			cb.logger.Log(context.Background(), message)
 			return true
 		}
 	}
@@ -127,5 +126,5 @@ func (cb FailureRatioBreaker) shouldTrip(counts gobreaker.Counts) bool {
 
 func (cb FailureRatioBreaker) stateChanged(name string, from gobreaker.State, to gobreaker.State) {
 	message := fmt.Sprintf("circuit breaker %v state changed from %v to %v", name, from, to)
-	cb.logger.Log(message)
+	cb.logger.Log(context.Background(), message)
 }

--- a/edgecontext/edgecontext.go
+++ b/edgecontext/edgecontext.go
@@ -158,6 +158,7 @@ func New(ctx context.Context, impl *Impl, args NewArgs) (*EdgeRequestContext, er
 		impl:   impl,
 		header: header,
 		raw:    args,
+		ctx:    ctx,
 	}, nil
 }
 
@@ -196,5 +197,6 @@ func FromHeader(ctx context.Context, header string, impl *Impl) (*EdgeRequestCon
 		impl:   impl,
 		header: header,
 		raw:    raw,
+		ctx:    ctx,
 	}, nil
 }

--- a/edgecontext/req_context.go
+++ b/edgecontext/req_context.go
@@ -1,6 +1,7 @@
 package edgecontext
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -32,7 +33,7 @@ func (e *EdgeRequestContext) AuthToken() *AuthenticationToken {
 		if token, err := e.impl.ValidateToken(e.raw.AuthToken); err != nil {
 			// empty jwt token is considered "normal", no need to spam them in logs.
 			if !errors.Is(err, ErrEmptyToken) {
-				e.impl.logger.Log("token validation failed: " + err.Error())
+				e.impl.logger.Log(context.Background(), "token validation failed: "+err.Error())
 			}
 			e.token = nil
 		} else {
@@ -127,7 +128,7 @@ func (e *EdgeRequestContext) UpdateExperimentEvent(ee *experiments.ExperimentEve
 		ee.DeviceID, err = uuid.FromString(deviceID)
 		if err != nil {
 			ee.DeviceID = uuid.Nil
-			e.impl.logger.Log(fmt.Sprintf(
+			e.impl.logger.Log(context.Background(), fmt.Sprintf(
 				"Failed to parse device id %q into uuid: %v",
 				deviceID,
 				err,

--- a/edgecontext/validator.go
+++ b/edgecontext/validator.go
@@ -1,6 +1,7 @@
 package edgecontext
 
 import (
+	"context"
 	"crypto/rsa"
 	"errors"
 	"fmt"
@@ -77,7 +78,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 
 		versioned, err := sec.GetVersionedSecret(authenticationPubKeySecretPath)
 		if err != nil {
-			impl.logger.Log(fmt.Sprintf(
+			impl.logger.Log(context.Background(), fmt.Sprintf(
 				"Failed to get secrets %q: %v",
 				authenticationPubKeySecretPath,
 				err,
@@ -90,7 +91,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 		for i, v := range all {
 			key, err := jwt.ParseRSAPublicKeyFromPEM([]byte(v))
 			if err != nil {
-				impl.logger.Log(fmt.Sprintf(
+				impl.logger.Log(context.Background(), fmt.Sprintf(
 					"Failed to parse key #%d: %v",
 					i,
 					err,
@@ -101,7 +102,7 @@ func (impl *Impl) validatorMiddleware(next secrets.SecretHandlerFunc) secrets.Se
 		}
 
 		if len(keys) == 0 {
-			impl.logger.Log("No valid keys in secrets store.")
+			impl.logger.Log(context.Background(), "No valid keys in secrets store.")
 			return
 		}
 

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -90,7 +90,7 @@ func (r *Result) watcherLoop(
 			return
 
 		case err := <-watcher.Errors:
-			logger.Log("watcher error: " + err.Error())
+			logger.Log(context.Background(), "watcher error: "+err.Error())
 
 		case ev := <-watcher.Events:
 			if filepath.Base(ev.Name) != file {
@@ -105,12 +105,12 @@ func (r *Result) watcherLoop(
 				func() {
 					f, err := os.Open(path)
 					if err != nil {
-						logger.Log("parser error: " + err.Error())
+						logger.Log(context.Background(), "parser error: "+err.Error())
 					}
 					defer f.Close()
 					d, err := parser(f)
 					if err != nil {
-						logger.Log("parser error: " + err.Error())
+						logger.Log(context.Background(), "parser error: "+err.Error())
 					} else {
 						r.data.Store(d)
 					}

--- a/filewatcher/filewatcher_test.go
+++ b/filewatcher/filewatcher_test.go
@@ -215,7 +215,7 @@ func TestParserFailure(t *testing.T) {
 		return value, nil
 	}
 	var loggerCalled int64
-	logger := func(msg string) {
+	logger := func(_ context.Context, msg string) {
 		atomic.StoreInt64(&loggerCalled, 1)
 		t.Log(msg)
 	}

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -158,12 +158,12 @@ func InitializeEdgeContextFromTrustedRequest(
 
 	header, err := decodeEdgeContextHeader(r.Header.Get(EdgeContextHeader))
 	if err != nil {
-		args.Logger.Log("Error while parsing EdgeRequestContext: " + err.Error())
+		args.Logger.Log(ctx, "Error while parsing EdgeRequestContext: "+err.Error())
 		return ctx
 	}
 	ec, err := edgecontext.FromHeader(ctx, string(header), args.EdgeContextImpl)
 	if err != nil {
-		args.Logger.Log("Error while parsing EdgeRequestContext: " + err.Error())
+		args.Logger.Log(ctx, "Error while parsing EdgeRequestContext: "+err.Error())
 		return ctx
 	}
 

--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/log",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_apache_thrift//lib/go/thrift:go_default_library",
         "@com_github_getsentry_sentry_go//:go_default_library",
         "@org_uber_go_zap//:go_default_library",
         "@org_uber_go_zap//zapcore:go_default_library",

--- a/log/wrapper_test.go
+++ b/log/wrapper_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/reddit/baseplate.go/log"
@@ -9,5 +10,7 @@ import (
 func TestLogWrapperNilSafe(t *testing.T) {
 	// Just make sure log.Wrapper.Log is nil-safe, no real tests
 	var logger log.Wrapper
-	logger.Log("Hello, world!")
+	logger.Log(context.Background(), "Hello, world!")
+	logger.ToThriftLogger()("Hello, world!")
+	log.WrapToThriftLogger(nil)("Hello, world!")
 }

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -294,7 +294,8 @@ func newClientPool(
 			)
 			if fallbackErr == nil {
 				cfg.InitialConnectionsFallbackLogger.Log(
-					"thriftbp: error initializing thrift clientpool but fallback to 0 initial connections worked. Original error: " + err.Error(),
+					context.Background(),
+					"thriftbp: error initializing thrift clientpool but fallback to 0 initial connections worked. Original error: "+err.Error(),
 				)
 				err = nil
 			} else {

--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -1,6 +1,7 @@
 package thriftbp_test
 
 import (
+	"context"
 	"errors"
 	"net"
 	"sync/atomic"
@@ -90,7 +91,7 @@ func TestInitialConnectionsFallback(t *testing.T) {
 	}
 
 	var loggerCalled int64
-	logger := func(msg string) {
+	logger := func(_ context.Context, msg string) {
 		t.Logf("InitialConnectionsFallbackLogger called with %q", msg)
 		atomic.StoreInt64(&loggerCalled, 1)
 	}

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -120,7 +120,7 @@ func NewBaseplateServer(
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)
 	cfg.Middlewares = middlewares
-	cfg.Logger = thrift.Logger(log.ZapWrapper(bp.Config().Log.Level))
+	cfg.Logger = log.ZapWrapper(bp.Config().Log.Level).ToThriftLogger()
 	cfg.Addr = bp.Config().Addr
 	cfg.Timeout = bp.Config().Timeout
 	cfg.Socket = nil

--- a/tracing/hooks.go
+++ b/tracing/hooks.go
@@ -1,5 +1,9 @@
 package tracing
 
+import (
+	"context"
+)
+
 // CreateServerSpanHook allows you to inject functionality into the lifecycle of a
 // Baseplate request.
 type CreateServerSpanHook interface {
@@ -89,6 +93,7 @@ func ResetHooks() {
 func onCreateServerSpan(span *Span) {
 	if span.SpanType() != SpanTypeServer {
 		span.logError(
+			context.Background(),
 			"OnCreateServerSpan called on non-server Span: ",
 			&InvalidSpanTypeError{
 				ExpectedSpanType: SpanTypeServer,
@@ -100,7 +105,7 @@ func onCreateServerSpan(span *Span) {
 
 	for _, hook := range createServerSpanHooks {
 		if err := hook.OnCreateServerSpan(span); err != nil {
-			span.logError("OnCreateServerSpan hook error: ", err)
+			span.logError(context.Background(), "OnCreateServerSpan hook error: ", err)
 		}
 	}
 }

--- a/tracing/log.go
+++ b/tracing/log.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/reddit/baseplate.go/log"
@@ -16,7 +17,7 @@ import (
 // and only start failing the test after startFailing is called.
 func TestWrapper(tb testing.TB) (logger log.Wrapper, startFailing func()) {
 	logf := tb.Logf
-	logger = func(msg string) {
+	logger = func(_ context.Context, msg string) {
 		logf("logger called with msg: %q", msg)
 	}
 	startFailing = func() {

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -17,7 +17,7 @@ const testTimeout = time.Millisecond * 100
 func TestTracer(t *testing.T) {
 	loggerFunc := func(t *testing.T) (logger log.Wrapper, called *bool) {
 		called = new(bool)
-		logger = func(msg string) {
+		logger = func(_ context.Context, msg string) {
 			*called = true
 			t.Logf("Logger called with msg: %q", msg)
 		}


### PR DESCRIPTION
This allows zap wrapper implementations to take advantage and don't lose
trace id when using Wrapper API to do logging.

This is a breaking change, but since log.Wrapper API is only supposed to
be used internally, for most users the breaking part is only that it can
no longer directly cast into thrift.Logger.