### PR TITLE
runtimebp: print to stderr instead of stdout

### DIFF
--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -2,6 +2,7 @@ package runtimebp
 
 import (
 	"fmt"
+	"os"
 )
 
 // Config is the configuration struct for the runtimebp package.
@@ -36,5 +37,5 @@ func InitFromConfig(cfg Config) {
 		min = cfg.NumProcesses.Min
 	}
 	prev, current := GOMAXPROCS(min, max)
-	fmt.Println("GOMAXPROCS:", prev, current)
+	fmt.Fprintf(os.Stderr, "GOMAXPROCS: %d %d\n", prev, current)
 }


### PR DESCRIPTION
This replaces the `fmt.Println` call in `runtimebp/config.go` with printing to stderr like we do in `runtimebp/cpu.go`.

In certain scenarios there is a need to have log messages by baseplate.go filtered out. Since the only occasions where it prints without logger is in runtimebp, they should both print to stderr, allowing it to be filter, i.e. through the user of `2> /dev/null`

---
### Deprecated: previous suggestion

I noticed we still have a place where we call `fmt.Println` instead of relying on `log.Wrapper`. This passes the logger in via the configuration.

Should we extend the function to pass in `context.Context`? I relied on the comment:
```
// Not all Wrapper implementations take advantage of context object passed in,
// but the caller should always pass it into Wrapper if they already have one,
// or just use context.Background() if they don't have one.
```
to decide passing in `context.Background()` for now.