### PR TITLE
errorsbp: Add Batch.AddPrefix

### DIFF
--- a/errorsbp/BUILD.bazel
+++ b/errorsbp/BUILD.bazel
@@ -15,8 +15,8 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "batch_example_test.go",
         "batch_test.go",
-        "doc_test.go",
         "suppressor_example_test.go",
         "suppressor_test.go",
     ],

--- a/errorsbp/batch_test.go
+++ b/errorsbp/batch_test.go
@@ -11,28 +11,28 @@ import (
 func TestAdd(t *testing.T) {
 	var err errorsbp.Batch
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("A new BatchError should contain zero errors: %v", err.GetErrors())
+		t.Errorf("A new BatchError should contain zero errors: %#v", err.GetErrors())
 	}
 
 	err.Add(nil)
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("Nil errors should be skipped: %v", err.GetErrors())
+		t.Errorf("Nil errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err0 := errors.New("foo")
 	err.Add(err0)
 	if len(err.GetErrors()) != 1 {
-		t.Errorf("Non-nil errors should be added to the batch: %v", err.GetErrors())
+		t.Errorf("Non-nil errors should be added to the batch: %#v", err.GetErrors())
 	}
 	actual := err.GetErrors()[0]
 	if actual != err0 {
-		t.Errorf("Expected %#v, got %#v", err0, actual)
+		t.Errorf("Expected %v, got %v", err0, actual)
 	}
 
 	var another errorsbp.Batch
 	err.Add(another)
 	if len(err.GetErrors()) != 1 {
-		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
+		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err1 := errors.New("bar")
 	another.Add(err1)
@@ -41,26 +41,26 @@ func TestAdd(t *testing.T) {
 	err.Add(another)
 	if len(err.GetErrors()) != 3 {
 		t.Errorf(
-			"The underlying errors should be added instead of the batch: %v",
+			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
 		)
 	}
 
 	batch := err.GetErrors()
 	if batch[0] != err0 {
-		t.Errorf("Expected %#v, got %#v", err0, batch[0])
+		t.Errorf("Expected %v, got %v", err0, batch[0])
 	}
 	if batch[1] != err1 {
-		t.Errorf("Expected %#v, got %#v", err1, batch[1])
+		t.Errorf("Expected %v, got %v", err1, batch[1])
 	}
 	if batch[2] != err2 {
-		t.Errorf("Expected %#v, got %#v", err2, batch[2])
+		t.Errorf("Expected %v, got %v", err2, batch[2])
 	}
 
 	err.Clear()
 	if len(err.GetErrors()) != 0 {
 		t.Errorf(
-			"A cleared BatchError should contain zero errors: %v",
+			"A cleared BatchError should contain zero errors: %#v",
 			err.GetErrors(),
 		)
 	}
@@ -68,7 +68,7 @@ func TestAdd(t *testing.T) {
 	pointer := new(errorsbp.Batch)
 	err.Add(pointer)
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
+		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err1 = errors.New("bar")
 	pointer.Add(err1)
@@ -77,7 +77,7 @@ func TestAdd(t *testing.T) {
 	err.Add(pointer)
 	if len(err.GetErrors()) != 2 {
 		t.Errorf(
-			"The underlying errors should be added instead of the batch: %v",
+			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
 		)
 	}
@@ -86,17 +86,17 @@ func TestAdd(t *testing.T) {
 func TestAddMultiple(t *testing.T) {
 	var err errorsbp.Batch
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("A new BatchError should contain zero errors: %v", err.GetErrors())
+		t.Errorf("A new BatchError should contain zero errors: %#v", err.GetErrors())
 	}
 
 	err.Add()
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("empty errors should be skipped: %v", err.GetErrors())
+		t.Errorf("empty errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err.Add(nil, nil)
 	if len(err.GetErrors()) != 0 {
-		t.Errorf("empty errors should be skipped: %v", err.GetErrors())
+		t.Errorf("empty errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err0 := errors.New("foo")
@@ -107,17 +107,17 @@ func TestAddMultiple(t *testing.T) {
 	}
 	actual0 := err.GetErrors()[0]
 	if actual0 != err0 {
-		t.Errorf("Expected %#v, got %#v", err0, actual0)
+		t.Errorf("Expected %v, got %v", err0, actual0)
 	}
 	actual1 := err.GetErrors()[1]
 	if actual1 != err1 {
-		t.Errorf("Expected %#v, got %#v", err1, actual1)
+		t.Errorf("Expected %v, got %v", err1, actual1)
 	}
 
 	var another errorsbp.Batch
 	err.Add(another)
 	if len(err.GetErrors()) != 2 {
-		t.Errorf("Empty batch should be skipped: %v", err.GetErrors())
+		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err2 := errors.New("fizz")
 	err3 := errors.New("buzz")
@@ -126,26 +126,26 @@ func TestAddMultiple(t *testing.T) {
 	err.Add(another, err4)
 	if len(err.GetErrors()) != 5 {
 		t.Errorf(
-			"The underlying errors should be added instead of the batch: %v",
+			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
 		)
 	}
 
 	batch := err.GetErrors()
 	if batch[0] != err0 {
-		t.Errorf("Expected %#v, got %#v", err0, batch[0])
+		t.Errorf("Expected %v, got %v", err0, batch[0])
 	}
 	if batch[1] != err1 {
-		t.Errorf("Expected %#v, got %#v", err1, batch[1])
+		t.Errorf("Expected %v, got %v", err1, batch[1])
 	}
 	if batch[2] != err2 {
-		t.Errorf("Expected %#v, got %#v", err2, batch[2])
+		t.Errorf("Expected %v, got %v", err2, batch[2])
 	}
 	if batch[3] != err3 {
-		t.Errorf("Expected %#v, got %#v", err3, batch[3])
+		t.Errorf("Expected %v, got %v", err3, batch[3])
 	}
 	if batch[4] != err4 {
-		t.Errorf("Expected %#v, got %#v", err4, batch[4])
+		t.Errorf("Expected %v, got %v", err4, batch[4])
 	}
 }
 
@@ -157,13 +157,13 @@ func TestCompile(t *testing.T) {
 
 	err := batch.Compile()
 	if err != nil {
-		t.Errorf("An empty batch should be compiled to nil, got: %#v", err)
+		t.Errorf("An empty batch should be compiled to nil, got: %v", err)
 	}
 	batch.Add(err0)
 	err = batch.Compile()
 	if err != err0 {
 		t.Errorf(
-			"A single error batch should be compiled to %#v, got %#v",
+			"A single error batch should be compiled to %v, got %v",
 			err0,
 			err,
 		)
@@ -173,12 +173,12 @@ func TestCompile(t *testing.T) {
 	err = batch.Compile()
 	expect := "errorsbp.Batch: total 3 error(s) in this batch: foo; bar; foobar"
 	if err.Error() != expect {
-		t.Errorf("Compiled error expected %#v, got %#v", expect, err)
+		t.Errorf("Compiled error expected %q, got %v", expect, err)
 	}
 
 	errString := batch.Error()
 	if errString != expect {
-		t.Errorf("Compiled error expected %#v, got %#v", expect, errString)
+		t.Errorf("Compiled error expected %q, got %q", expect, errString)
 	}
 }
 
@@ -205,5 +205,63 @@ func TestGetErrors(t *testing.T) {
 			expect,
 			errs,
 		)
+	}
+}
+
+func TestAddPrefix(t *testing.T) {
+	const (
+		prefix1 = "prefix1"
+		prefix2 = "pre%sfix2"
+
+		separator = ": "
+
+		msg0 = "foo"
+		msg1 = "bar"
+		msg2 = "foobar"
+	)
+	var batch errorsbp.Batch
+	err0 := errors.New(msg0)
+	err1 := errors.New(msg1)
+	err2 := errors.New(msg2)
+
+	batch.AddPrefix(prefix1, nil)
+	if len(batch.GetErrors()) != 0 {
+		t.Errorf("Nil errors should be skipped: %#v", batch.GetErrors())
+	}
+
+	batch.AddPrefix(prefix1, err0)
+	if len(batch.GetErrors()) != 1 {
+		t.Errorf("Non-nil errors should be added to the batch: %#v", batch.GetErrors())
+	}
+
+	if !errors.Is(batch, err0) {
+		t.Errorf("Expected batch to contain %v, got false: %#v", err0, batch.GetErrors())
+	}
+
+	var batch2 errorsbp.Batch
+	batch2.AddPrefix(prefix2, err1)
+	batch2.AddPrefix("", err2)
+
+	batch.AddPrefix(prefix1, batch2)
+	errs := batch.GetErrors()
+	if !errors.Is(batch, err1) {
+		t.Errorf("Expected batch to contain %v, got false: %#v", err1, errs)
+	}
+	if !errors.Is(batch, err2) {
+		t.Errorf("Expected batch to contain %v, got false: %#v", err2, errs)
+	}
+	if len(errs) != 3 {
+		t.Fatalf("Expected Batch to be flattened while using AddPrefix, got: %#v", errs)
+	}
+
+	expectedMsgs := []string{
+		prefix1 + separator + msg0,
+		prefix1 + separator + prefix2 + separator + msg1,
+		prefix1 + separator + msg2,
+	}
+	for i, err := range errs {
+		if err.Error() != expectedMsgs[i] {
+			t.Errorf("Expected %dth error to be %q, got %v", i, expectedMsgs[i], err)
+		}
 	}
 }


### PR DESCRIPTION
Also deprecate batchcloser.CloseError, and change
batchcloser.BatchCloser to use AddPrefix instead of CloseError.