### PR TITLE
ecinterface: Add global implementation

### DIFF
--- a/ecinterface/BUILD.bazel
+++ b/ecinterface/BUILD.bazel
@@ -4,10 +4,14 @@ go_library(
     name = "ecinterface",
     srcs = [
         "doc.go",
+        "global.go",
         "interface.go",
         "mock.go",
     ],
     importpath = "github.com/reddit/baseplate.go/ecinterface",
     visibility = ["//visibility:public"],
-    deps = ["//secrets"],
+    deps = [
+        "//log",
+        "//secrets",
+    ],
 )

--- a/ecinterface/global.go
+++ b/ecinterface/global.go
@@ -1,0 +1,54 @@
+package ecinterface
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+// Logger is used by Get when it's called before Set is called.
+var Logger log.Wrapper = log.ErrorWithSentryWrapper()
+
+// ErrGetBeforeSet is the error returned when Get is called before Set.
+var ErrGetBeforeSet = errors.New("ecinterface: Get called before Set is called")
+
+// actual type: Interface
+var global atomic.Value
+
+// Set sets the global edge context implementation.
+func Set(impl Interface) {
+	global.Store(impl)
+}
+
+// Get returns the previously Set global edge context implementation.
+//
+// It's guaranteed to return a non-nil implementation.
+// If it's called before any Set is called,
+// it logs the event (via Logger),
+// then returns an implementation that does nothing:
+//
+// - Its HeaderToContext always return the context intact with ErrGetBeforeSet.
+//
+// - Its ContextToHeader always return ("", false).
+func Get() Interface {
+	v := global.Load()
+	if impl, _ := v.(Interface); impl != nil {
+		return impl
+	}
+	Logger.Log(context.Background(), ErrGetBeforeSet.Error())
+	return nopImpl
+}
+
+type nop struct{}
+
+var nopImpl nop
+
+func (nop) HeaderToContext(ctx context.Context, header string) (context.Context, error) {
+	return ctx, ErrGetBeforeSet
+}
+
+func (nop) ContextToHeader(ctx context.Context) (string, bool) {
+	return "", false
+}

--- a/edgecontext/edgecontext.go
+++ b/edgecontext/edgecontext.go
@@ -100,12 +100,15 @@ func Factory(cfg Config) ecinterface.Factory {
 }
 
 // Init intializes an Impl.
+//
+// It also calls ecinterface.Set to store the implementation created globally.
 func Init(cfg Config) *Impl {
 	impl := &Impl{
 		store:  cfg.Store,
 		logger: cfg.Logger,
 	}
 	impl.store.AddMiddlewares(impl.validatorMiddleware)
+	ecinterface.Set(impl)
 	return impl
 }
 

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -46,9 +46,6 @@ var (
 
 // ClientPoolConfig is the configuration struct for creating a new ClientPool.
 type ClientPoolConfig struct {
-	// The edge context implementation. Required.
-	EdgeContextImpl ecinterface.Interface
-
 	// ServiceSlug is a short identifier for the thrift service you are creating
 	// clients for.  The preferred convention is to take the service's name,
 	// remove the 'Service' prefix, if present, and convert from camel case to
@@ -171,6 +168,11 @@ type ClientPoolConfig struct {
 	// a breakerbp.FailureRatioBreaker will be created for the pool,
 	// and its middleware will be set for the pool.
 	BreakerConfig *breakerbp.Config
+
+	// The edge context implementation. Optional.
+	//
+	// If it's not set, the global one from ecinterface.Get will be used instead.
+	EdgeContextImpl ecinterface.Interface
 }
 
 // Validate checks ClientPoolConfig for any missing or erroneous values.
@@ -179,9 +181,6 @@ type ClientPoolConfig struct {
 // BaseplateClientPoolConfig(c).Validate should be used instead.
 func (c ClientPoolConfig) Validate() error {
 	var batch errorsbp.Batch
-	if c.EdgeContextImpl == nil {
-		batch.Add(ErrConfigMissingEdgeContext)
-	}
 	if c.InitialConnections > c.MaxConnections {
 		batch.Add(ErrConfigInvalidConnections)
 	}

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -26,7 +26,6 @@ var (
 var (
 	ErrConfigMissingServiceSlug = errors.New("ServiceSlug cannot be empty")
 	ErrConfigMissingAddr        = errors.New("Addr cannot be empty")
-	ErrConfigMissingEdgeContext = errors.New("EdgeContextImpl cannot be empty")
 	ErrConfigInvalidConnections = errors.New("InitialConnections cannot be bigger than MaxConnections")
 )
 

--- a/thriftbp/headers.go
+++ b/thriftbp/headers.go
@@ -57,6 +57,9 @@ var HeadersToForward = []string{
 // context attached to ctx object set to forward using the "Edge-Request" header
 // on any Thrift calls made with that context object.
 func AttachEdgeRequestContext(ctx context.Context, ecImpl ecinterface.Interface) context.Context {
+	if ecImpl == nil {
+		ecImpl = ecinterface.Get()
+	}
 	header, ok := ecImpl.ContextToHeader(ctx)
 	if !ok {
 		return thrift.UnsetHeader(ctx, HeaderEdgeRequest)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -26,9 +26,6 @@ var (
 // BaseplateDefaultProcessorMiddlewares function to create default processor
 // middlewares.
 type DefaultProcessorMiddlewaresArgs struct {
-	// The edge context implementation. Required.
-	EdgeContextImpl ecinterface.Interface
-
 	// Suppress some of the errors returned by the server before sending them to
 	// the server span.
 	//
@@ -46,6 +43,11 @@ type DefaultProcessorMiddlewaresArgs struct {
 	//
 	// This is optional. If it's not set none of the requests will be sampled.
 	ReportPayloadSizeMetricsSampleRate float64
+
+	// The edge context implementation. Optional.
+	//
+	// If it's not set, the global one from ecinterface.Get will be used instead.
+	EdgeContextImpl ecinterface.Interface
 }
 
 // BaseplateDefaultProcessorMiddlewares returns the default processor
@@ -171,6 +173,9 @@ func InitializeEdgeContext(ctx context.Context, impl ecinterface.Interface) cont
 // context object.  These should be automatically injected by your
 // thrift.TSimpleServer.
 func InjectEdgeContext(impl ecinterface.Interface) thrift.ProcessorMiddleware {
+	if impl == nil {
+		impl = ecinterface.Get()
+	}
 	return func(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 		return thrift.WrappedTProcessorFunction{
 			Wrapped: func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (bool, thrift.TException) {


### PR DESCRIPTION
And change all other packages taking ecinterface.Interface as an arg to
fallback to the global one when the arg is nil.