### PR TITLE
healthcheck: Support positional type+endpoint args

### DIFF
--- a/cmd/lib/healthcheck/BUILD.bazel
+++ b/cmd/lib/healthcheck/BUILD.bazel
@@ -21,8 +21,8 @@ go_test(
     name = "healthcheck_test",
     size = "small",
     srcs = ["healthcheck_test.go"],
+    embed = [":healthcheck"],
     deps = [
-        ":healthcheck",
         "//httpbp",
         "//internal/gen-go/reddit/baseplate",
         "//thriftbp",


### PR DESCRIPTION
Actually in the Python version the type and endpoint args are only
positional. This is the full --help output:

    usage: baseplate-healthcheck [-h] [--probe {readiness,liveness,startup}]
                                 {thrift,wsgi} endpoint

    Check health of a baseplate service on localhost.

    positional arguments:
      {thrift,wsgi}         The protocol of the service to check.
      endpoint              The endpoint to find the service on.

    optional arguments:
      -h, --help            show this help message and exit
      --probe {readiness,liveness,startup}
                            The probe to check.

So support up to 2 positional args, and use them to override
--type/--endpoint flags, and as a result the go version of healthcheck
can really take the same args as the python version (and more).

Also add unexported runArgs which allows to override the output to be
used in tests, so we don't get so much stuff going into stderr in tests.