### PR TITLE
timebp: Make the types also implement encoding.TextMarshaler

### DIFF
--- a/timebp/millisecond.go
+++ b/timebp/millisecond.go
@@ -1,20 +1,23 @@
 package timebp
 
 import (
+	"encoding"
 	"encoding/json"
 	"strconv"
 	"time"
 )
 
 var (
-	_ json.Unmarshaler = (*TimestampMillisecond)(nil)
-	_ json.Marshaler   = TimestampMillisecond{}
+	_ json.Unmarshaler         = (*TimestampMillisecond)(nil)
+	_ json.Marshaler           = TimestampMillisecond{}
+	_ encoding.TextUnmarshaler = (*TimestampMillisecond)(nil)
+	_ encoding.TextMarshaler   = TimestampMillisecond{}
 )
 
 const millisecondsPerSecond = int64(time.Second / time.Millisecond)
 
-// TimestampMillisecond implements json encoding/decoding using milliseconds
-// since EPOCH.
+// TimestampMillisecond implements json/text encoding/decoding using
+// milliseconds since EPOCH.
 type TimestampMillisecond time.Time
 
 func (ts TimestampMillisecond) String() string {
@@ -26,20 +29,29 @@ func (ts TimestampMillisecond) ToTime() time.Time {
 	return time.Time(ts)
 }
 
-// UnmarshalJSON implements json.Unmarshaler.
-func (ts *TimestampMillisecond) UnmarshalJSON(data []byte) error {
-	s := string(data)
-	if s == "null" {
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (ts *TimestampMillisecond) UnmarshalText(data []byte) error {
+	// Empty/default
+	if len(data) == 0 {
 		*ts = TimestampMillisecond{}
 		return nil
 	}
 
-	ms, err := strconv.ParseInt(s, 10, 64)
+	ms, err := strconv.ParseInt(string(data), 10, 64)
 	if err != nil {
 		return err
 	}
 	*ts = TimestampMillisecond(MillisecondsToTime(ms))
 	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (ts *TimestampMillisecond) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*ts = TimestampMillisecond{}
+		return nil
+	}
+	return ts.UnmarshalText(data)
 }
 
 // MillisecondsToTime converts milliseconds since EPOCH to time.Time.
@@ -53,6 +65,16 @@ func MillisecondsToTime(ms int64) time.Time {
 	)
 }
 
+// MarshalText implements encoding.TextMarshaler.
+func (ts TimestampMillisecond) MarshalText() ([]byte, error) {
+	t := ts.ToTime()
+	if t.IsZero() {
+		return nil, nil
+	}
+
+	return []byte(strconv.FormatInt(TimeToMilliseconds(t), 10)), nil
+}
+
 // MarshalJSON implements json.Marshaler.
 func (ts TimestampMillisecond) MarshalJSON() ([]byte, error) {
 	t := ts.ToTime()
@@ -60,7 +82,7 @@ func (ts TimestampMillisecond) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 
-	return []byte(strconv.FormatInt(TimeToMilliseconds(t), 10)), nil
+	return ts.MarshalText()
 }
 
 // TimeToMilliseconds converts time.Time to milliseconds since EPOCH.


### PR DESCRIPTION
Sometimes we have the need to use for example milliseconds since EPOCH
format in non-json encoding/decoding, so implement
TextMarshaler/TextUnmarshaler, which is supported by most go encoding
libraries.

Make the MarshalJSON/UnmarshalJSON functions just call the new
MarshalText/UnmarshalText functions, but keep the special "null"
handling as those are unique to JSON.