### PR TITLE
Add ecinterface package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//batchcloser:go_default_library",
-        "//edgecontext:go_default_library",
+        "//ecinterface:go_default_library",
         "//errorsbp:go_default_library",
         "//log:go_default_library",
         "//metricsbp:go_default_library",
@@ -32,6 +32,7 @@ go_test(
     srcs = ["baseplate_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//ecinterface:go_default_library",
         "//log:go_default_library",
         "//metricsbp:go_default_library",
         "//runtimebp:go_default_library",

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/runtimebp"
@@ -93,7 +94,11 @@ func TestServe(t *testing.T) {
 	store := newSecretsStore(t)
 	defer store.Close()
 
-	bp := baseplate.NewTestBaseplate(baseplate.Config{StopTimeout: testTimeout}, store)
+	bp := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
+		Config:          baseplate.Config{StopTimeout: testTimeout},
+		Store:           store,
+		EdgeContextImpl: ecinterface.Mock(),
+	})
 	closeError := errors.New("test close error")
 
 	cases := []struct {
@@ -165,7 +170,11 @@ func TestServeClosers(t *testing.T) {
 	store := newSecretsStore(t)
 	defer store.Close()
 
-	bp := baseplate.NewTestBaseplate(baseplate.Config{StopTimeout: testTimeout}, store)
+	bp := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
+		Config:          baseplate.Config{StopTimeout: testTimeout},
+		Store:           store,
+		EdgeContextImpl: ecinterface.Mock(),
+	})
 
 	pre := &timestampCloser{}
 	post := &timestampCloser{}

--- a/ecinterface/BUILD.bazel
+++ b/ecinterface/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "interface.go",
+        "mock.go",
+    ],
+    importpath = "github.com/reddit/baseplate.go/ecinterface",
+    visibility = ["//visibility:public"],
+    deps = ["//secrets:go_default_library"],
+)

--- a/ecinterface/doc.go
+++ b/ecinterface/doc.go
@@ -1,0 +1,6 @@
+// Package ecinterface defines the interfaces of edgecontext package used in
+// Baseplate.go.
+//
+// The actual edgecontext implementation is provided in a separated library,
+// but it implements the interfaces defined in this package.
+package ecinterface

--- a/ecinterface/interface.go
+++ b/ecinterface/interface.go
@@ -1,0 +1,33 @@
+package ecinterface
+
+import (
+	"context"
+
+	"github.com/reddit/baseplate.go/secrets"
+)
+
+// Interface defines the interface edgecontext implementation must implements.
+//
+// The string "header" does not necessarily need to be ASCII/UTF-8 string.
+// For thrift those headers will be used as-is,
+// for HTTP those headers will always be wrapped with additional base64
+// encoding.
+type Interface interface {
+	// HeaderToContext parses the edge context from header,
+	// then inject the object into context.
+	HeaderToContext(ctx context.Context, header string) (context.Context, error)
+
+	// ContextToHeader extracts edge context object from context,
+	// then serializes it into header.
+	//
+	// It shall return ("", false) when there's no edge context attached to ctx.
+	ContextToHeader(ctx context.Context) (header string, ok bool)
+}
+
+// FactoryArgs defines the args used in Factory.
+type FactoryArgs struct {
+	Store *secrets.Store
+}
+
+// Factory is the callback used by baseplate.New to create the implementation.
+type Factory func(args FactoryArgs) (Interface, error)

--- a/ecinterface/mock.go
+++ b/ecinterface/mock.go
@@ -1,0 +1,26 @@
+package ecinterface
+
+import (
+	"context"
+)
+
+type ecKey struct{}
+
+type ecImpl struct{}
+
+func (ecImpl) ContextToHeader(ctx context.Context) (string, bool) {
+	if v := ctx.Value(ecKey{}); v != nil {
+		header, ok := v.(string)
+		return header, ok
+	}
+	return "", false
+}
+
+func (ecImpl) HeaderToContext(ctx context.Context, header string) (context.Context, error) {
+	return context.WithValue(ctx, ecKey{}, header), nil
+}
+
+// Mock creates a mocked Interface.
+func Mock() Interface {
+	return ecImpl{}
+}

