### PR TITLE
log: Send extra key values to sentry in ErrorWithSentry

### DIFF
--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -28,8 +28,13 @@ go_test(
     srcs = [
         "kit_wrapper_test.go",
         "log_test.go",
+        "sentry_test.go",
         "wrapper_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@com_github_go_kit_kit//log:go_default_library"],
+    deps = [
+        "@com_github_go_kit_kit//log:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
+    ],
 )

--- a/log/log.go
+++ b/log/log.go
@@ -1,9 +1,6 @@
 package log
 
 import (
-	"context"
-
-	sentry "github.com/getsentry/sentry-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -239,24 +236,4 @@ func Sync() error {
 // With wraps around the underline logger's With.
 func With(args ...interface{}) *zap.SugaredLogger {
 	return globalLogger.With(args...)
-}
-
-// ErrorWithSentry logs a message with some additional context,
-// then sends the error to Sentry.
-//
-// The variadic key-value pairs are treated as they are in With.
-//
-// If a sentry hub is attached to the context object passed in
-// (it will be if the context object is from baseplate hooked request context),
-// that hub will be used to do the reporting.
-// Otherwise the global sentry hub will be used instead.
-func ErrorWithSentry(ctx context.Context, msg string, err error, keysAndValues ...interface{}) {
-	keysAndValues = append(keysAndValues, "err", err)
-	C(ctx).Errorw(msg, keysAndValues...)
-
-	if hub := sentry.GetHubFromContext(ctx); hub != nil {
-		hub.CaptureException(err)
-	} else {
-		sentry.CaptureException(err)
-	}
 }

--- a/log/sentry_test.go
+++ b/log/sentry_test.go
@@ -1,0 +1,127 @@
+package log
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type pair struct {
+	key, value string
+}
+
+func TestExtractKeyValuePairs(t *testing.T) {
+	for _, c := range []struct {
+		label    string
+		kv       []interface{}
+		expected []pair
+		dangling bool
+	}{
+		{
+			label: "empty",
+		},
+		{
+			label: "normal",
+			kv: []interface{}{
+				"key1", "value1",
+				"key2", 2,
+				"key3", 3.14,
+			},
+			expected: []pair{
+				{
+					key:   "key1",
+					value: "value1",
+				},
+				{
+					key:   "key2",
+					value: "2",
+				},
+				{
+					key:   "key3",
+					value: "3.14",
+				},
+			},
+		},
+		{
+			label: "ignore-zap-field",
+			kv: []interface{}{
+				"key1", "value1",
+				"key2", "value2",
+				zap.Field{},     // will be ignored
+				zapcore.Field{}, // will be ignored
+			},
+			expected: []pair{
+				{
+					key:   "key1",
+					value: "value1",
+				},
+				{
+					key:   "key2",
+					value: "value2",
+				},
+			},
+		},
+		{
+			label: "dangling",
+			kv: []interface{}{
+				"key1", "value1",
+				"dangling",
+			},
+			expected: []pair{
+				{
+					key:   "key1",
+					value: "value1",
+				},
+			},
+			dangling: true,
+		},
+		{
+			label: "dangling-with-field",
+			kv: []interface{}{
+				"key1", "value1",
+				zap.Field{},
+				"dangling",
+			},
+			expected: []pair{
+				{
+					key:   "key1",
+					value: "value1",
+				},
+			},
+			dangling: true,
+		},
+	} {
+		t.Run(
+			c.label,
+			func(t *testing.T) {
+				var called int
+				f := func(key, value string) {
+					t.Helper()
+					defer func() {
+						called++
+					}()
+					if called >= len(c.expected) {
+						t.Errorf("Extra call with (%q, %q)", key, value)
+						return
+					}
+					if c.expected[called].key != key || c.expected[called].value != value {
+						t.Errorf(
+							"Expected %#v on %dth call, got (%q, %q)",
+							c.expected[called],
+							called,
+							key, value,
+						)
+					}
+				}
+				dangling := extractKeyValuePairs(c.kv, f)
+				if dangling != c.dangling {
+					t.Errorf("Expected dangling to return %v, got %v", c.dangling, dangling)
+				}
+				if called < len(c.expected) {
+					t.Errorf("Expected %d calls, got %v", len(c.expected), called)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
Also move ErrorWithSentry from log.go to sentry.go.