### PR TITLE
thriftbp: Fix WrapBaseplateError

### DIFF
--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -110,12 +110,13 @@ func IDLExceptionSuppressor(err error) bool {
 var _ errorsbp.Suppressor = IDLExceptionSuppressor
 
 type wrappedBaseplateError struct {
-	cause baseplateError
+	cause error
+	bpErr baseplateError
 }
 
 func (e wrappedBaseplateError) Error() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("baseplate.Error: %q", e.cause.GetMessage()))
+	sb.WriteString(fmt.Sprintf("baseplate.Error: %q", e.bpErr.GetMessage()))
 	first := true
 	writeSeparator := func() {
 		if first {
@@ -125,17 +126,17 @@ func (e wrappedBaseplateError) Error() string {
 			sb.WriteString(", ")
 		}
 	}
-	if e.cause.IsSetCode() {
+	if e.bpErr.IsSetCode() {
 		writeSeparator()
-		sb.WriteString(fmt.Sprintf("code=%d", e.cause.GetCode()))
+		sb.WriteString(fmt.Sprintf("code=%d", e.bpErr.GetCode()))
 	}
-	if e.cause.IsSetRetryable() {
+	if e.bpErr.IsSetRetryable() {
 		writeSeparator()
-		sb.WriteString(fmt.Sprintf("retryable=%v", e.cause.GetRetryable()))
+		sb.WriteString(fmt.Sprintf("retryable=%v", e.bpErr.GetRetryable()))
 	}
-	if e.cause.IsSetDetails() {
+	if e.bpErr.IsSetDetails() {
 		writeSeparator()
-		sb.WriteString(fmt.Sprintf("details=%#v", e.cause.GetDetails()))
+		sb.WriteString(fmt.Sprintf("details=%#v", e.bpErr.GetDetails()))
 	}
 	if !first {
 		sb.WriteString(")")
@@ -159,7 +160,8 @@ func WrapBaseplateError(e error) error {
 	var bpErr baseplateError
 	if errors.As(e, &bpErr) {
 		return wrappedBaseplateError{
-			cause: bpErr,
+			cause: e,
+			bpErr: bpErr,
 		}
 	}
 	return e


### PR DESCRIPTION
I just realized that in the previous WrapBaseplateError implementation,
we unwrap the error passed in into baseplate error, and only keep the
unwrapped baseplate error, but drops everything originally wrapped
around it.

Store both the original error and unwrapped baseplate error into the
unexported error struct, so that its Unwrap can return the original
error, but Error can use the original baseplate error to construct for
better error message.