### PR TITLE
Add healthcheck binary and library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # thrift compiled go files that we don't use
 **/gen-go/**/*-remote/
+
+# Binaries
+/cmd/healthcheck/healthcheck

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,4 @@ bazeltest:
 	$(BAZEL_TEST)
 
 gotest:
-	if [ -n "$(shell which $(BAZEL))" ]; then $(BAZEL_CLEAN); fi
 	$(GO_TEST)

--- a/cmd/healthcheck/BUILD.bazel
+++ b/cmd/healthcheck/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "healthcheck_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/reddit/baseplate.go/cmd/healthcheck",
+    visibility = ["//visibility:private"],
+    deps = ["//cmd/lib/healthcheck"],
+)
+
+go_binary(
+    name = "healthcheck",
+    embed = [":healthcheck_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "healthcheck_test",
+    size = "small",
+    srcs = ["dummy_test.go"],
+    embed = [":healthcheck_lib"],
+)

--- a/cmd/healthcheck/dummy_test.go
+++ b/cmd/healthcheck/dummy_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestDummy makes sure that this package is built when running bazel tests.
+func TestDummy(t *testing.T) {}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/reddit/baseplate.go/cmd/lib/healthcheck"
+)
+
+func main() {
+	os.Exit(healthcheck.Run())
+}

--- a/cmd/lib/healthcheck/BUILD.bazel
+++ b/cmd/lib/healthcheck/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "healthcheck",
+    srcs = [
+        "doc.go",
+        "healthcheck.go",
+        "oneof.go",
+    ],
+    importpath = "github.com/reddit/baseplate.go/cmd/lib/healthcheck",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//httpbp",
+        "//internal/gen-go/reddit/baseplate",
+        "//thriftbp",
+        "@com_github_apache_thrift//lib/go/thrift",
+    ],
+)
+
+go_test(
+    name = "healthcheck_test",
+    size = "small",
+    srcs = ["healthcheck_test.go"],
+    deps = [
+        ":healthcheck",
+        "//httpbp",
+        "//internal/gen-go/reddit/baseplate",
+        "//thriftbp",
+        "@com_github_apache_thrift//lib/go/thrift",
+    ],
+)

--- a/cmd/lib/healthcheck/doc.go
+++ b/cmd/lib/healthcheck/doc.go
@@ -1,0 +1,8 @@
+// Package healthcheck implements the logic for healthcheck binary.
+//
+// To use this library, create a package with main function as:
+//
+//     func main() {
+//       os.Exit(healthcheck.Run())
+//     }
+package healthcheck

