### PR TITLE
thriftbp: Upgrade thrift

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: test
-  image: golang:1.15.6-buster
+  image: golang:1.15.7-buster
   pull: if-not-exists
   commands:
   - go test ./... -race
@@ -21,7 +21,7 @@ steps:
     - push
 
 - name: check-go-modules
-  image: golang:1.15.6-buster
+  image: golang:1.15.7-buster
   pull: if-not-exists
   commands:
   - go mod tidy
@@ -80,7 +80,7 @@ platform:
 
 steps:
 - name: lint
-  image: golang:1.15.6-buster
+  image: golang:1.15.7-buster
   pull: if-not-exists
   commands:
   - go get -u golang.org/x/lint/golint

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ with `*-remote` directories removed.
 They are excluded from the linter.
 DO NOT EDIT.
 
-They were generated with [thrift compiler 4db7a0a][thrift-version] against
+They were generated with [thrift compiler d831230][thrift-version] against
 [`baseplate.thrift`][baseplate.thrift] and
 [`edgecontext.thrift`][edgecontext.thrift]
 using the following commands under `internal/`:
@@ -74,4 +74,4 @@ bazel test //...:all
 
 [godev]: https://pkg.go.dev/github.com/reddit/baseplate.go
 
-[thrift-version]: https://github.com/apache/thrift/tree/4db7a0af13ac9614e3e9758d42b2791040f4dc7e
+[thrift-version]: https://github.com/apache/thrift/tree/d831230929bb332189c9509d07102e4be9e7f681

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ workspace(name = "baseplate_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-GO_VERSION = "1.15.6"
+GO_VERSION = "1.15.7"
 
 # For rules_go
 RULES_GO_VERSION = "v0.25.0"

--- a/external.bzl
+++ b/external.bzl
@@ -34,8 +34,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_apache_thrift",
         importpath = "github.com/apache/thrift",
-        sum = "h1:yv68jHUhpc+13C3f3lm9jZG1YEFeXXIvc7MGeYi00mQ=",
-        version = "v0.13.1-0.20201019212144-2676327f6ea7",
+        sum = "h1:kDzuYj7Rec8Oe5gItpFaeMGkV7SYAiHP3tT9/ayq01Q=",
+        version = "v0.13.1-0.20210120194924-d9fcdd3dbafb",
     )
     go_repository(
         name = "com_github_armon_consul_api",

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
-	github.com/apache/thrift v0.13.1-0.20201019212144-2676327f6ea7
+	github.com/apache/thrift v0.13.1-0.20210120194924-d9fcdd3dbafb
 	github.com/avast/retry-go v2.6.1+incompatible
 	github.com/getsentry/sentry-go v0.6.0
 	github.com/go-kit/kit v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMw
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis v2.5.0+incompatible h1:yBHoLpsyjupjz3NL3MhKMVkR41j82Yjf3KFv7ApYzUI=
 github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+DxYx+6BMjkBbe5ONFIF1MXffk=
-github.com/apache/thrift v0.13.1-0.20201019212144-2676327f6ea7 h1:yv68jHUhpc+13C3f3lm9jZG1YEFeXXIvc7MGeYi00mQ=
-github.com/apache/thrift v0.13.1-0.20201019212144-2676327f6ea7/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
+github.com/apache/thrift v0.13.1-0.20210120194924-d9fcdd3dbafb h1:kDzuYj7Rec8Oe5gItpFaeMGkV7SYAiHP3tT9/ayq01Q=
+github.com/apache/thrift v0.13.1-0.20210120194924-d9fcdd3dbafb/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/avast/retry-go v2.6.1+incompatible h1:quvLI98pOPWtTq7xnbX4TI5l9PmRJooM2AI1T7mOFUA=
 github.com/avast/retry-go v2.6.1+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=

--- a/internal/gen-go/reddit/baseplate/baseplate.go
+++ b/internal/gen-go/reddit/baseplate/baseplate.go
@@ -562,8 +562,14 @@ func (p *Error) String() string {
 }
 
 func (p *Error) Error() string {
-  return p.String()
+return p.String()
 }
+
+func (Error) TExceptionType() thrift.TExceptionType {
+return thrift.TExceptionTypeCompiled
+}
+
+var _ thrift.TException = (*Error)(nil)
 
 type BaseplateService interface {  //The base for any baseplate-based service.
   //
@@ -659,8 +665,8 @@ return self4
 }
 
 func (p *BaseplateServiceProcessor) Process(ctx context.Context, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
-  name, _, seqId, err := iprot.ReadMessageBegin(ctx)
-  if err != nil { return false, err }
+  name, _, seqId, err2 := iprot.ReadMessageBegin(ctx)
+  if err2 != nil { return false, thrift.WrapTException(err2) }
   if processor, ok := p.GetProcessorFunction(name); ok {
     return processor.Process(ctx, seqId, iprot, oprot)
   }
@@ -681,14 +687,15 @@ type baseplateServiceProcessorIsHealthy struct {
 
 func (p *baseplateServiceProcessorIsHealthy) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
   args := BaseplateServiceIsHealthyArgs{}
-  if err = args.Read(ctx, iprot); err != nil {
+  var err2 error
+  if err2 = args.Read(ctx, iprot); err2 != nil {
     iprot.ReadMessageEnd(ctx)
-    x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+    x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err2.Error())
     oprot.WriteMessageBegin(ctx, "is_healthy", thrift.EXCEPTION, seqId)
     x.Write(ctx, oprot)
     oprot.WriteMessageEnd(ctx)
     oprot.Flush(ctx)
-    return false, err
+    return false, thrift.WrapTException(err2)
   }
   iprot.ReadMessageEnd(ctx)
 
@@ -720,33 +727,32 @@ func (p *baseplateServiceProcessorIsHealthy) Process(ctx context.Context, seqId 
 
   result := BaseplateServiceIsHealthyResult{}
   var retval bool
-  var err2 error
   if retval, err2 = p.handler.IsHealthy(ctx); err2 != nil {
     tickerCancel()
     if err2 == thrift.ErrAbandonRequest {
-      return false, err2
+      return false, thrift.WrapTException(err2)
     }
     x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing is_healthy: " + err2.Error())
     oprot.WriteMessageBegin(ctx, "is_healthy", thrift.EXCEPTION, seqId)
     x.Write(ctx, oprot)
     oprot.WriteMessageEnd(ctx)
     oprot.Flush(ctx)
-    return true, err2
+    return true, thrift.WrapTException(err2)
   } else {
     result.Success = &retval
   }
   tickerCancel()
   if err2 = oprot.WriteMessageBegin(ctx, "is_healthy", thrift.REPLY, seqId); err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = oprot.WriteMessageEnd(ctx); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err != nil {
     return
@@ -1006,8 +1012,8 @@ return self8
 }
 
 func (p *BaseplateServiceV2Processor) Process(ctx context.Context, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
-  name, _, seqId, err := iprot.ReadMessageBegin(ctx)
-  if err != nil { return false, err }
+  name, _, seqId, err2 := iprot.ReadMessageBegin(ctx)
+  if err2 != nil { return false, thrift.WrapTException(err2) }
   if processor, ok := p.GetProcessorFunction(name); ok {
     return processor.Process(ctx, seqId, iprot, oprot)
   }
@@ -1028,14 +1034,15 @@ type baseplateServiceV2ProcessorIsHealthy struct {
 
 func (p *baseplateServiceV2ProcessorIsHealthy) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
   args := BaseplateServiceV2IsHealthyArgs{}
-  if err = args.Read(ctx, iprot); err != nil {
+  var err2 error
+  if err2 = args.Read(ctx, iprot); err2 != nil {
     iprot.ReadMessageEnd(ctx)
-    x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+    x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err2.Error())
     oprot.WriteMessageBegin(ctx, "is_healthy", thrift.EXCEPTION, seqId)
     x.Write(ctx, oprot)
     oprot.WriteMessageEnd(ctx)
     oprot.Flush(ctx)
-    return false, err
+    return false, thrift.WrapTException(err2)
   }
   iprot.ReadMessageEnd(ctx)
 
@@ -1067,33 +1074,32 @@ func (p *baseplateServiceV2ProcessorIsHealthy) Process(ctx context.Context, seqI
 
   result := BaseplateServiceV2IsHealthyResult{}
   var retval bool
-  var err2 error
   if retval, err2 = p.handler.IsHealthy(ctx, args.Request); err2 != nil {
     tickerCancel()
     if err2 == thrift.ErrAbandonRequest {
-      return false, err2
+      return false, thrift.WrapTException(err2)
     }
     x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing is_healthy: " + err2.Error())
     oprot.WriteMessageBegin(ctx, "is_healthy", thrift.EXCEPTION, seqId)
     x.Write(ctx, oprot)
     oprot.WriteMessageEnd(ctx)
     oprot.Flush(ctx)
-    return true, err2
+    return true, thrift.WrapTException(err2)
   } else {
     result.Success = &retval
   }
   tickerCancel()
   if err2 = oprot.WriteMessageBegin(ctx, "is_healthy", thrift.REPLY, seqId); err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = result.Write(ctx, oprot); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = oprot.WriteMessageEnd(ctx); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
-    err = err2
+    err = thrift.WrapTException(err2)
   }
   if err != nil {
     return

--- a/thriftbp/server_middlewares_test.go
+++ b/thriftbp/server_middlewares_test.go
@@ -58,7 +58,7 @@ func TestInjectServerSpan(t *testing.T) {
 		map[string]thrift.TProcessorFunction{
 			name: thrift.WrappedTProcessorFunction{
 				Wrapped: func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (bool, thrift.TException) {
-					return false, errors.New("TError")
+					return false, thrift.WrapTException(errors.New("TError"))
 				},
 			},
 		},


### PR DESCRIPTION
1. Switch to use TConfiguration to config timeouts and THeaderProtocolID
   in client pools.
2. Use the new TException interface to implement IDLExceptionSuppressor.

This is a breaking change with thrift compiler upgrade.