### PR TITLE
Add path to file watcher error & disallow empty paths

### DIFF
--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -186,7 +186,7 @@ func New(ctx context.Context, cfg Config) (*Result, error) {
 		select {
 		default:
 		case <-ctx.Done():
-			return nil, fmt.Errorf("filewatcher: context cancelled while waiting for file to load. %w", ctx.Err())
+			return nil, fmt.Errorf("filewatcher: context cancelled while waiting for file under %q to load. %w", cfg.Path, ctx.Err())
 		}
 
 		var err error

--- a/secrets/errors.go
+++ b/secrets/errors.go
@@ -9,6 +9,9 @@ import (
 // encoding in the secrets.json file.
 var ErrInvalidEncoding = errors.New("secrets: invalid encoding, expected identity, base64 or empty")
 
+// ErrEmptySecretKey is returned when the path for a secret is empty.
+var ErrEmptySecretKey = errors.New("secrets: secret path cannot be empty")
+
 // TooManyFieldsError is a type of errors could be returned by
 // Document.Validate.
 //

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -38,6 +38,9 @@ type Secrets struct {
 
 // GetSimpleSecret fetches a simple secret or error if the key is not present.
 func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
+	if path == "" {
+		return SimpleSecret{}, ErrEmptySecretKey
+	}
 	secret, ok := s.simpleSecrets[path]
 	if !ok {
 		return secret, SecretNotFoundError(path)
@@ -48,6 +51,9 @@ func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
 
 // GetVersionedSecret fetches a versioned secret or error if the key is not present.
 func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
+	if path == "" {
+		return VersionedSecret{}, ErrEmptySecretKey
+	}
 	secret, ok := s.versionedSecrets[path]
 	if !ok {
 		return secret, SecretNotFoundError(path)
@@ -59,6 +65,9 @@ func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
 // GetCredentialSecret fetches a credential secret or error if the key is not
 // present.
 func (s *Secrets) GetCredentialSecret(path string) (CredentialSecret, error) {
+	if path == "" {
+		return CredentialSecret{}, ErrEmptySecretKey
+	}
 	secret, ok := s.credentialSecrets[path]
 	if !ok {
 		return secret, SecretNotFoundError(path)


### PR DESCRIPTION
I ran into this issue myself or have seen other run into it. Adding a path to the file watcher error message and disallowing empty paths to begin with could help give more directions when setting these things up or debugging them.