--- a/cmd/lib/healthcheck/healthcheck.go
+++ b/cmd/lib/healthcheck/healthcheck.go
@@ -1,0 +1,162 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/thriftbp"
+)
+
+const (
+	defaultTimeout = time.Second
+	maxHTTPBody    = 4096
+)
+
+// Run runs healthcheck.
+//
+// It returns 0 to indicate success,
+// and non-zero to indicate failure.
+//
+// Your main function usually should look like:
+//
+//     func main() {
+//       os.Exit(healthcheck.Run())
+//     }
+func Run() (ret int) {
+	if err := RunArgs(os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return -1
+	}
+	fmt.Println("OK!")
+	return 0
+}
+
+// Actual value type: checker
+var checkers = map[string]interface{}{
+	"thrift": checker(checkThrift),
+	"wsgi":   checker(checkHTTP),
+	"http":   checker(checkHTTP),
+}
+
+// Actual value type: baseplate.IsHealthyProbe
+var probes = map[string]interface{}{
+	"readiness": baseplate.IsHealthyProbe_READINESS,
+	"liveness":  baseplate.IsHealthyProbe_LIVENESS,
+	"startup":   baseplate.IsHealthyProbe_STARTUP,
+}
+
+// RunArgs is the more customizable/testable version of Run.
+//
+// In production code it expects you to pass in os.Args as the arg.
+func RunArgs(args []string) error {
+	fs := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	addr := fs.String(
+		"endpoint",
+		"localhost:9090",
+		`The endpoint to find the service on, in "host:port" format without schema.`,
+	)
+	timeout := fs.Duration(
+		"timeout",
+		defaultTimeout,
+		"The timeout for this healthcheck.",
+	)
+	check := oneof{
+		choices: checkers,
+		value:   "thrift",
+	}
+	fs.Var(
+		&check,
+		"type",
+		fmt.Sprintf("The protocol of the service to check, one of %s.", check.choicesString()),
+	)
+	probe := oneof{
+		choices: probes,
+		value:   "readiness",
+	}
+	fs.Var(
+		&probe,
+		"probe",
+		fmt.Sprintf("The probe to check, one of %s.", probe.choicesString()),
+	)
+	if err := fs.Parse(args[1:]); err != nil {
+		return fmt.Errorf("failed to parse args: %w", err)
+	}
+	return check.getValue().(checker)(
+		*addr,
+		probe.getValue().(baseplate.IsHealthyProbe),
+		*timeout,
+	)
+}
+
+type checker func(addr string, probe baseplate.IsHealthyProbe, timeout time.Duration) error
+
+func checkThrift(addr string, probe baseplate.IsHealthyProbe, timeout time.Duration) error {
+	cfg := thriftbp.ClientPoolConfig{
+		Addr:               addr,
+		InitialConnections: 1,
+		MaxConnections:     5,
+		ConnectTimeout:     timeout,
+		SocketTimeout:      timeout,
+	}
+	pool, err := thriftbp.NewCustomClientPool(
+		cfg,
+		thriftbp.SingleAddressGenerator(addr),
+		thrift.NewTHeaderProtocolFactoryConf(cfg.ToTConfiguration()),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create thrift client pool: %w", err)
+	}
+	defer pool.Close()
+	client := baseplate.NewBaseplateServiceV2Client(pool)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ret, err := client.IsHealthy(ctx, &baseplate.IsHealthyRequest{
+		Probe: &probe,
+	})
+	if err != nil {
+		return fmt.Errorf("thrift IsHealthy request failed: %w", err)
+	}
+	if !ret {
+		return errors.New("thrift IsHealthy returned false")
+	}
+	return nil
+}
+
+func checkHTTP(addr string, probe baseplate.IsHealthyProbe, timeout time.Duration) error {
+	client := http.Client{
+		Timeout: timeout,
+	}
+	url := fmt.Sprintf(`http://%s/health?type=%v`, addr, probe)
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer httpbp.DrainAndClose(resp.Body)
+	clientErr := httpbp.ClientErrorFromResponse(resp)
+	if clientErr != nil {
+		body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPBody))
+		if err != nil {
+			return fmt.Errorf(
+				"http client error: %w, failed to read body: %v",
+				clientErr,
+				err,
+			)
+		}
+		return fmt.Errorf(
+			"http client error: %w, body: %s",
+			clientErr,
+			body,
+		)
+	}
+	return nil
+}

