### PR TITLE
Cherry picks for 0.7.x

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -96,14 +96,16 @@ func InitLoggerWithConfig(logLevel Level, cfg zap.Config) error {
 		globalLogger = zap.NewNop().Sugar()
 		return nil
 	}
-	l, err := cfg.Build()
+	l, err := cfg.Build(
+		zap.AddCallerSkip(1),
+		zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return wrappedCore{Core: core}
+		}),
+	)
 	if err != nil {
 		return err
 	}
-	globalLogger = zap.New(
-		wrappedCore{Core: l.Core()},
-		zap.AddCallerSkip(1),
-	).Sugar()
+	globalLogger = l.Sugar()
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick https://github.com/reddit/baseplate.go/pull/326 & https://github.com/reddit/baseplate.go/pull/327 into `0.7.x` branch (which was created on top of `v0.7.2` tag) to prepare for `v0.7.3` release.