### PR TITLE
log: Wrap zapcore.Core to convert int64 fields to strings

### DIFF
--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "context.go",
+        "core_wrapper.go",
         "doc.go",
         "encoder.go",
         "kit_wrapper.go",
@@ -26,6 +27,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "core_wrapper_test.go",
         "kit_wrapper_test.go",
         "log_test.go",
         "sentry_test.go",

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"strconv"
+
+	"go.uber.org/zap/zapcore"
+)
+
+type wrappedCore struct {
+	zapcore.Core
+}
+
+func (w wrappedCore) With(fields []zapcore.Field) zapcore.Core {
+	return wrappedCore{Core: w.Core.With(fieldsInt64ToString(fields))}
+}
+
+func (w wrappedCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	return w.Core.Write(entry, fieldsInt64ToString(fields))
+}
+
+func (w wrappedCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if w.Enabled(ent.Level) {
+		return ce.AddCore(ent, w)
+	}
+	return ce
+}
+
+func fieldsInt64ToString(fields []zapcore.Field) []zapcore.Field {
+	for i, f := range fields {
+		switch f.Type {
+		case zapcore.Int64Type:
+			f.Type = zapcore.StringType
+			f.String = strconv.FormatInt(f.Integer, 10)
+		case zapcore.Uint64Type:
+			f.Type = zapcore.StringType
+			f.String = strconv.FormatUint(uint64(f.Integer), 10)
+		}
+		fields[i] = f
+	}
+	return fields
+}

--- a/log/core_wrapper_test.go
+++ b/log/core_wrapper_test.go
@@ -1,0 +1,100 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func log(l *zap.SugaredLogger) {
+	l.Debugw(
+		"This is a log",
+		"int", int(123),
+		"int64", int64(1234),
+		"uint64", uint64(1234),
+	)
+}
+
+func initCore(buf *bytes.Buffer) zapcore.Core {
+	// Mostly copied from zap.NewExample, to make the log deterministic.
+	encoderCfg := zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	}
+	return zapcore.NewCore(zapcore.NewJSONEncoder(encoderCfg), zapcore.AddSync(buf), zap.DebugLevel)
+}
+
+func TestWrappedCore(t *testing.T) {
+	const (
+		expectedOrigin  = `{"level":"debug","msg":"This is a log","int":123,"int64":1234,"uint64":1234}`
+		expectedWrapped = `{"level":"debug","msg":"This is a log","int":"123","int64":"1234","uint64":"1234"}`
+	)
+	t.Run("origin", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		core := initCore(buf)
+		logger := zap.New(core).Sugar()
+		log(logger)
+		actual := strings.TrimSpace(buf.String())
+		if actual != expectedOrigin {
+			t.Errorf("Expected log line %s, got %s", expectedOrigin, actual)
+		}
+	})
+	t.Run("wrapped", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		core := wrappedCore{initCore(buf)}
+		logger := zap.New(core).Sugar()
+		log(logger)
+		actual := strings.TrimSpace(buf.String())
+		if actual != expectedWrapped {
+			t.Errorf("Expected log line %s, got %s", expectedWrapped, actual)
+		}
+	})
+	t.Run("wrapped-with", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		core := wrappedCore{initCore(buf)}
+		logger := zap.New(core).Sugar()
+		logger = logger.With("int", int(123))
+		logger.Debugw(
+			"This is a log",
+			"int64", int64(1234),
+			"uint64", uint64(1234),
+		)
+		actual := strings.TrimSpace(buf.String())
+		if actual != expectedWrapped {
+			t.Errorf("Expected log line %s, got %s", expectedWrapped, actual)
+		}
+	})
+}
+
+func BenchmarkWrappedCore(b *testing.B) {
+	b.Run("origin", func(b *testing.B) {
+		buf := new(bytes.Buffer)
+		core := initCore(buf)
+		logger := zap.New(core).Sugar()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			log(logger)
+		}
+	})
+
+	b.Run("wrapped", func(b *testing.B) {
+		buf := new(bytes.Buffer)
+		core := wrappedCore{initCore(buf)}
+		logger := zap.New(core).Sugar()
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			log(logger)
+		}
+	})
+}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -6,5 +6,5 @@ import (
 
 func TestZapLogger(t *testing.T) {
 	InitLogger(DebugLevel)
-	globalLogger.Debug("printing flag values")
+	log(globalLogger)
 }


### PR DESCRIPTION
This allows us to mitigate the loss of precision issue without the merge
of [1] to upstream.

In the future if [1] is accepted by upstream, we would still want to
revert this change and use that one instead, as this change makes
logging slightly slower:

    $ go test -bench . -benchmem
    ts=2020-12-07T23:09:17.386513Z  level=DEBUG     This is a log   {"int": "123", "int64": "1234", "uint64": "1234"}
    goos: linux
    goarch: amd64
    pkg: github.com/reddit/baseplate.go/log
    BenchmarkWrappedCore/origin-12           1550918               858 ns/op             384 B/op          1 allocs/op
    BenchmarkWrappedCore/wrapped-12          1000000              1054 ns/op             412 B/op          5 allocs/op
    PASS
    ok      github.com/reddit/baseplate.go/log      4.338s

[1]: https://github.com/uber-go/zap/pull/885