### PR TITLE
Add a validate method to thriftbp.ClientPoolConfig

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -171,6 +171,9 @@ type ClientPoolConfig struct {
 
 // Validate checks the ClientPoolConfig for any missing or erroneous values. It
 // returns an errorsbp.Batch to be combineable with other error batching.
+//
+// This method is designated to be used when passing a configuration to
+// NewBaseplateClientPool, for NewCustomClientPool other constraints apply.
 func (c ClientPoolConfig) Validate() error {
 	var batch errorsbp.Batch
 	if c.ServiceSlug == "" {
@@ -247,6 +250,10 @@ func SingleAddressGenerator(addr string) AddressGenerator {
 // BaseplateDefaultClientMiddlewares plus any additional client middlewares
 // passed into this function.
 func NewBaseplateClientPool(cfg ClientPoolConfig, middlewares ...thrift.ClientMiddleware) (ClientPool, error) {
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
 	defaults := BaseplateDefaultClientMiddlewares(
 		DefaultClientMiddlewareArgs{
 			ServiceSlug:         cfg.ServiceSlug,
@@ -275,10 +282,6 @@ func NewCustomClientPool(
 	protoFactory thrift.TProtocolFactory,
 	middlewares ...thrift.ClientMiddleware,
 ) (ClientPool, error) {
-	err := cfg.Validate()
-	if err != nil {
-		return nil, err
-	}
 	return newClientPool(cfg, genAddr, protoFactory, middlewares...)
 }
 

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -174,15 +174,15 @@ type ClientPoolConfig struct {
 func (c ClientPoolConfig) Validate() error {
 	var batch errorsbp.Batch
 	if c.ServiceSlug == "" {
-		batch.Add(errors.New("ServiceSlug cannot be empty"))
+		batch.Add(ErrConfigMissingServiceSlug)
 	}
 	if c.Addr == "" {
-		batch.Add(errors.New("Addr cannot be empty"))
+		batch.Add(ErrConfigMissingAddr)
 	}
 	if c.InitialConnections > c.MaxConnections {
-		batch.Add(errors.New("InitialConnections cannot be bigger than MaxConnections"))
+		batch.Add(ErrConfigInvalidConnections)
 	}
-	return batch
+	return batch.Compile()
 }
 
 // Client is a client object that implements both the clientpool.Client and
@@ -275,6 +275,10 @@ func NewCustomClientPool(
 	protoFactory thrift.TProtocolFactory,
 	middlewares ...thrift.ClientMiddleware,
 ) (ClientPool, error) {
+	err := cfg.Validate()
+	if err != nil {
+		return nil, err
+	}
 	return newClientPool(cfg, genAddr, protoFactory, middlewares...)
 }
 

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -169,6 +169,22 @@ type ClientPoolConfig struct {
 	BreakerConfig *breakerbp.Config
 }
 
+// Validate checks the ClientPoolConfig for any missing or erroneous values. It
+// returns an errorsbp.Batch to be combineable with other error batching.
+func (c ClientPoolConfig) Validate() error {
+	var batch errorsbp.Batch
+	if c.ServiceSlug == "" {
+		batch.Add(errors.New("ServiceSlug cannot be empty"))
+	}
+	if c.Addr == "" {
+		batch.Add(errors.New("Addr cannot be empty"))
+	}
+	if c.InitialConnections > c.MaxConnections {
+		batch.Add(errors.New("InitialConnections cannot be bigger than MaxConnections"))
+	}
+	return batch
+}
+
 // Client is a client object that implements both the clientpool.Client and
 // thrift.TCLient interfaces.
 //

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -169,12 +169,27 @@ type ClientPoolConfig struct {
 	BreakerConfig *breakerbp.Config
 }
 
-// Validate checks the ClientPoolConfig for any missing or erroneous values. It
-// returns an errorsbp.Batch to be combineable with other error batching.
+// Validate checks ClientPoolConfig for any missing or erroneous values.
+//
+// If this is the configuration for a baseplate service
+// BaseplateClientPoolConfig(c).Validate should be used instead.
+func (c ClientPoolConfig) Validate() error {
+	var batch errorsbp.Batch
+	if c.InitialConnections > c.MaxConnections {
+		batch.Add(ErrConfigInvalidConnections)
+	}
+	return batch.Compile()
+}
+
+// BaseplateClientPoolConfig provides a more concrete Validate method tailored
+// to validating baseplate service confgiurations.
+type BaseplateClientPoolConfig ClientPoolConfig
+
+// Validate checks the BaseplateClientPoolConfig for any missing or erroneous values.
 //
 // This method is designated to be used when passing a configuration to
 // NewBaseplateClientPool, for NewCustomClientPool other constraints apply.
-func (c ClientPoolConfig) Validate() error {
+func (c BaseplateClientPoolConfig) Validate() error {
 	var batch errorsbp.Batch
 	if c.ServiceSlug == "" {
 		batch.Add(ErrConfigMissingServiceSlug)
@@ -250,7 +265,7 @@ func SingleAddressGenerator(addr string) AddressGenerator {
 // BaseplateDefaultClientMiddlewares plus any additional client middlewares
 // passed into this function.
 func NewBaseplateClientPool(cfg ClientPoolConfig, middlewares ...thrift.ClientMiddleware) (ClientPool, error) {
-	err := cfg.Validate()
+	err := BaseplateClientPoolConfig(cfg).Validate()
 	if err != nil {
 		return nil, err
 	}
@@ -282,6 +297,9 @@ func NewCustomClientPool(
 	protoFactory thrift.TProtocolFactory,
 	middlewares ...thrift.ClientMiddleware,
 ) (ClientPool, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
 	return newClientPool(cfg, genAddr, protoFactory, middlewares...)
 }
 

--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -60,6 +60,7 @@ func TestCustomClientPool(t *testing.T) {
 
 	if _, err := thriftbp.NewCustomClientPool(
 		thriftbp.ClientPoolConfig{
+			Addr:               ":9090",
 			ServiceSlug:        "test",
 			InitialConnections: 1,
 			MaxConnections:     5,
@@ -98,6 +99,7 @@ func TestInitialConnectionsFallback(t *testing.T) {
 
 	cfg := thriftbp.ClientPoolConfig{
 		ServiceSlug:                      "test",
+		Addr:                             ":9090",
 		InitialConnections:               2,
 		MaxConnections:                   5,
 		ConnectTimeout:                   time.Millisecond * 5,

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -16,10 +16,17 @@ type BaseplateErrorCode interface {
 }
 
 var (
-	_                           BaseplateErrorCode = (*baseplatethrift.Error)(nil)
-	ErrConfigMissingServiceSlug                    = errors.New("ServiceSlug cannot be empty")
-	ErrConfigMissingAddr                           = errors.New("Addr cannot be empty")
-	ErrConfigInvalidConnections                    = errors.New("InitialConnections cannot be bigger than MaxConnections")
+	_ BaseplateErrorCode = (*baseplatethrift.Error)(nil)
+)
+
+var (
+	// ErrConfigMissingServiceSlug is returned when the service slug is missing in ClientPoolConfig
+	ErrConfigMissingServiceSlug = errors.New("ServiceSlug cannot be empty")
+	// ErrConfigMissingAddr is returned when the listener address is missing in ClientPoolConfig
+	ErrConfigMissingAddr = errors.New("Addr cannot be empty")
+	// ErrConfigInvalidConnections is returned when initial connections has a
+	// bigger value than maximum connections.
+	ErrConfigInvalidConnections = errors.New("InitialConnections cannot be bigger than MaxConnections")
 )
 
 // WithDefaultRetryableCodes returns a list including the given error codes and

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -19,13 +19,10 @@ var (
 	_ BaseplateErrorCode = (*baseplatethrift.Error)(nil)
 )
 
+// ClientPoolConfig errors are returned if the configuration validation fails.
 var (
-	// ErrConfigMissingServiceSlug is returned when the service slug is missing in ClientPoolConfig
 	ErrConfigMissingServiceSlug = errors.New("ServiceSlug cannot be empty")
-	// ErrConfigMissingAddr is returned when the listener address is missing in ClientPoolConfig
-	ErrConfigMissingAddr = errors.New("Addr cannot be empty")
-	// ErrConfigInvalidConnections is returned when initial connections has a
-	// bigger value than maximum connections.
+	ErrConfigMissingAddr        = errors.New("Addr cannot be empty")
 	ErrConfigInvalidConnections = errors.New("InitialConnections cannot be bigger than MaxConnections")
 )
 

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -16,7 +16,10 @@ type BaseplateErrorCode interface {
 }
 
 var (
-	_ BaseplateErrorCode = (*baseplatethrift.Error)(nil)
+	_                           BaseplateErrorCode = (*baseplatethrift.Error)(nil)
+	ErrConfigMissingServiceSlug                    = errors.New("ServiceSlug cannot be empty")
+	ErrConfigMissingAddr                           = errors.New("Addr cannot be empty")
+	ErrConfigInvalidConnections                    = errors.New("InitialConnections cannot be bigger than MaxConnections")
 )
 
 // WithDefaultRetryableCodes returns a list including the given error codes and


### PR DESCRIPTION
It's often useful to have a way to check configuration files for completeness. I usually create a validate command that will check the files for correctness. I believe it makes sense to have configurations themselves provide a validate method too which at the minimum check for required values or returns an error if a value is out of range. This way the validation chain can be partially delegated.