### PR TITLE
kafkabp: Actually set ClientID in sarama config

### DIFF
--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -86,7 +86,7 @@ type ConsumerConfig struct {
 	// Optional. If non-nil, will be used to log errors. At present, this only
 	// pertains to logging errors closing the existing consumer when calling
 	// consumer.reset() when GroupID is empty.
-	Logger log.Wrapper `yaml:"-"`
+	Logger log.Wrapper `yaml:"logger"`
 }
 
 // NewSaramaConfig instantiates a sarama.Config with sane consumer defaults
@@ -119,6 +119,7 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 
 	c := sarama.NewConfig()
 
+	c.ClientID = cfg.ClientID
 	c.Version = version
 
 	if cfg.GroupID == "" {

--- a/kafkabp/config_test.go
+++ b/kafkabp/config_test.go
@@ -75,5 +75,8 @@ func TestConsumerConfig(t *testing.T) {
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
+		if sc.ClientID != cfg.ClientID {
+			t.Errorf("expected sarama client id to be %q, got %q", cfg.ClientID, sc.ClientID)
+		}
 	})
 }


### PR DESCRIPTION
We didn't do that before and that's a bug. Also add an unit test for it.

While I'm here, also allow logger of kafkabp config to be set from yaml,
as we added the support to that in 58d8ccc.