### PR TITLE
timebp: Cleanup incorrect comments

### DIFF
--- a/timebp/microsecond.go
+++ b/timebp/microsecond.go
@@ -59,8 +59,6 @@ func MicrosecondsToTime(us int64) time.Time {
 	if us == 0 {
 		return time.Time{}
 	}
-	// NOTE: A timestamp before the year 1678 or after 2262 would overflow this,
-	// but that's OK.
 	return time.Unix(
 		us/microsecondsPerSecond,                         // sec
 		us%microsecondsPerSecond*int64(time.Microsecond), // nanosec

--- a/timebp/millisecond.go
+++ b/timebp/millisecond.go
@@ -47,8 +47,6 @@ func MillisecondsToTime(ms int64) time.Time {
 	if ms == 0 {
 		return time.Time{}
 	}
-	// NOTE: A timestamp before the year 1678 or after 2262 would overflow this,
-	// but that's OK.
 	return time.Unix(
 		ms/millisecondsPerSecond,                         // sec
 		ms%millisecondsPerSecond*int64(time.Millisecond), // nanosec

--- a/timebp/second_f.go
+++ b/timebp/second_f.go
@@ -59,8 +59,6 @@ func SecondsToTimeF(s float64) time.Time {
 	}
 	sec := int64(s)
 	nanosec := (s - float64(sec)) * float64(time.Second)
-	// NOTE: A timestamp before the year 1678 or after 2262 would overflow this,
-	// but that's OK.
 	return time.Unix(sec, int64(nanosec))
 }
 


### PR DESCRIPTION
Those comments only apply when we use nanoseconds since EPOCH as
timestamp, not milliseconds/microseconds. I can't remember why I added
them in the first place...

https://play.golang.org/p/u-9jx4H7qZU