### PR TITLE
Add struct arg with optional pre- and postShutdown closers to Serve()

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -96,9 +96,12 @@ type ServeArgs struct {
 //
 // It uses runtimebp.HandleShutdown to handle the signal and gracefully shut
 // down, in order:
-//     * any provided PreShutdown closers,
-//     * the Server, and
-//     * any provided PostShutdown closers.
+//
+// * any provided PreShutdown closers,
+//
+// * the Server, and
+//
+// * any provided PostShutdown closers.
 //
 // Returns the (possibly nil) error returned by "Close", or
 // context.DeadlineExceeded if it times out.

--- a/baseplate.go
+++ b/baseplate.go
@@ -79,16 +79,16 @@ type Server interface {
 
 // ServeArgs provides a list of arguments to Serve.
 type ServeArgs struct {
-	// Server: Mandatory. Indicates the Server that should be run until receiving
-	// a shutdown signal.
+	// Server is the Server that should be run until receiving a shutdown signal.
+	// This is a required argument and baseplate.Serve will panic if this is nil.
 	Server Server
 
-	// PreShutdown: Optional. Indicates a slice of io.Closers that should be
-	// gracefully shut down before the server upon receipt of a shutdown signal.
+	// PreShutdown is an optional slice of io.Closers that should be gracefully
+	// shut down before the server upon receipt of a shutdown signal.
 	PreShutdown []io.Closer
 
-	// PostShutdown: Optional. Indicates a slice of io.Closers that should be
-	// gracefully shut down after the server upon receipt of a shutdown signal.
+	// PostShutdown is an optional slice of io.Closers that should be gracefully
+	// shut down after the server upon receipt of a shutdown signal.
 	PostShutdown []io.Closer
 }
 

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -200,7 +200,7 @@ func TestServeClosers(t *testing.T) {
 	}
 
 	if !pre.ts[0].Before(post.ts[0]) {
-		t.Fatalf(
+		t.Errorf(
 			"PreShutdown finished after PostShutdown: pre: %v, post: %v",
 			pre.ts[0],
 			post.ts[0],

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -196,7 +196,7 @@ func TestServeClosers(t *testing.T) {
 		t.Fatalf("Unexpected number of PreShutdown calls: expected 1, got %v", len(pre.ts))
 	}
 	if len(post.ts) != 1 {
-		t.Fatalf("Unexpected number of PostShutdown calls: expected 1, got %v", len(pre.ts))
+		t.Fatalf("Unexpected number of PostShutdown calls: expected 1, got %v", len(post.ts))
 	}
 
 	if !pre.ts[0].Before(post.ts[0]) {

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -123,9 +123,11 @@ func TestServe(t *testing.T) {
 			c.name,
 			func(t *testing.T) {
 				ch := make(chan error)
+
+				args := baseplate.ServeArgs{Server: c.server}
 				go func() {
 					// Run Serve in a goroutine since it is blocking
-					ch <- baseplate.Serve(context.Background(), c.server)
+					ch <- baseplate.Serve(context.Background(), args)
 				}()
 
 				time.Sleep(time.Millisecond)

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -178,17 +178,17 @@ func TestServeClosers(t *testing.T) {
 
 	ch := make(chan error)
 
+	p, err := os.FindProcess(syscall.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	go func() {
 		// Run Serve in a goroutine since it is blocking
 		ch <- baseplate.Serve(context.Background(), args)
 	}()
 
 	time.Sleep(time.Millisecond)
-	p, err := os.FindProcess(syscall.Getpid())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	p.Signal(os.Interrupt)
 	<-ch
 

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -124,10 +124,12 @@ func TestServe(t *testing.T) {
 			func(t *testing.T) {
 				ch := make(chan error)
 
-				args := baseplate.ServeArgs{Server: c.server}
 				go func() {
 					// Run Serve in a goroutine since it is blocking
-					ch <- baseplate.Serve(context.Background(), args)
+					ch <- baseplate.Serve(
+						context.Background(),
+						baseplate.ServeArgs{Server: c.server},
+					)
 				}()
 
 				time.Sleep(time.Millisecond)

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -107,8 +107,9 @@ func ExampleNewBaseplateServer() {
 		Endpoints:   handlers.Endpoints(),
 		Middlewares: []httpbp.Middleware{loggingMiddleware},
 	})
+	args := baseplate.ServeArgs{Server: server}
 	if err != nil {
 		panic(err)
 	}
-	log.Info(baseplate.Serve(ctx, server))
+	log.Info(baseplate.Serve(ctx, args))
 }

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -107,9 +107,8 @@ func ExampleNewBaseplateServer() {
 		Endpoints:   handlers.Endpoints(),
 		Middlewares: []httpbp.Middleware{loggingMiddleware},
 	})
-	args := baseplate.ServeArgs{Server: server}
 	if err != nil {
 		panic(err)
 	}
-	log.Info(baseplate.Serve(ctx, args))
+	log.Info(baseplate.Serve(ctx, baseplate.ServeArgs{Server: server}))
 }

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -26,10 +26,9 @@ func ExampleNewBaseplateServer() {
 	server, err := thriftbp.NewBaseplateServer(bp, thriftbp.ServerConfig{
 		Processor: processor,
 	})
-	args := baseplate.ServeArgs{Server: server}
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Info(baseplate.Serve(ctx, args))
+	log.Info(baseplate.Serve(ctx, baseplate.ServeArgs{Server: server}))
 }

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -26,9 +26,10 @@ func ExampleNewBaseplateServer() {
 	server, err := thriftbp.NewBaseplateServer(bp, thriftbp.ServerConfig{
 		Processor: processor,
 	})
+	args := baseplate.ServeArgs{Server: server}
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Info(baseplate.Serve(ctx, server))
+	log.Info(baseplate.Serve(ctx, args))
 }

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -95,7 +95,8 @@ type Server struct {
 // The server can be shut down manually using server.Close, with the shutdown
 // commands defined in runtimebp, or by cancelling the given context.
 func (s *Server) Start(ctx context.Context) {
-	go baseplate.Serve(ctx, s)
+	args := baseplate.ServeArgs{Server: s}
+	go baseplate.Serve(ctx, args)
 	time.Sleep(10 * time.Millisecond)
 }
 

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -95,8 +95,7 @@ type Server struct {
 // The server can be shut down manually using server.Close, with the shutdown
 // commands defined in runtimebp, or by cancelling the given context.
 func (s *Server) Start(ctx context.Context) {
-	args := baseplate.ServeArgs{Server: s}
-	go baseplate.Serve(ctx, args)
+	go baseplate.Serve(ctx, baseplate.ServeArgs{Server: s})
 	time.Sleep(10 * time.Millisecond)
 }
 


### PR DESCRIPTION
Add an argument struct to Serve(), allowing for optional slices of `io.Closers` that can shut down gracefully before and after the server.

-----

This is a precursor for adding queue consumers, so that they can be cleanly shutdown alongside the server.