### PR TITLE
tracing: Support UUID

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"context"
-	"strconv"
 
 	"go.uber.org/zap"
 )
@@ -13,7 +12,7 @@ var contextKey contextKeyType
 
 // logger keys for attached data.
 const (
-	traceIDKey = "trace_id"
+	traceIDKey = "traceID"
 )
 
 // AttachArgs are used to create loggers to be attached to context object with
@@ -25,7 +24,7 @@ const (
 // AdditionalPairs are provided to add any free form, additional key-value pairs
 // you want to attach to all logs from the same context object.
 type AttachArgs struct {
-	TraceID uint64
+	TraceID string
 
 	AdditionalPairs map[string]interface{}
 }
@@ -37,8 +36,8 @@ func Attach(ctx context.Context, args AttachArgs) context.Context {
 	const additional = 1
 	kv := make([]interface{}, 0, len(args.AdditionalPairs)*2+additional)
 
-	if args.TraceID != 0 {
-		kv = append(kv, zap.String(traceIDKey, strconv.FormatUint(args.TraceID, 10)))
+	if args.TraceID != "" {
+		kv = append(kv, zap.String(traceIDKey, args.TraceID))
 	}
 
 	for k, v := range args.AdditionalPairs {

--- a/thriftbp/server_middlewares_test.go
+++ b/thriftbp/server_middlewares_test.go
@@ -95,13 +95,9 @@ func TestInjectServerSpan(t *testing.T) {
 
 func TestStartSpanFromThriftContext(t *testing.T) {
 	const (
-		name = "foo"
-
-		traceInt = 12345
-		traceStr = "12345"
-
-		spanInt = 54321
-		spanStr = "54321"
+		name   = "foo"
+		trace  = "12345"
+		spanID = "54321"
 	)
 
 	defer func() {
@@ -115,23 +111,23 @@ func TestStartSpanFromThriftContext(t *testing.T) {
 	startFailing()
 
 	ctx := context.Background()
-	ctx = thrift.SetHeader(ctx, thriftbp.HeaderTracingTrace, traceStr)
-	ctx = thrift.SetHeader(ctx, thriftbp.HeaderTracingSpan, spanStr)
+	ctx = thrift.SetHeader(ctx, thriftbp.HeaderTracingTrace, trace)
+	ctx = thrift.SetHeader(ctx, thriftbp.HeaderTracingSpan, spanID)
 
 	ctx, span := thriftbp.StartSpanFromThriftContext(ctx, name)
 
-	if span.TraceID() != traceInt {
+	if span.TraceID() != trace {
 		t.Errorf(
-			"span's traceID expected %d, got %d",
-			traceInt,
+			"span's traceID expected %q, got %q",
+			trace,
 			span.TraceID(),
 		)
 	}
 
-	if span.ParentID() != spanInt {
+	if span.ParentID() != spanID {
 		t.Errorf(
-			"span's parent id expected %d, got %d",
-			spanInt,
+			"span's parent id expected %q, got %q",
+			spanID,
 			span.ParentID(),
 		)
 	}

--- a/thriftbp/tracing.go
+++ b/thriftbp/tracing.go
@@ -36,14 +36,14 @@ func CreateThriftContextFromSpan(ctx context.Context, span *tracing.Span) contex
 	ctx = thrift.SetHeader(
 		ctx,
 		HeaderTracingTrace,
-		strconv.FormatUint(span.TraceID(), 10),
+		span.TraceID(),
 	)
 	headers = append(headers, HeaderTracingTrace)
 
 	ctx = thrift.SetHeader(
 		ctx,
 		HeaderTracingSpan,
-		strconv.FormatUint(span.ID(), 10),
+		span.ID(),
 	)
 	headers = append(headers, HeaderTracingSpan)
 
@@ -54,11 +54,11 @@ func CreateThriftContextFromSpan(ctx context.Context, span *tracing.Span) contex
 	)
 	headers = append(headers, HeaderTracingFlags)
 
-	if span.ParentID() != 0 {
+	if span.ParentID() != "" {
 		ctx = thrift.SetHeader(
 			ctx,
 			HeaderTracingParent,
-			strconv.FormatUint(span.ParentID(), 10),
+			span.ParentID(),
 		)
 		headers = append(headers, HeaderTracingParent)
 	} else {

--- a/thriftbp/tracing_test.go
+++ b/thriftbp/tracing_test.go
@@ -87,7 +87,7 @@ func TestCreateThriftContextFromSpan(t *testing.T) {
 			}
 
 			checkContextKey(t, ctx, thriftbp.HeaderTracingSpan)
-			expectedSpanID := fmt.Sprintf("%d", child.ID())
+			expectedSpanID := child.ID()
 			if v, ok := thrift.GetHeader(ctx, thriftbp.HeaderTracingSpan); !ok || v != expectedSpanID {
 				t.Errorf(
 					"span in the context expected to be %q, got %q & %v",
@@ -144,7 +144,7 @@ func TestCreateThriftContextFromSpan(t *testing.T) {
 			}
 
 			checkContextKey(t, ctx, thriftbp.HeaderTracingSpan)
-			expectedSpanID := fmt.Sprintf("%d", child.ID())
+			expectedSpanID := child.ID()
 			if v, ok := thrift.GetHeader(ctx, thriftbp.HeaderTracingSpan); !ok || v != expectedSpanID {
 				t.Errorf(
 					"span in the context expected to be %q, got %q & %v",

--- a/tracing/BUILD.bazel
+++ b/tracing/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//runtimebp:go_default_library",
         "//timebp:go_default_library",
         "@com_github_getsentry_sentry_go//:go_default_library",
+        "@com_github_gofrs_uuid//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_opentracing_opentracing_go//log:go_default_library",
     ],
@@ -48,6 +49,7 @@ go_test(
         "//randbp:go_default_library",
         "//thriftbp:go_default_library",
         "//timebp:go_default_library",
+        "@com_github_gofrs_uuid//:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
     ],
 )

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -26,9 +26,9 @@ type trace struct {
 	tracer *Tracer
 
 	name     string
-	traceID  uint64
-	spanID   uint64
-	parentID uint64
+	traceID  string
+	spanID   string
+	parentID string
 	sampled  bool
 	flags    int64
 
@@ -49,8 +49,8 @@ func newTrace(tracer *Tracer, name string) *trace {
 		tracer: tracer,
 
 		name:    name,
-		traceID: nonZeroRandUint64(),
-		spanID:  nonZeroRandUint64(),
+		traceID: tracer.newID(),
+		spanID:  tracer.newID(),
 		start:   time.Now(),
 
 		counters: make(map[string]float64),

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"testing/quick"
 	"time"
 
+	"github.com/gofrs/uuid"
 	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/log"
@@ -132,4 +134,22 @@ func TestTracer(t *testing.T) {
 			t.Logf("Encoded span: %s", msg)
 		},
 	)
+}
+
+func TestFakeUUIDQuick(t *testing.T) {
+	f := func() bool {
+		s := fakeUUID()
+		id, err := uuid.FromString(s)
+		if err != nil {
+			t.Errorf("Failed to parse %q as uuid: %v", s, err)
+		}
+		if s != id.String() {
+			t.Errorf("fake uuid %q parsed differently as %q", s, id.String())
+		}
+		return !t.Failed()
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+	t.Log(fakeUUID())
 }

--- a/tracing/zipkin.go
+++ b/tracing/zipkin.go
@@ -13,15 +13,14 @@ import (
 // https://github.com/reddit/baseplate.py/blob/1ca8488bcd42c8786e6a3db35b2a99517fd07a99/baseplate/observers/tracing.py#L266-L280
 type ZipkinSpan struct {
 	// Required fields.
-	TraceID  uint64                      `json:"traceId"`
+	TraceID  string                      `json:"traceId"`
 	Name     string                      `json:"name"`
-	SpanID   uint64                      `json:"id"`
+	SpanID   string                      `json:"id"`
 	Start    timebp.TimestampMicrosecond `json:"timestamp"`
 	Duration timebp.DurationMicrosecond  `json:"duration"`
 
-	// parentId is actually optional,
-	// but when it's absent 0 needs to be set explicitly.
-	ParentID uint64 `json:"parentId"`
+	// parentId is optional,
+	ParentID string `json:"parentId,omitempty"`
 
 	// Annotations are all optional.
 	TimeAnnotations   []ZipkinTimeAnnotation   `json:"annotations,omitempty"`

--- a/tracing/zipkin_test.go
+++ b/tracing/zipkin_test.go
@@ -23,19 +23,19 @@ func TestZipkinSpan(t *testing.T) {
 	}
 	cases := map[string]tracing.ZipkinSpan{
 		"optional-absent": {
-			TraceID:  1234,
+			TraceID:  "1234",
 			Name:     "foo",
-			SpanID:   4321,
+			SpanID:   "4321",
 			Start:    timebp.TimestampMicrosecond(now),
 			Duration: timebp.DurationMicrosecond(duration),
 		},
 		"optional-filled": {
-			TraceID:  1234,
+			TraceID:  "1234",
 			Name:     "foo",
-			SpanID:   4321,
+			SpanID:   "4321",
 			Start:    timebp.TimestampMicrosecond(now),
 			Duration: timebp.DurationMicrosecond(duration),
-			ParentID: 54321,
+			ParentID: "54321",
 			TimeAnnotations: []tracing.ZipkinTimeAnnotation{
 				{
 					Endpoint:  endpoint,


### PR DESCRIPTION
Add support to UUID and option UseUUID to Tracer's Config.

Also change the log key for trace id from trace_id to traceID.