### PR TITLE
thriftbp: add a helper method for creating new baseplate.Error objects

### DIFF
--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -59,3 +59,13 @@ func BaseplateErrorFilter(codes ...int32) retrybp.Filter {
 		return next(err)
 	}
 }
+
+// NewBaseplateError is a helper function for creating baseplate.Error thrift objects.
+func NewBaseplateError(code baseplatethrift.ErrorCode, message string) *baseplatethrift.Error {
+	asInt32 := int32(code)
+	return &baseplatethrift.Error{
+		Code:    &asInt32,
+		Message: &message,
+		Details: make(map[string]string),
+	}
+}

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -63,10 +63,10 @@ func BaseplateErrorFilter(codes ...int32) retrybp.Filter {
 }
 
 // NewBaseplateError is a helper function for creating baseplate.Error thrift
-// objects.
+// objects to avoid manual type-conversion that the generated Thrift code requires.
 //
 // detailsKeysValues is used to populate baseplate.Error.Details and should have
-// an even number of values, if it has an odd number of values, the last value
+// an even number of values. If it has an odd number of values the last value
 // will be discarded. The first entry in each pair of values will be the key and
 // the second entry will be the value. If no values are provided, the
 // baseplate.Error will be initialized with an empty map as Details rather than

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -3,7 +3,9 @@ package thriftbp
 import (
 	"errors"
 
+	"github.com/apache/thrift/lib/go/thrift"
 	retry "github.com/avast/retry-go"
+
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/retrybp"
 )
@@ -60,12 +62,24 @@ func BaseplateErrorFilter(codes ...int32) retrybp.Filter {
 	}
 }
 
-// NewBaseplateError is a helper function for creating baseplate.Error thrift objects.
-func NewBaseplateError(code baseplatethrift.ErrorCode, message string) *baseplatethrift.Error {
-	asInt32 := int32(code)
+// NewBaseplateError is a helper function for creating baseplate.Error thrift
+// objects.
+//
+// detailsKeysValues is used to populate baseplate.Error.Details and should have
+// an even number of values, if it has an odd number of values, the last value
+// will be discarded. The first entry in each pair of values will be the key and
+// the second entry will be the value. If no values are provided, the
+// baseplate.Error will be initialized with an empty map as Details rather than
+// nil.
+func NewBaseplateError(code baseplatethrift.ErrorCode, message string, detailsKeysValues ...string) *baseplatethrift.Error {
+	details := make(map[string]string, len(detailsKeysValues)/2)
+	for i := 0; i+1 < len(detailsKeysValues); i += 2 {
+		key, value := detailsKeysValues[i], detailsKeysValues[i+1]
+		details[key] = value
+	}
 	return &baseplatethrift.Error{
-		Code:    &asInt32,
+		Code:    thrift.Int32Ptr(int32(code)),
 		Message: &message,
-		Details: make(map[string]string),
+		Details: details,
 	}
 }

--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -127,3 +127,43 @@ func TestBaseplateErrorFilter(t *testing.T) {
 		)
 	}
 }
+
+func TestNewBaseplateError_DetailsKeysValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		keysValues []string
+		expected   map[string]string
+	}{
+		{
+			name:       "empty",
+			keysValues: []string{},
+			expected:   map[string]string{},
+		},
+		{
+			name:       "even",
+			keysValues: []string{"foo", "bar", "fizz", "buzz"},
+			expected:   map[string]string{"foo": "bar", "fizz": "buzz"},
+		},
+		{
+			name:       "odd",
+			keysValues: []string{"foo", "bar", "fizz"},
+			expected:   map[string]string{"foo": "bar"},
+		},
+	}
+
+	for _, _c := range cases {
+		c := _c
+		t.Run(c.name, func(t *testing.T) {
+			be := thriftbp.NewBaseplateError(
+				baseplatethrift.ErrorCode_BAD_REQUEST,
+				"test",
+				c.keysValues...,
+			)
+			if !reflect.DeepEqual(be.Details, c.expected) {
+				t.Errorf("error.Details do not match, expected %+v, got %+v", c.expected, be.Details)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Creating `baseplate.Error` objects is kind of annoying in Go because of the type conversions and need to use pointers, this adds a small helper function that you can use to create a new `baseplate.Error` without having to worry about that.