### PR TITLE
Cleanup %s usage in error messages

### DIFF
--- a/batchcloser/closers.go
+++ b/batchcloser/closers.go
@@ -23,7 +23,7 @@ type CloseError struct {
 
 // Error implements the interface for error.
 func (err CloseError) Error() string {
-	return fmt.Sprintf("batchcloser: error closing closer %#v : %s", err.Closer, err.Cause.Error())
+	return fmt.Sprintf("batchcloser: error closing closer %#v: %v", err.Closer, err.Cause)
 }
 
 // Unwrap implements helper interface for errors.Is.

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -35,7 +35,7 @@ type MissingBucketKeyError struct {
 
 func (e MissingBucketKeyError) Error() string {
 	return fmt.Sprintf(
-		"experiment: must specify %q in call to variant for experiment %s",
+		"experiment: must specify %q in call to variant for experiment %q",
 		e.ArgsKey,
 		e.ExperimentName,
 	)
@@ -128,7 +128,7 @@ func (e *Experiments) experiment(name string) (*SimpleExperiment, error) {
 		return NewSimpleExperiment(experiment)
 	}
 	return nil, fmt.Errorf(
-		"experiments.Experiments.Variant: unknown experiment %s",
+		"experiments.Experiments.Variant: unknown experiment %q",
 		experiment.Type,
 	)
 }

--- a/httpbp/response.go
+++ b/httpbp/response.go
@@ -158,7 +158,7 @@ func HTMLContentWriter(templates *template.Template) ContentWriter {
 
 			var t *template.Template
 			if t = templates.Lookup(htmlBody.TemplateName()); t == nil {
-				return fmt.Errorf("httpbp: no html template with name %s", htmlBody.TemplateName())
+				return fmt.Errorf("httpbp: no html template with name %q", htmlBody.TemplateName())
 			}
 
 			return t.Execute(w, htmlBody)

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -99,18 +99,18 @@ func numCPUSharesFallback() (n float64) {
 func readNumberFromFile(path string, buf []byte) (float64, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to open %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to open %q: %w", path, err)
 	}
 	defer file.Close()
 
 	n, err := file.Read(buf)
 	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to read %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to read %q: %w", path, err)
 	}
 
 	f, err := strconv.ParseInt(strings.TrimSpace(string(buf[:n])), 10, 64)
 	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to parse %s: %w", path, err)
+		return 0, fmt.Errorf("runtimebp: failed to parse %q: %w", path, err)
 	}
 	return float64(f), nil
 }

--- a/secrets/errors.go
+++ b/secrets/errors.go
@@ -21,7 +21,7 @@ type TooManyFieldsError struct {
 
 func (e TooManyFieldsError) Error() string {
 	return fmt.Sprintf(
-		"secrets: expected %s secret but other fields were present for %s",
+		"secrets: expected %q secret but other fields were present for %q",
 		e.SecretType,
 		e.Key,
 	)

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -281,8 +281,9 @@ func NewSecrets(r io.Reader) (*Secrets, error) {
 			secrets.credentialSecrets[key] = credential
 		default:
 			return nil, fmt.Errorf(
-				"secrets.NewSecrets: encountered unknown secret type %s",
+				"secrets.NewSecrets: encountered unknown secret type %q for secret %q",
 				secret.Type,
+				key,
 			)
 		}
 	}


### PR DESCRIPTION
A common cause of error is empty strings, but using %s to construct the
error message will make those cases more confusing. Use %q instead for
most cases.