### PR TITLE
baseplate: Implement strict yaml parsing

### DIFF
--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 type config struct {
+	baseplate.Config `yaml:",inline"`
+
 	Redis redisbp.ClusterConfig `yaml:"redis"`
 }
 

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -213,10 +213,10 @@ func NewBaseplateServer(args ServerArgs) (baseplate.Server, error) {
 	}
 
 	srv := &http.Server{
-		Addr:         args.Baseplate.Config().Addr,
+		Addr:         args.Baseplate.GetConfig().Addr,
 		Handler:      args.EndpointRegistry,
-		ReadTimeout:  args.Baseplate.Config().Timeout,
-		WriteTimeout: args.Baseplate.Config().Timeout,
+		ReadTimeout:  args.Baseplate.GetConfig().Timeout,
+		WriteTimeout: args.Baseplate.GetConfig().Timeout,
 	}
 	for _, f := range args.OnShutdown {
 		srv.RegisterOnShutdown(f)

--- a/redis/deprecated/redisbp/example_config_test.go
+++ b/redis/deprecated/redisbp/example_config_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 type Config struct {
+	baseplate.Config `yaml:",inline"`
+
 	Redis redisbp.ClientConfig `yaml:"redis"`
 }
 

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -115,9 +115,9 @@ func NewBaseplateServer(
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)
 	cfg.Middlewares = middlewares
-	cfg.Logger = log.ZapWrapper(bp.Config().Log.Level).ToThriftLogger()
-	cfg.Addr = bp.Config().Addr
-	cfg.Timeout = bp.Config().Timeout
+	cfg.Logger = log.ZapWrapper(bp.GetConfig().Log.Level).ToThriftLogger()
+	cfg.Addr = bp.GetConfig().Addr
+	cfg.Timeout = bp.GetConfig().Timeout
 	cfg.Socket = nil
 	srv, err := NewServer(cfg)
 	if err != nil {

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -207,7 +207,7 @@ func NewBaseplateServer(cfg ServerConfig) (*Server, error) {
 	}
 	server := &Server{Server: thriftbp.ApplyBaseplate(bp, srv)}
 
-	cfg.ClientConfig.Addr = server.Baseplate().Config().Addr
+	cfg.ClientConfig.Addr = server.Baseplate().GetConfig().Addr
 	cfg.ClientConfig.ReportPoolStats = ReportClientPoolStats
 	cfg.ClientConfig.InitialConnections = InitialClientConnections
 


### PR DESCRIPTION
Closes https://github.com/reddit/baseplate.go/issues/366.

Always enable strict yaml parsing, and require users to embed
baseplate.Config with yaml tag of `yaml:",inline"` in their custom
config structs.

Also unexport parseConfig.