### PR TITLE
retrybp: Add RetryableError and RetryableErrorFilter

### DIFF
--- a/clientpool/BUILD.bazel
+++ b/clientpool/BUILD.bazel
@@ -18,7 +18,9 @@ go_test(
     srcs = [
         "bench_test.go",
         "channel_test.go",
+        "errors_test.go",
         "interface_test.go",
     ],
     embed = [":go_default_library"],
+    deps = ["//retrybp:go_default_library"],
 )

--- a/clientpool/errors.go
+++ b/clientpool/errors.go
@@ -1,12 +1,24 @@
 package clientpool
 
 import (
-	"errors"
 	"fmt"
 )
 
 // ErrExhausted is the error returned by Get when the pool is exhausted.
-var ErrExhausted = errors.New("clientpool: exhausted")
+var ErrExhausted = exhaustedError{}
+
+type exhaustedError struct{}
+
+func (exhaustedError) Error() string {
+	return "clientpool: exhausted"
+}
+
+// Retryable implements retrybp.RetryableError.
+//
+// It always returns 1 to indicate that it's retryable.
+func (exhaustedError) Retryable() int {
+	return 1
+}
 
 // ConfigError is the error type returned when trying to open a new
 // client pool, but the configuration values passed in won't work.

--- a/clientpool/errors_test.go
+++ b/clientpool/errors_test.go
@@ -1,0 +1,9 @@
+package clientpool_test
+
+import (
+	"github.com/reddit/baseplate.go/clientpool"
+	"github.com/reddit/baseplate.go/retrybp"
+)
+
+// Doing this check in test code to avoid making clientpool importing retrybp.
+var _ retrybp.RetryableError = clientpool.ErrExhausted

--- a/httpbp/errors_test.go
+++ b/httpbp/errors_test.go
@@ -537,3 +537,5 @@ func TestClientError(t *testing.T) {
 		})
 	}
 }
+
+var _ retrybp.RetryableError = httpbp.ClientError{}

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -34,17 +34,14 @@ const MonitorClientWrappedSlugSuffix = "-with-retry"
 // WithDefaultRetryFilters returns a list of retrybp.Filters by appending the
 // given filters to the "default" retry filters:
 //
-// 1. ContextErrorFilter - do not retry on context cancellation/timeout.
+// 1. RetryableErrorFilter - handle errors already provided retryable
+// information, this includes clientpool.ErrExhausted
 //
-// 2. UnrecoverableErrorFilter - do not retry errors marked as unrecoverable with
-//    retry.Unrecoverable.
-//
-// 3. PoolExhaustedFilter - do retry on clientpool.PoolExhausted errors.
+// 2. ContextErrorFilter - do not retry on context cancellation/timeout.
 func WithDefaultRetryFilters(filters ...retrybp.Filter) []retrybp.Filter {
 	return append([]retrybp.Filter{
+		retrybp.RetryableErrorFilter,
 		retrybp.ContextErrorFilter,
-		retrybp.UnrecoverableErrorFilter,
-		retrybp.PoolExhaustedFilter,
 	}, filters...)
 }
 

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -34,14 +34,26 @@ var (
 //
 // 1. TOO_EARLY
 //
-// 2. SERVICE_UNAVAILABLE
+// 2. TOO_MANY_REQUESTS
 //
-// 3. TIMEOUT
+// 3. INTERNAL_SERVER_ERROR
+//
+// 4. BAD_GATEWAY
+//
+// 5. SERVICE_UNAVAILABLE
+//
+// 6. TIMEOUT
+//
+// 7. INSUFFICIENT_STORAGE
 func WithDefaultRetryableCodes(codes ...int32) []int32 {
 	return append([]int32{
 		int32(baseplatethrift.ErrorCode_TOO_EARLY),
+		int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
+		int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
+		int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 		int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
 		int32(baseplatethrift.ErrorCode_TIMEOUT),
+		int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 	}, codes...)
 }
 

--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -24,8 +24,12 @@ func TestWithDefaultRetryableCodes(t *testing.T) {
 			name: "default",
 			expected: []int32{
 				int32(baseplatethrift.ErrorCode_TOO_EARLY),
+				int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
+				int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
+				int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 				int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
 				int32(baseplatethrift.ErrorCode_TIMEOUT),
+				int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 			},
 		},
 		{
@@ -33,8 +37,12 @@ func TestWithDefaultRetryableCodes(t *testing.T) {
 			codes: []int32{1, 2, 3},
 			expected: []int32{
 				int32(baseplatethrift.ErrorCode_TOO_EARLY),
+				int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
+				int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
+				int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 				int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
 				int32(baseplatethrift.ErrorCode_TIMEOUT),
+				int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 				1,
 				2,
 				3,


### PR DESCRIPTION
Define RetryableError interface, and make RetryableErrorFilter as a
Filter implementation to check against it. Also add Unrecoverable helper
function to be used in favor over retry.Unrecoverable to have better
error wrapping.

Also make clientpool.ErrExhausted and httpbp.ClientError to implement
RetryableError.

As a result, deprecate PoolExhaustedFilter and UnrecoverableErrorFilter.