### PR TITLE
log: Fix missing caller

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -96,14 +96,16 @@ func InitLoggerWithConfig(logLevel Level, cfg zap.Config) error {
 		globalLogger = zap.NewNop().Sugar()
 		return nil
 	}
-	l, err := cfg.Build()
+	l, err := cfg.Build(
+		zap.AddCallerSkip(1),
+		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return wrappedCore{Core: core}
+		}),
+	)
 	if err != nil {
 		return err
 	}
-	globalLogger = zap.New(
-		wrappedCore{Core: l.Core()},
-		zap.AddCallerSkip(1),
-	).Sugar()
+	globalLogger = l.Sugar()
 	return nil
 }
 


### PR DESCRIPTION
Use zap.WrapCore as a standard option instead of doing the manual core
wrapping to apply our wrapper for int to string conversion. This fixes a
bug introduced in c006ae3163 that we accidentally broke caller in logs.