### PR TITLE
randbp: Small tweak on the GetSeed implementation

### DIFF
--- a/randbp/BUILD.bazel
+++ b/randbp/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     srcs = [
         "rand_test.go",
         "sample_test.go",
+        "seed_test.go",
         "string_example_test.go",
         "string_test.go",
     ],

--- a/randbp/seed.go
+++ b/randbp/seed.go
@@ -3,18 +3,39 @@ package randbp
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
 	"time"
 )
 
-// GetSeed returns a seed for pseudo-random generator.
+// Define as variables so they can be mocked in unit tests.
+var (
+	cryptoReader               = rand.Read
+	getSeedLogOutput io.Writer = os.Stderr
+)
+
+// GetSeed returns an int64 seed for pseudo-random generator.
 //
 // It tries to use crypto/rand to read an int64,
-// and fallback to use current time if that fails for whatever reason.
+// and if an error happens, it logs the error to stderr,
+// then fallback to use current time bitwise xor the part it read from
+// crypto/rand instead.
+//
+// The bitwise xor part in the fallback is in order to try to prevent two
+// processes starting at the same time getting the same seed from happening.
 func GetSeed() int64 {
 	buf := make([]byte, 8)
-	_, err := rand.Read(buf)
+	n, err := cryptoReader(buf)
+	seed := int64(binary.LittleEndian.Uint64(buf))
 	if err != nil {
-		return time.Now().UnixNano()
+		fmt.Fprintf(
+			getSeedLogOutput,
+			"randbp.GetSeed: only read %d bytes from crypto/rand: %v\n",
+			n,
+			err,
+		)
+		return seed ^ time.Now().UnixNano()
 	}
-	return int64(binary.BigEndian.Uint64(buf))
+	return seed
 }

--- a/randbp/seed_test.go
+++ b/randbp/seed_test.go
@@ -1,0 +1,90 @@
+package randbp
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"testing"
+)
+
+func TestGetSeed(t *testing.T) {
+	const maxBytes = 8
+
+	oldCryptoReader := cryptoReader
+	oldLogOutput := getSeedLogOutput
+	defer func() {
+		cryptoReader = oldCryptoReader
+		getSeedLogOutput = oldLogOutput
+	}()
+
+	getSeedLogOutput = ioutil.Discard
+
+	readerGenerator := func(t *testing.T, n int) func(p []byte) (int, error) {
+		var err error
+		if n < maxBytes {
+			err = errors.New("error")
+		}
+
+		return func(p []byte) (int, error) {
+			t.Helper()
+
+			ret := n
+			if n < len(p) {
+				p = p[:n]
+			} else {
+				ret = len(p)
+			}
+			if _, readErr := R.Read(p); readErr != nil {
+				t.Error(readErr)
+			}
+			return ret, err
+		}
+	}
+
+	const (
+		// Number of concurrent GetSeed calls
+		n = 1000
+
+		// Don't use 100% unique as the target as the randomness nature of this
+		// test, but the randomness shouldn't cause it to be fewer than 90% unique
+		// unless there's a bug in the implementation.
+		target = int(n * 0.9)
+	)
+	for i := 0; i <= maxBytes; i++ {
+		t.Run(fmt.Sprintf("read-%d-bytes", i), func(t *testing.T) {
+			cryptoReader = readerGenerator(t, i)
+			set := make(map[int64]bool)
+			var lock sync.Mutex
+			var wg sync.WaitGroup
+			wg.Add(n)
+			for j := 0; j < n; j++ {
+				go func() {
+					defer wg.Done()
+					seed := GetSeed()
+					lock.Lock()
+					defer lock.Unlock()
+					set[seed] = true
+				}()
+			}
+			wg.Wait()
+
+			if t.Failed() {
+				// In case that readerGenerator failed to generate required bytes,
+				// fail early.
+				t.FailNow()
+			}
+
+			size := len(set)
+			t.Logf("%d unique seeds among %d tries", size, n)
+			// This will fail for i == 0 and probably also i == 1 when someone
+			// accidentally change bitwise xor to bitwise and in the implementation.
+			if size < target {
+				t.Errorf(
+					"Too few unique seeds returned: %v",
+					set,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When reading int64 from crypto/rand failed:

1. Log the error to stderr
2. In case of partial failures (read some bytes but not enough for
   int64), xor the bytes read against time so that time is not the only
   entropy of the fallback seed.