### PR TITLE
retrybp: Implement retry-after logic in CappedExponentialBackoff

### DIFF
--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = [
+        "errors_example_test.go",
         "errors_test.go",
         "example_server_test.go",
         "fixtures_test.go",
@@ -48,6 +49,7 @@ go_test(
         "//log:go_default_library",
         "//mqsend:go_default_library",
         "//redisbp:go_default_library",
+        "//retrybp:go_default_library",
         "//secrets:go_default_library",
         "//tracing:go_default_library",
     ],

--- a/httpbp/errors_example_test.go
+++ b/httpbp/errors_example_test.go
@@ -1,0 +1,45 @@
+package httpbp_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/log"
+)
+
+// This example demonstrates how you can read the response body and add that
+// back to ClientError's AdditionalInfo field.
+func ExampleClientError() {
+	resp, err := http.Get("https://www.reddit.com")
+	if err != nil {
+		log.Errorw("http request failed", "err", err)
+		return
+	}
+	defer httpbp.DrainAndClose(resp.Body)
+	err = httpbp.ClientErrorFromResponse(resp)
+	if err != nil {
+		var ce *httpbp.ClientError
+		if errors.As(err, &ce) {
+			if body, e := ioutil.ReadAll(resp.Body); e == nil {
+				ce.AdditionalInfo = string(body)
+			}
+		}
+		log.Errorw("http request failed", "err", err)
+		return
+	}
+	// now read/handle body normally
+}
+
+// This example demonstrates how DrainAndClose should be used with http
+// requests.
+func ExampleDrainAndClose() {
+	resp, err := http.Get("https://www.reddit.com")
+	if err != nil {
+		log.Errorw("http request failed", "err", err)
+		return
+	}
+	defer httpbp.DrainAndClose(resp.Body)
+	// now read/handle body normally
+}


### PR DESCRIPTION
Define retrybp.RetryAfterError interface and add support to it to
CappedExponentialBackoff, and implement it in httpbp as
httpbp.ClientError.