--- a/edgecontext/BUILD.bazel
+++ b/edgecontext/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/edgecontext",
     visibility = ["//visibility:public"],
     deps = [
+        "//ecinterface:go_default_library",
         "//experiments:go_default_library",
         "//internal/gen-go/reddit/edgecontext:go_default_library",
         "//log:go_default_library",

--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:go_default_library",
-        "//edgecontext:go_default_library",
+        "//ecinterface:go_default_library",
         "//errorsbp:go_default_library",
         "//internal/gen-go/reddit/baseplate:go_default_library",
         "//log:go_default_library",
@@ -44,7 +44,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
-        "//edgecontext:go_default_library",
+        "//ecinterface:go_default_library",
         "//internal/gen-go/reddit/baseplate:go_default_library",
         "//log:go_default_library",
         "//mqsend:go_default_library",

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/redisbp"
@@ -92,7 +93,13 @@ var (
 // Baseplate HTTP service.
 func ExampleNewBaseplateServer() {
 	var cfg config
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
+	// In real code this MUST be replaced by the factory from the actual implementation.
+	var ecFactory ecinterface.Factory
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
+		ConfigPath:         "example.yaml",
+		EdgeContextFactory: ecFactory,
+		ServiceCfg:         &cfg,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/reddit/baseplate.go/edgecontext"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/signing"
 )
@@ -74,8 +73,8 @@ func NewEdgeContextHeaders(h http.Header) (EdgeContextHeaders, error) {
 }
 
 // SetEdgeContextHeader attach EdgeRequestContext into response header.
-func SetEdgeContextHeader(ec *edgecontext.EdgeRequestContext, w http.ResponseWriter) {
-	w.Header().Set(EdgeContextHeader, encodeEdgeContextHeader([]byte(ec.Header())))
+func SetEdgeContextHeader(header string, w http.ResponseWriter) {
+	w.Header().Set(EdgeContextHeader, encodeEdgeContextHeader([]byte(header)))
 }
 
 // AsMap returns the EdgeContextHeaders as a map of header keys to header

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -45,7 +45,7 @@ func Wrap(name string, handle HandlerFunc, middlewares ...Middleware) HandlerFun
 // Middlewares
 type DefaultMiddlewareArgs struct {
 	// The edgecontext implementation to use. Required.
-	EdgeContextImpl *edgecontext.Impl
+	EdgeContextImpl ecinterface.Interface
 
 	// The HeaderTrustHandler to use.
 	// If empty, NeverTrustHeaders will be used instead.
@@ -161,20 +161,19 @@ func InitializeEdgeContextFromTrustedRequest(
 		args.Logger.Log(ctx, "Error while parsing EdgeRequestContext: "+err.Error())
 		return ctx
 	}
-	ec, err := edgecontext.FromHeader(ctx, string(header), args.EdgeContextImpl)
+	ctx, err = args.EdgeContextImpl.HeaderToContext(ctx, string(header))
 	if err != nil {
 		args.Logger.Log(ctx, "Error while parsing EdgeRequestContext: "+err.Error())
-		return ctx
 	}
 
-	return edgecontext.SetEdgeContext(ctx, ec)
+	return ctx
 }
 
 // InjectEdgeRequestContextArgs are the args to be passed into
 // InjectEdgeRequestContext function.
 type InjectEdgeRequestContextArgs struct {
 	// The edgecontext implementation to use. Required.
-	EdgeContextImpl *edgecontext.Impl
+	EdgeContextImpl ecinterface.Interface
 
 	// The HeaderTrustHandler to use.
 	// If empty, NeverTrustHeaders{} will be used instead.

--- a/httpbp/middlewares_test.go
+++ b/httpbp/middlewares_test.go
@@ -10,17 +10,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/reddit/baseplate.go/edgecontext"
-
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/tracing"
-)
-
-const (
-	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L56
-	headerWithValidAuth = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x00"
 )
 
 func TestWrap(t *testing.T) {
@@ -63,7 +57,7 @@ func TestInjectServerSpan(t *testing.T) {
 	})
 	startFailing()
 
-	req := newRequest(t)
+	req := newRequest(t, "")
 
 	cases := []struct {
 		name           string
@@ -146,39 +140,34 @@ func TestInjectServerSpan(t *testing.T) {
 func TestInjectEdgeRequestContext(t *testing.T) {
 	t.Parallel()
 
-	const expectedID = "t2_example"
+	const expectedHeader = "dummy-edge-context"
 
-	store := newSecretsStore(t)
-	defer store.Close()
-
-	impl := edgecontext.Init(edgecontext.Config{Store: store})
-	req := newRequest(t)
-	noHeader := newRequest(t)
+	impl := ecinterface.Mock()
+	req := newRequest(t, expectedHeader)
+	noHeader := newRequest(t, expectedHeader)
 	noHeader.Header.Del(httpbp.EdgeContextHeader)
 
 	cases := []struct {
-		name       string
-		truster    httpbp.HeaderTrustHandler
-		request    *http.Request
-		expectedID string
+		name           string
+		truster        httpbp.HeaderTrustHandler
+		request        *http.Request
+		expectedHeader string
 	}{
 		{
-			name:       "trust/header",
-			truster:    httpbp.AlwaysTrustHeaders{},
-			request:    req,
-			expectedID: expectedID,
+			name:           "trust/header",
+			truster:        httpbp.AlwaysTrustHeaders{},
+			request:        req,
+			expectedHeader: expectedHeader,
 		},
 		{
-			name:       "trust/no-header",
-			truster:    httpbp.AlwaysTrustHeaders{},
-			request:    noHeader,
-			expectedID: "",
+			name:    "trust/no-header",
+			truster: httpbp.AlwaysTrustHeaders{},
+			request: noHeader,
 		},
 		{
-			name:       "no-trust",
-			truster:    httpbp.NeverTrustHeaders{},
-			request:    req,
-			expectedID: "",
+			name:    "no-trust",
+			truster: httpbp.NeverTrustHeaders{},
+			request: req,
 		},
 	}
 	for _, _c := range cases {
@@ -195,26 +184,12 @@ func TestInjectEdgeRequestContext(t *testing.T) {
 						TrustHandler:    c.truster,
 						Logger:          log.TestWrapper(t),
 					}),
-					edgecontextRecorderMiddleware(&recorder),
+					edgecontextRecorderMiddleware(impl, &recorder),
 				)
 				handle(c.request.Context(), httptest.NewRecorder(), c.request)
 
-				if c.expectedID != "" {
-					if recorder.EdgeContext == nil {
-						t.Fatal("edge request context not set")
-					}
-
-					userID, ok := recorder.EdgeContext.User().ID()
-					if !ok {
-						t.Error("user should be logged in")
-					}
-					if userID != c.expectedID {
-						t.Errorf("user ID mismatch, expected %q, got %q", c.expectedID, userID)
-					}
-				} else {
-					if recorder.EdgeContext != nil {
-						t.Fatal("edge request context should not be set")
-					}
+				if c.expectedHeader != recorder.header {
+					t.Errorf("Expected edge-context header to be %q, got %q", c.expectedHeader, recorder.header)
 				}
 			},
 		)
@@ -272,7 +247,7 @@ func TestSupportedMethods(t *testing.T) {
 		t.Run(
 			c.name,
 			func(t *testing.T) {
-				req := newRequest(t)
+				req := newRequest(t, "")
 				req.Method = c.method
 				handle := httpbp.Wrap(
 					"test",

--- a/redisbp/BUILD.bazel
+++ b/redisbp/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
+        "//ecinterface:go_default_library",
         "//metricsbp:go_default_library",
         "//mqsend:go_default_library",
         "//thriftbp:go_default_library",

--- a/redisbp/example_config_test.go
+++ b/redisbp/example_config_test.go
@@ -5,18 +5,25 @@ import (
 
 	"github.com/go-redis/redis/v7"
 	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/redisbp"
 )
 
-type config struct {
+type Config struct {
 	Redis redisbp.ClientConfig `yaml:"redis"`
 }
 
 // This example shows how you can embed a redis config in a struct and parse
 // that with `baseplate.New`.
 func ExampleClientConfig() {
-	var cfg config
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", &cfg)
+	var cfg Config
+	// In real code this MUST be replaced by the factory from the actual implementation.
+	var ecFactory ecinterface.Factory
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
+		ConfigPath:         "example.yaml",
+		EdgeContextFactory: ecFactory,
+		ServiceCfg:         &cfg,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/thriftbp/BUILD.bazel
+++ b/thriftbp/BUILD.bazel
@@ -20,7 +20,7 @@ go_library(
         "//:go_default_library",
         "//breakerbp:go_default_library",
         "//clientpool:go_default_library",
-        "//edgecontext:go_default_library",
+        "//ecinterface:go_default_library",
         "//errorsbp:go_default_library",
         "//internal/gen-go/reddit/baseplate:go_default_library",
         "//log:go_default_library",
@@ -54,7 +54,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//:go_default_library",
-        "//edgecontext:go_default_library",
+        "//ecinterface:go_default_library",
         "//internal/gen-go/reddit/baseplate:go_default_library",
         "//log:go_default_library",
         "//mqsend:go_default_library",

--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/thriftbp"
 )
 
@@ -39,6 +41,7 @@ func TestNewBaseplateClientPool(t *testing.T) {
 	if _, err = thriftbp.NewBaseplateClientPool(
 		thriftbp.ClientPoolConfig{
 			Addr:               ln.Addr().String(),
+			EdgeContextImpl:    ecinterface.Mock(),
 			ServiceSlug:        "test",
 			InitialConnections: 1,
 			MaxConnections:     5,
@@ -61,6 +64,7 @@ func TestCustomClientPool(t *testing.T) {
 	if _, err := thriftbp.NewCustomClientPool(
 		thriftbp.ClientPoolConfig{
 			Addr:               ":9090",
+			EdgeContextImpl:    ecinterface.Mock(),
 			ServiceSlug:        "test",
 			InitialConnections: 1,
 			MaxConnections:     5,
@@ -99,6 +103,7 @@ func TestInitialConnectionsFallback(t *testing.T) {
 
 	cfg := thriftbp.ClientPoolConfig{
 		ServiceSlug:                      "test",
+		EdgeContextImpl:                  ecinterface.Mock(),
 		Addr:                             ":9090",
 		InitialConnections:               2,
 		MaxConnections:                   5,

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -26,6 +26,7 @@ var (
 var (
 	ErrConfigMissingServiceSlug = errors.New("ServiceSlug cannot be empty")
 	ErrConfigMissingAddr        = errors.New("Addr cannot be empty")
+	ErrConfigMissingEdgeContext = errors.New("EdgeContextImpl cannot be empty")
 	ErrConfigInvalidConnections = errors.New("InitialConnections cannot be bigger than MaxConnections")
 )
 

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/ecinterface"
 	bpgen "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/thriftbp"
@@ -12,7 +13,12 @@ import (
 // This example demonstrates what a typical main function should look like for a
 // Baseplate thrift service.
 func ExampleNewBaseplateServer() {
-	ctx, bp, err := baseplate.New(context.Background(), "example.yaml", nil)
+	// In real code this MUST be replaced by the factory from the actual implementation.
+	var ecFactory ecinterface.Factory
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
+		ConfigPath:         "example.yaml",
+		EdgeContextFactory: ecFactory,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/thriftbp/fixtures_test.go
+++ b/thriftbp/fixtures_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/reddit/baseplate.go/secrets"
 )
 
-const (
-	// copied from https://github.com/reddit/edgecontext.py/blob/420e58728ee7085a2f91c5db45df233142b251f9/tests/edge_context_tests.py#L56
-	headerWithValidAuth = "\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x0b\x00\x03\x00\x00\x01\xaeeyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0Ml9leGFtcGxlIiwiZXhwIjoyNTI0NjA4MDAwfQ.dRzzfc9GmzyqfAbl6n_C55JJueraXk9pp3v0UYXw0ic6W_9RVa7aA1zJWm7slX9lbuYldwUtHvqaSsOpjF34uqr0-yMoRDVpIrbkwwJkNuAE8kbXGYFmXf3Ip25wMHtSXn64y2gJN8TtgAAnzjjGs9yzK9BhHILCDZTtmPbsUepxKmWTiEX2BdurUMZzinbcvcKY4Rb_Fl0pwsmBJFs7nmk5PvTyC6qivCd8ZmMc7dwL47mwy_7ouqdqKyUEdLoTEQ_psuy9REw57PRe00XCHaTSTRDCLmy4gAN6J0J056XoRHLfFcNbtzAmqmtJ_D9HGIIXPKq-KaggwK9I4qLX7g\x0c\x00\x04\x0b\x00\x01\x00\x00\x00$becc50f6-ff3d-407a-aa49-fa49531363be\x00\x0c\x00\x05\x0b\x00\x01\x00\x00\x00\tbaseplate\x00\x0c\x00\x06\x0b\x00\x01\x00\x00\x00\x02OK\x00\x00"
-)
-
 func newSecretsStore(t testing.TB) *secrets.Store {
 	t.Helper()
 

--- a/thriftbp/headers.go
+++ b/thriftbp/headers.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	"github.com/reddit/baseplate.go/edgecontext"
+	"github.com/reddit/baseplate.go/ecinterface"
 )
 
 // Edge request context propagation related headers, as defined in
@@ -53,14 +53,15 @@ var HeadersToForward = []string{
 	HeaderTracingFlags,
 }
 
-// AttachEdgeRequestContext returns a context that has the header of the given
-// EdgeRequestContext set to forward using the "Edge-Request" header on any
-// Thrift calls made with that context object.
-func AttachEdgeRequestContext(ctx context.Context, ec *edgecontext.EdgeRequestContext) context.Context {
-	if ec == nil {
+// AttachEdgeRequestContext returns a context that has the header of the edge
+// context attached to ctx object set to forward using the "Edge-Request" header
+// on any Thrift calls made with that context object.
+func AttachEdgeRequestContext(ctx context.Context, ecImpl ecinterface.Interface) context.Context {
+	header, ok := ecImpl.ContextToHeader(ctx)
+	if !ok {
 		return thrift.UnsetHeader(ctx, HeaderEdgeRequest)
 	}
-	return AddClientHeader(ctx, HeaderEdgeRequest, ec.Header())
+	return AddClientHeader(ctx, HeaderEdgeRequest, header)
 }
 
 // AddClientHeader adds a key-value pair to thrift client's headers.

--- a/thriftbp/thrifttest/BUILD.bazel
+++ b/thriftbp/thrifttest/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//:go_default_library",
         "//batchcloser:go_default_library",
         "//clientpool:go_default_library",
+        "//ecinterface:go_default_library",
         "//errorsbp:go_default_library",
         "//secrets:go_default_library",
         "//thriftbp:go_default_library",

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -8,6 +8,7 @@ import (
 
 	baseplate "github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/batchcloser"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/thriftbp"
@@ -181,7 +182,11 @@ func NewBaseplateServer(cfg ServerConfig) (*Server, error) {
 	}
 
 	cfg.ServerConfig.Addr = socket.Addr().String()
-	bp := baseplate.NewTestBaseplate(cfg.ServerConfig, cfg.SecretStore)
+	bp := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
+		Config:          cfg.ServerConfig,
+		Store:           cfg.SecretStore,
+		EdgeContextImpl: ecinterface.Mock(),
+	})
 	middlewares := thriftbp.BaseplateDefaultProcessorMiddlewares(
 		thriftbp.DefaultProcessorMiddlewaresArgs{
 			EdgeContextImpl:     bp.EdgeContextImpl(),
@@ -214,6 +219,9 @@ func NewBaseplateServer(cfg ServerConfig) (*Server, error) {
 	}
 	if cfg.ClientConfig.ServiceSlug == "" {
 		cfg.ClientConfig.ServiceSlug = DefaultServiceSlug
+	}
+	if cfg.ClientConfig.EdgeContextImpl == nil {
+		cfg.ClientConfig.EdgeContextImpl = ecinterface.Mock()
 	}
 	if cfg.ClientConfig.MaxConnections == 0 {
 		cfg.ClientConfig.MaxConnections = DefaultClientMaxConnections


### PR DESCRIPTION
And switch everything else to use it instead of edgecontext package.

This is the first step of splitting edgecontext implementation to its
own repo. After this change, nothing in Baseplate.go depends on
edgecontext package any more, so we could move it to its own repo and
remove it from Baseplate.go in the next step.