### PR TITLE
clientpool: More detailed error message from init errors

### DIFF
--- a/clientpool/channel.go
+++ b/clientpool/channel.go
@@ -1,6 +1,7 @@
 package clientpool
 
 import (
+	"fmt"
 	"sync/atomic"
 )
 
@@ -28,7 +29,12 @@ func NewChannelPool(initialClients, maxClients int, opener ClientOpener) (Pool, 
 	for i := 0; i < initialClients; i++ {
 		c, err := opener()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf(
+				"error creating client #%d/%d: %w",
+				i,
+				initialClients,
+				err,
+			)
 		}
 		pool <- c
 	}


### PR DESCRIPTION
When failed to create initialConnections, add number info to the error
message. Usually it's quite different between the first client failing
and client #15/30 failing so this gives us that information.