### PR TITLE
retrybp: Upgrade retry-go to v3.0.0

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -46,8 +46,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_avast_retry_go",
         importpath = "github.com/avast/retry-go",
-        sum = "h1:quvLI98pOPWtTq7xnbX4TI5l9PmRJooM2AI1T7mOFUA=",
-        version = "v2.6.1+incompatible",
+        sum = "h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=",
+        version = "v3.0.0+incompatible",
     )
     go_repository(
         name = "com_github_aymerick_raymond",

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/apache/thrift v0.13.1-0.20210123045027-c2ddaf076649
-	github.com/avast/retry-go v2.6.1+incompatible
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/getsentry/sentry-go v0.6.0
 	github.com/go-kit/kit v0.9.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/alicebob/miniredis v2.5.0+incompatible/go.mod h1:8HZjEj4yU0dwhYHky+Dx
 github.com/apache/thrift v0.13.1-0.20210123045027-c2ddaf076649 h1:J4dS9DgqdyU18qH50c/R+8LBmj/2mvyXAdfHyQ4qOuE=
 github.com/apache/thrift v0.13.1-0.20210123045027-c2ddaf076649/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/avast/retry-go v2.6.1+incompatible h1:quvLI98pOPWtTq7xnbX4TI5l9PmRJooM2AI1T7mOFUA=
-github.com/avast/retry-go v2.6.1+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/retrybp/delay.go
+++ b/retrybp/delay.go
@@ -65,7 +65,7 @@ func cappedExponentialBackoffFunc(args CappedExponentialBackoffArgs) retry.Delay
 
 	maxInt64 := uint64(math.MaxInt64)
 
-	return func(n uint, _ *retry.Config) time.Duration {
+	return func(n uint, _ error, _ *retry.Config) time.Duration {
 		if n > uMaxExponent {
 			n = uMaxExponent
 		}
@@ -111,7 +111,7 @@ func FixedDelay(delay time.Duration) retry.Option {
 
 // FixedDelayFunc is an retry.DelayTypeFunc implementation causing fixed delays.
 func FixedDelayFunc(delay time.Duration) retry.DelayTypeFunc {
-	return func(_ uint, _ *retry.Config) time.Duration {
+	return func(_ uint, _ error, _ *retry.Config) time.Duration {
 		return delay
 	}
 }

--- a/retrybp/delay_test.go
+++ b/retrybp/delay_test.go
@@ -153,7 +153,7 @@ func TestCappedExponentialBackoff(t *testing.T) {
 					MaxDelay:     c.maxDelay,
 					MaxExponent:  c.maxExponent,
 					MaxJitter:    c.maxJitter,
-				})(c.n, nil)
+				})(c.n, nil, nil)
 				if delay < c.min || delay > c.max {
 					t.Errorf("Delay %v not in range [%v, %v]", delay, c.min, c.max)
 				}
@@ -171,7 +171,7 @@ func TestCappedExponentialBackoffQuick(t *testing.T) {
 		MaxJitter: max,
 	})
 	f := func() bool {
-		delay := delayFunc(n, nil)
+		delay := delayFunc(n, nil, nil)
 		if delay > max || delay <= 0 {
 			t.Errorf("Delay result overflew: %v", delay)
 		}


### PR DESCRIPTION
There's a breaking change in the upstream, this change makes retrybp
compatible with the new breaking change (and incompatible with the old
one), so that our users can upgrade to the latest version of retry-go.