### PR TITLE
events&tracing: Make max mq size configurable

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -51,6 +51,12 @@ type Config struct {
 	//
 	// If MaxPutTimeout <= 0, DefaultMaxPutTimeout will be used instead.
 	MaxPutTimeout time.Duration
+
+	// The max size of the message queue (number of messages).
+	//
+	// If it <=0 or > MaxQueueSize (the constant, 10000),
+	// MaxQueueSize constant will be used instead.
+	MaxQueueSize int64
 }
 
 // V2 initializes a new v2 event queue with default configurations.
@@ -64,9 +70,12 @@ func V2WithConfig(cfg Config) (*Queue, error) {
 	if name == "" {
 		name = DefaultV2Name
 	}
+	if cfg.MaxQueueSize <= 0 || cfg.MaxQueueSize > MaxQueueSize {
+		cfg.MaxQueueSize = MaxQueueSize
+	}
 	queue, err := mqsend.OpenMessageQueue(mqsend.MessageQueueConfig{
 		Name:           QueueNamePrefix + name,
-		MaxQueueSize:   MaxQueueSize,
+		MaxQueueSize:   cfg.MaxQueueSize,
 		MaxMessageSize: MaxEventSize,
 	})
 	if err != nil {

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -87,6 +87,14 @@ type TracerConfig struct {
 	// including the ones with debug flag set.
 	QueueName string
 
+	// The max size of the message queue (number of messages).
+	//
+	// If it <=0 or > MaxQueueSize (the constant, 10000),
+	// MaxQueueSize constant will be used instead.
+	//
+	// This is only used when QueueName is non-empty.
+	MaxQueueSize int64
+
 	// In test code,
 	// this field can be used to set the message queue the tracer publishes to,
 	// usually an *mqsend.MockMessageQueue.
@@ -106,9 +114,12 @@ type TracerConfig struct {
 // and the error will be logged if logger is non-nil.
 func InitGlobalTracer(cfg TracerConfig) error {
 	if cfg.QueueName != "" {
+		if cfg.MaxQueueSize <= 0 || cfg.MaxQueueSize > MaxQueueSize {
+			cfg.MaxQueueSize = MaxQueueSize
+		}
 		recorder, err := mqsend.OpenMessageQueue(mqsend.MessageQueueConfig{
 			Name:           QueueNamePrefix + cfg.QueueName,
-			MaxQueueSize:   MaxQueueSize,
+			MaxQueueSize:   cfg.MaxQueueSize,
 			MaxMessageSize: MaxSpanSize,
 		})
 		if err != nil {


### PR DESCRIPTION
When the publishing sidecar is having trouble keeping up and messages
piling up in the mq, the memory used by the mq could be count towards
the memory used by the service, and in some cases could cause the
service getting OOM killed.

Make them configurable so for services that would have low memory
request/limit could limit the max memory used by the message queue.

See also: https://github.com/reddit/baseplate.py/pull/553.