### PR TITLE
thriftbp: Listen on localhost in unit tests

### DIFF
--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	addr = ":0"
+	addr = "localhost:0"
 )
 
 func TestSingleAddressGenerator(t *testing.T) {


### PR DESCRIPTION
On Mac OS, binding to a non-localhost address will ask the user for approval. Since unit tests are rebuilt each time, this approval is required each time.

After this change, `go test ./...` does not require any approvals on my Mac.