### PR TITLE
Bazel updates

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 GO_VERSION = "1.14.6"
 
 # For rules_go
-RULES_GO_VERSION = "v0.23.5"
+RULES_GO_VERSION = "v0.23.6"
 
 http_archive(
     name = "io_bazel_rules_go",
@@ -13,7 +13,7 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/%s/rules_go-%s.tar.gz" % (RULES_GO_VERSION, RULES_GO_VERSION),
         "https://github.com/bazelbuild/rules_go/releases/download/%s/rules_go-%s.tar.gz" % (RULES_GO_VERSION, RULES_GO_VERSION),
     ],
-    sha256 = "2d536797707dd1697441876b2e862c58839f975c8fc2f0f96636cbd428f45866",
+    sha256 = "8663604808d2738dc615a2c3eb70eba54a9a982089dd09f6ffe5d0e75771bc4f",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/breakerbp/BUILD.bazel
+++ b/breakerbp/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["failure_ratio_test.go"],
     embed = [":go_default_library"],
     deps = [


### PR DESCRIPTION
Upgrade rules_go to v0.23.6, which fixed
https://github.com/bazelbuild/rules_go/issues/1877 that's affecting us.

Also add 'size = "small"' to breakerbp's test target.