--- a/cmd/lib/healthcheck/healthcheck_test.go
+++ b/cmd/lib/healthcheck/healthcheck_test.go
@@ -1,0 +1,273 @@
+package healthcheck_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/cmd/lib/healthcheck"
+	"github.com/reddit/baseplate.go/httpbp"
+	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/thriftbp"
+)
+
+type healthyMap = map[baseplate.IsHealthyProbe]bool
+
+var (
+	allHealthy = healthyMap{
+		baseplate.IsHealthyProbe_READINESS: true,
+		baseplate.IsHealthyProbe_LIVENESS:  true,
+		baseplate.IsHealthyProbe_STARTUP:   true,
+	}
+	allUnhealthy = healthyMap(nil)
+)
+
+type service struct {
+	addr string
+	up   func(t *testing.T)
+	down func(t *testing.T)
+}
+
+type thriftHandler struct {
+	healthy healthyMap
+}
+
+func (th thriftHandler) IsHealthy(ctx context.Context, req *baseplate.IsHealthyRequest) (bool, error) {
+	return th.healthy[req.GetProbe()], nil
+}
+
+func thriftService(healthy healthyMap) *service {
+	var wg sync.WaitGroup
+	var server *thrift.TSimpleServer
+
+	s := new(service)
+	s.up = func(t *testing.T) {
+		t.Helper()
+
+		socket, err := thrift.NewTServerSocket("localhost:0")
+		if err != nil {
+			t.Fatalf("Failed to create service socket: %v", err)
+		}
+		if err := socket.Listen(); err != nil {
+			t.Fatalf("Failed to start listener: %v", err)
+		}
+		s.addr = socket.Addr().String()
+		t.Logf("Listening on %v...", s.addr)
+		server, err = thriftbp.NewServer(thriftbp.ServerConfig{
+			Socket: socket,
+			Processor: baseplate.NewBaseplateServiceV2Processor(&thriftHandler{
+				healthy: healthy,
+			}),
+		})
+		if err != nil {
+			t.Fatalf("Failed to start service: %v", err)
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := server.Serve(); err != nil {
+				t.Errorf("server.Serve returned error: %v", err)
+			}
+		}()
+	}
+	s.down = func(t *testing.T) {
+		t.Helper()
+
+		if server != nil {
+			if err := server.Stop(); err != nil {
+				t.Errorf("Failed to stop service: %v", err)
+			}
+		}
+		wg.Wait()
+	}
+	return s
+}
+
+func httpService(healthy healthyMap) *service {
+	var wg sync.WaitGroup
+	mux := http.NewServeMux()
+	server := &http.Server{
+		Handler: mux,
+	}
+
+	s := new(service)
+	s.up = func(t *testing.T) {
+		t.Helper()
+
+		listener, err := net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Failed to create listener: %v", err)
+		}
+		s.addr = listener.Addr().String()
+		t.Logf("Listening on %v...", s.addr)
+		mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+			probe, err := httpbp.GetHealthCheckProbe(r.URL.Query())
+			if err != nil {
+				t.Errorf("httpbp.GetHealthCheckProbe returned error: %v", err)
+			}
+			if healthy[baseplate.IsHealthyProbe(probe)] {
+				io.WriteString(w, "ok")
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+				io.WriteString(w, "not ok")
+			}
+		})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				t.Errorf("server.Serve returned error: %v", err)
+			}
+		}()
+	}
+	s.down = func(t *testing.T) {
+		t.Helper()
+
+		if err := server.Shutdown(context.Background()); err != nil {
+			t.Errorf("Failed to shutdown http server: %v", err)
+		}
+		wg.Wait()
+	}
+	return s
+}
+
+func TestRunArgs(t *testing.T) {
+	const timeout = time.Millisecond * 100
+	for _, c := range []struct {
+		label   string
+		args    []string
+		err     bool
+		service *service
+	}{
+		{
+			label:   "default",
+			service: thriftService(allHealthy),
+		},
+		{
+			label:   "all-unhealthy-thrift",
+			err:     true,
+			service: thriftService(allUnhealthy),
+		},
+		{
+			label: "startup-unhealthy-thrift-1",
+			args:  []string{"--type", "thrift", "--probe", "startup"},
+			err:   true,
+			service: thriftService(healthyMap{
+				baseplate.IsHealthyProbe_READINESS: true,
+				baseplate.IsHealthyProbe_LIVENESS:  true,
+				baseplate.IsHealthyProbe_STARTUP:   false,
+			}),
+		},
+		{
+			label: "startup-unhealthy-thrift-2",
+			err:   false, // This one checks readiness probe so it should report healthy
+			service: thriftService(healthyMap{
+				baseplate.IsHealthyProbe_READINESS: true,
+				baseplate.IsHealthyProbe_LIVENESS:  false,
+				baseplate.IsHealthyProbe_STARTUP:   false,
+			}),
+		},
+		{
+			label:   "http",
+			args:    []string{"--type", "wsgi"},
+			service: httpService(allHealthy),
+		},
+		{
+			label:   "all-unhealthy-http",
+			args:    []string{"--type", "wsgi"},
+			err:     true,
+			service: httpService(allUnhealthy),
+		},
+		{
+			label: "liveness-unhealthy-http-1",
+			args:  []string{"--type", "wsgi", "--probe", "liveness"},
+			err:   true,
+			service: httpService(healthyMap{
+				baseplate.IsHealthyProbe_READINESS: true,
+				baseplate.IsHealthyProbe_LIVENESS:  false,
+				baseplate.IsHealthyProbe_STARTUP:   true,
+			}),
+		},
+		{
+			label: "liveness-unhealthy-http-2",
+			args:  []string{"--type", "wsgi"},
+			err:   false, // This one checks readiness probe so it should report healthy
+			service: httpService(healthyMap{
+				baseplate.IsHealthyProbe_READINESS: true,
+				baseplate.IsHealthyProbe_LIVENESS:  false,
+				baseplate.IsHealthyProbe_STARTUP:   false,
+			}),
+		},
+		{
+			label: "help",
+			args:  []string{"-h"},
+			err:   true,
+		},
+		{
+			label: "unknown-flag",
+			args:  []string{"--fancy"},
+			err:   true,
+		},
+		{
+			label: "wrong-type",
+			args:  []string{"--type", "foo"},
+			err:   true,
+		},
+		{
+			label: "wrong-probe",
+			args:  []string{"--probe", "bar"},
+			err:   true,
+		},
+		{
+			label: "wrong-endpoint",
+			args:  []string{"--endpoint", "localhost:1"},
+			err:   true,
+		},
+		{
+			label:   "short-timeout",
+			args:    []string{"--timeout", "1ns"},
+			err:     true,
+			service: thriftService(allHealthy),
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			args := []string{"./healthcheck", "--timeout", timeout.String()}
+
+			if c.service != nil {
+				if c.service.up != nil {
+					c.service.up(t)
+				}
+				if c.service.down != nil {
+					t.Cleanup(func() {
+						c.service.down(t)
+					})
+				}
+				if c.service.addr != "" {
+					args = append(args, "--endpoint", c.service.addr)
+				}
+			}
+			args = append(args, c.args...)
+
+			err := healthcheck.RunArgs(args)
+			if err != nil {
+				t.Logf("error: %v", err)
+			}
+			if c.err {
+				if err == nil {
+					t.Error("Expected error, got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Did not expect error, got: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/lib/healthcheck/oneof.go
+++ b/cmd/lib/healthcheck/oneof.go
@@ -1,0 +1,55 @@
+package healthcheck
+
+import (
+	"flag"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type oneof struct {
+	choices map[string]interface{}
+	value   string
+}
+
+var _ flag.Getter = (*oneof)(nil)
+
+func (o *oneof) String() string {
+	return o.value
+}
+
+func (o *oneof) Get() interface{} {
+	return o
+}
+
+func (o *oneof) Set(v string) error {
+	if _, ok := o.choices[v]; ok {
+		o.value = v
+		return nil
+	}
+	return fmt.Errorf("%q is not one of the choices of %s", v, o.choicesString())
+}
+
+func (o oneof) choicesString() string {
+	// Sort the map to stabilize the output
+	choices := make([]string, 0, len(o.choices))
+	for c := range o.choices {
+		choices = append(choices, c)
+	}
+	sort.Strings(choices)
+
+	var sb strings.Builder
+	sb.WriteString("(")
+	for i, c := range choices {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("%q", c))
+	}
+	sb.WriteString(")")
+	return sb.String()
+}
+
+func (o oneof) getValue() interface{} {
+	return o.choices[o.value]
+}


### PR DESCRIPTION
This allows go services to get healthcheck without depending on
Baseplate.py. They can either build the healthcheck binary from
github.com/reddit/baseplate.go/cmd/healthcheck, or create a main package
in their repo and use the library version.

The implementation matches the behavior (including command line flags)
of the Baseplate.py implementation [1], with the exception of unix
domain socket, and added --timeout flag.

Also change the default timeout from Baseplate.py's 30s to 1s, as 30s
for a healthcheck timeout is too high.

[1]: https://github.com/reddit/baseplate.py/blob/develop/baseplate/server/healthcheck.py