### PR TITLE
metricsbp: Stop calling doWrite in Statsd.Close

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -148,7 +148,9 @@ func Serve(ctx context.Context, args ServeArgs) error {
 			}
 
 			// Initialize a channel to pass the result of server.Close().
-			closeChannel := make(chan error)
+			//
+			// It's buffered with size 1 to avoid blocking the goroutine forever.
+			closeChannel := make(chan error, 1)
 
 			// Tell the server and any provided closers to close.
 			//

--- a/metricsbp/statsd.go
+++ b/metricsbp/statsd.go
@@ -408,10 +408,7 @@ func (st *Statsd) Ctx() context.Context {
 // and use Close() call to do the cleanup instead of canceling the context.
 func (st *Statsd) Close() error {
 	st.cancel()
-	if st.writer == nil {
-		return nil
-	}
-	return st.writer.doWrite(st.statsd, log.KitLogger(st.cfg.LogLevel))
+	return nil
 }
 
 // WriteTo calls the underlying statsd implementation's WriteTo function.


### PR DESCRIPTION
We used to do that because the upstream implementation (go-kit statsd)
does not provide flushing ability in their ticker goroutine. We
reimplemented the ticker goroutine with the buffered writer change, and
added the ability to do one more flush before exiting, but forgot to
remove the extra flushing in Statsd.Close. This actually causes race
condition when Statsd.Close is called, because two goroutines are gonna
do the flushing at the same time, using the same writer.

While I'm here, also fix the potential deadlock issue in HandleShutdown
callback.