### PR TITLE
thriftbp: Add header to write header list in SetDeadlineBudget

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -229,7 +229,7 @@ func SetDeadlineBudget(next thrift.TClient) thrift.TClient {
 					ms = 1
 				}
 				value := strconv.FormatInt(ms, 10)
-				ctx = thrift.SetHeader(ctx, HeaderDeadlineBudget, value)
+				ctx = AddClientHeader(ctx, HeaderDeadlineBudget, value)
 			}
 
 			return next.Call(ctx, method, args, result)

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -216,17 +216,7 @@ func TestForwardEdgeRequestContext(t *testing.T) {
 	}
 
 	ctx = recorder.Calls()[0].Ctx
-	headers := thrift.GetWriteHeaderList(ctx)
-	var found bool
-	for _, key := range headers {
-		if key == thriftbp.HeaderEdgeRequest {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("header not added to thrift write list")
-	}
+	headerInWriteHeaderList(ctx, t, thriftbp.HeaderEdgeRequest)
 
 	header, ok := thrift.GetHeader(ctx, thriftbp.HeaderEdgeRequest)
 	if !ok {
@@ -261,7 +251,7 @@ func TestForwardEdgeRequestContextNotSet(t *testing.T) {
 	}
 }
 
-func TesetSetDeadlineBudget(t *testing.T) {
+func TestSetDeadlineBudget(t *testing.T) {
 	mock, recorder, client := initClients()
 	mock.AddMockCall(
 		method,
@@ -313,6 +303,8 @@ func TesetSetDeadlineBudget(t *testing.T) {
 					v,
 				)
 			}
+
+			headerInWriteHeaderList(ctx, t, thriftbp.HeaderDeadlineBudget)
 		},
 	)
 }

--- a/thriftbp/headers.go
+++ b/thriftbp/headers.go
@@ -57,12 +57,19 @@ var HeadersToForward = []string{
 // EdgeRequestContext set to forward using the "Edge-Request" header on any
 // Thrift calls made with that context object.
 func AttachEdgeRequestContext(ctx context.Context, ec *edgecontext.EdgeRequestContext) context.Context {
-	headers := thrift.GetWriteHeaderList(ctx)
 	if ec == nil {
-		ctx = thrift.UnsetHeader(ctx, HeaderEdgeRequest)
-	} else {
-		ctx = thrift.SetHeader(ctx, HeaderEdgeRequest, ec.Header())
-		headers = append(headers, HeaderEdgeRequest)
+		return thrift.UnsetHeader(ctx, HeaderEdgeRequest)
 	}
+	return AddClientHeader(ctx, HeaderEdgeRequest, ec.Header())
+}
+
+// AddClientHeader adds a key-value pair to thrift client's headers.
+//
+// It takes care of setting the header in context (overwrite previous value if
+// any), and also adding the header to the write header list.
+func AddClientHeader(ctx context.Context, key, value string) context.Context {
+	headers := thrift.GetWriteHeaderList(ctx)
+	ctx = thrift.SetHeader(ctx, key, value)
+	headers = append(headers, key)
 	return thrift.SetWriteHeaderList(ctx, headers)
 }

--- a/thriftbp/headers_test.go
+++ b/thriftbp/headers_test.go
@@ -54,3 +54,27 @@ func TestAttachEdgeRequestContextNilHeader(t *testing.T) {
 		t.Fatal("header should not be set")
 	}
 }
+
+func headerInWriteHeaderList(ctx context.Context, t *testing.T, header string) {
+	t.Helper()
+
+	headers := thrift.GetWriteHeaderList(ctx)
+	for _, h := range headers {
+		if h == header {
+			return
+		}
+	}
+	t.Errorf("Cannot find header %q in list %#v", header, headers)
+}
+
+func TestAddClientHeader(t *testing.T) {
+	const (
+		key      = "key"
+		expected = "value"
+	)
+	ctx := thriftbp.AddClientHeader(context.Background(), key, expected)
+	if value, ok := thrift.GetHeader(ctx, key); value != expected {
+		t.Errorf("Expected header value to be %q, got %q, %v", expected, value, ok)
+	}
+	headerInWriteHeaderList(ctx, t, key)
+}


### PR DESCRIPTION
We only set the header in ctx, but not add it to write header list, and
that's a bug causing we don't really add the header to the wire.