### PR TITLE
tracing: Add more doc and example to SpanTypeOption

### DIFF
--- a/tracing/BUILD.bazel
+++ b/tracing/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "example_error_reporter_hooks_test.go",
         "hooks_test.go",
         "span_test.go",
+        "start_options_example_test.go",
         "tags_test.go",
         "trace_test.go",
         "tracer_test.go",

--- a/tracing/start_options.go
+++ b/tracing/start_options.go
@@ -38,6 +38,10 @@ func (nopOption) Apply(*opentracing.StartSpanOptions) {}
 type SpanTypeOption struct {
 	nopOption
 
+	// NOTE: If the Type is SpanTypeClient,
+	// the name of the span is expected (by metricsbp.CreateServerSpanHook)
+	// to be in the format of "service.endpoint",
+	// so that it can get the client and endpoint tags correctly.
 	Type SpanType
 }
 

--- a/tracing/start_options_example_test.go
+++ b/tracing/start_options_example_test.go
@@ -1,0 +1,47 @@
+package tracing_test
+
+import (
+	"context"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/reddit/baseplate.go/tracing"
+)
+
+// This example demonstrates how to use SpanTypeOption to create a client span.
+func ExampleSpanTypeOption_client() {
+	var (
+		// In real code this should be in the args of your function
+		ctx context.Context
+		// In real code this should be the named return of your function
+		err error
+	)
+
+	span, ctx := opentracing.StartSpanFromContext(
+		ctx,
+		"service.endpoint", // For example, "mysql.query"
+		tracing.SpanTypeOption{
+			Type: tracing.SpanTypeClient,
+		},
+	)
+	// NOTE: It's important to wrap span.FinishWithOptions in a lambda.
+	//
+	// If you just do this:
+	//
+	//     // Bad example, DO NOT USE.
+	//     defer span.FinishWithOptions(tracing.FinishOptions{
+	//       Ctx: ctx,
+	//       Err: err,
+	//     }.Convert())
+	//
+	// Err will always be nil,
+	// because the args of defer'd function are evaluated at the time of defer,
+	// not time of execution.
+	defer func() {
+		span.FinishWithOptions(tracing.FinishOptions{
+			Ctx: ctx,
+			Err: err,
+		}.Convert())
+	}()
+
+	// Do real work here.
+}


### PR DESCRIPTION
The new requirement from Baseplate spec regarding the span name of
client spans are not well documented, so add some doc to emphasize it.
Also add an example to it.