### PR TITLE
httpbp&thriftbp: Tweak default list for retryable codes

### DIFF
--- a/httpbp/errors.go
+++ b/httpbp/errors.go
@@ -672,8 +672,8 @@ func (ce ClientError) RetryAfterDuration() time.Duration {
 
 // Retryable implements retrybp.RetryableError.
 //
-// It returns no decision (0) if the status code is unknown (0),
-// true (1) on any of the following conditions and false (-1) otherwise:
+// It returns true (1) on any of the following conditions and no decision (0)
+// otherwise:
 //
 // - There was a valid Retry-After header in the response
 //
@@ -681,11 +681,7 @@ func (ce ClientError) RetryAfterDuration() time.Duration {
 //
 //   * 425 (too early)
 //   * 429 (too many requests)
-//   * 500 (internal server error)
-//   * 502 (bad gateway)
 //   * 503 (service unavailable)
-//   * 504 (gateway timeout)
-//   * 507 (insufficient storage)
 func (ce ClientError) Retryable() int {
 	if ce.StatusCode == 0 {
 		// We didn't even get a response, not enough information to make a decision.
@@ -700,16 +696,12 @@ func (ce ClientError) Retryable() int {
 
 	switch ce.StatusCode {
 	default:
-		return -1
+		return 0
 
 	case
 		http.StatusTooEarly,
 		http.StatusTooManyRequests,
-		http.StatusInternalServerError,
-		http.StatusBadGateway,
-		http.StatusServiceUnavailable,
-		http.StatusGatewayTimeout,
-		http.StatusInsufficientStorage:
+		http.StatusServiceUnavailable:
 
 		return 1
 	}

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -58,24 +58,12 @@ var (
 //
 // 2. TOO_MANY_REQUESTS
 //
-// 3. INTERNAL_SERVER_ERROR
-//
-// 4. BAD_GATEWAY
-//
-// 5. SERVICE_UNAVAILABLE
-//
-// 6. TIMEOUT
-//
-// 7. INSUFFICIENT_STORAGE
+// 3. SERVICE_UNAVAILABLE
 func WithDefaultRetryableCodes(codes ...int32) []int32 {
 	return append([]int32{
 		int32(baseplatethrift.ErrorCode_TOO_EARLY),
 		int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
-		int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
-		int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 		int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
-		int32(baseplatethrift.ErrorCode_TIMEOUT),
-		int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 	}, codes...)
 }
 

--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -26,11 +26,7 @@ func TestWithDefaultRetryableCodes(t *testing.T) {
 			expected: []int32{
 				int32(baseplatethrift.ErrorCode_TOO_EARLY),
 				int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
-				int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
-				int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 				int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
-				int32(baseplatethrift.ErrorCode_TIMEOUT),
-				int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 			},
 		},
 		{
@@ -39,11 +35,7 @@ func TestWithDefaultRetryableCodes(t *testing.T) {
 			expected: []int32{
 				int32(baseplatethrift.ErrorCode_TOO_EARLY),
 				int32(baseplatethrift.ErrorCode_TOO_MANY_REQUESTS),
-				int32(baseplatethrift.ErrorCode_INTERNAL_SERVER_ERROR),
-				int32(baseplatethrift.ErrorCode_BAD_GATEWAY),
 				int32(baseplatethrift.ErrorCode_SERVICE_UNAVAILABLE),
-				int32(baseplatethrift.ErrorCode_TIMEOUT),
-				int32(baseplatethrift.ErrorCode_INSUFFICIENT_STORAGE),
 				1,
 				2,
 				3,


### PR DESCRIPTION
There's no guarantee that there's no side-effects in 500, 502, 504, and
507 errors. So be more conservative and don't mark them as retryable by
default.

Also tweak httpbp.ClientError.Retryable logic, to return 0 instead of -1
for codes not in the default list. This way users can implement their
own retrybp.Filter to mark certain codes not in the default list
retryable. On thriftbp the list is already customizable and also we
defer to the next filter instead of mark the error non-retryable when
it's not in the list, so this actually brings us feature parity (kinda)
between thriftbp and httpbp.

The current codes in default retryable list for both httpbp and thriftbp
are:

* 425 (too early)
* 429 (too many requests)
* 503 (service unavailable)