### PR TITLE
metricsbp: Buffer udp messages together

### DIFF
--- a/log/kit_wrapper.go
+++ b/log/kit_wrapper.go
@@ -9,7 +9,7 @@ type KitWrapper zapcore.Level
 
 // Log implements go-kit/log.Logger interface.
 func (w KitWrapper) Log(keyvals ...interface{}) error {
-	const msg = ""
+	const msg = "log.KitWrapper"
 	switch zapcore.Level(w) {
 	default:
 		// for unknown values, fallback to info level.

--- a/metricsbp/BUILD.bazel
+++ b/metricsbp/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "baseplate_hooks.go",
+        "buffered_writer.go",
         "config.go",
         "doc.go",
         "log.go",

--- a/metricsbp/buffered_writer.go
+++ b/metricsbp/buffered_writer.go
@@ -1,0 +1,58 @@
+package metricsbp
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+type bufferedWriter struct {
+	buf  bytes.Buffer
+	w    io.Writer
+	size int
+}
+
+func newBufferedWriter(w io.Writer, size int) *bufferedWriter {
+	bufWriter := &bufferedWriter{
+		w:    w,
+		size: size,
+	}
+	if size > 0 {
+		bufWriter.buf.Grow(size)
+	}
+	return bufWriter
+}
+
+func (bw *bufferedWriter) Flush() error {
+	if bw.buf.Len() == 0 {
+		return nil
+	}
+
+	_, err := bw.w.Write(bw.buf.Bytes())
+	bw.buf.Reset()
+	return err
+}
+
+func (bw *bufferedWriter) Write(p []byte) (n int, err error) {
+	if bw.buf.Len()+len(p) > bw.size {
+		err = bw.Flush()
+		if err != nil {
+			return
+		}
+	}
+	return bw.buf.Write(p)
+}
+
+func (bw *bufferedWriter) doWrite(src io.WriterTo, logger log.KitWrapper) (err error) {
+	defer func() {
+		if err != nil {
+			logger.Log("during", "WriteTo", "err", err)
+		}
+	}()
+
+	if _, err := src.WriteTo(bw); err != nil {
+		return err
+	}
+	return bw.Flush()
+}


### PR DESCRIPTION
When using telegraf as the statsd collector, telegraf has a limit of how
many UDP messages can be buffered, and the default go-kit influxstatsd
implementation sends one UDP message per metric on the report interval,
so when we have a lot of metrics, telegraf could be dropping those UDP
messages, thus dropping metrics.

Add a configurable buffer size can help reduce the number of UDP
messages.

Eventually we probably want to upstream this to go-kit.