### PR TITLE
log: Switch to StringDurationEncoder as default

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -87,6 +87,7 @@ func InitLogger(logLevel Level) {
 	config.Encoding = "console"
 	config.EncoderConfig.EncodeCaller = ShortCallerEncoder
 	config.EncoderConfig.EncodeTime = TimeEncoder
+	config.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
 	config.EncoderConfig.EncodeLevel = CapitalLevelEncoder
 
 	if err := InitLoggerWithConfig(logLevel, config); err != nil {
@@ -105,6 +106,7 @@ func InitLoggerJSON(logLevel Level) {
 	config.Encoding = "json"
 	config.EncoderConfig.EncodeCaller = zapcore.ShortCallerEncoder
 	config.EncoderConfig.EncodeTime = JSONTimeEncoder
+	config.EncoderConfig.EncodeDuration = zapcore.StringDurationEncoder
 	config.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	// json keys expected by logdna:
 	config.EncoderConfig.MessageKey = "message"


### PR DESCRIPTION
Previously we are using zap's default duration encoder, which is float64
seconds [1], so a duration of 1ms will show in the log as "0.001", that
can be very confusing because no one knows from a glance what's the
unit.

Override it with string encoder so it would be "1ms" instead.

[1]: https://github.com/uber-go/zap/blob/404189cf44aea95b0cd9bddcb0242dd4cf88c510/config.go#L110