### PR TITLE
baseplate: Add Drainer

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "baseplate.go",
         "doc.go",
+        "drainer.go",
     ],
     importpath = "github.com/reddit/baseplate.go",
     visibility = ["//visibility:public"],
@@ -29,14 +30,20 @@ go_library(
 go_test(
     name = "baseplate_go_test",
     size = "small",
-    srcs = ["baseplate_test.go"],
+    srcs = [
+        "baseplate_test.go",
+        "drainer_example_test.go",
+        "drainer_test.go",
+    ],
     deps = [
         ":baseplate_go",
         "//ecinterface",
+        "//internal/gen-go/reddit/baseplate",
         "//log",
         "//metricsbp",
         "//runtimebp",
         "//secrets",
+        "//thriftbp",
         "//tracing",
     ],
 )

--- a/drainer.go
+++ b/drainer.go
@@ -1,0 +1,49 @@
+package baseplate
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+)
+
+// HealthChecker defines an interface to report healthy status.
+type HealthChecker interface {
+	IsHealthy(ctx context.Context) bool
+}
+
+// HealthCheckCloser is the combination of Healthyer and io.Closer.
+type HealthCheckCloser interface {
+	HealthChecker
+	io.Closer
+}
+
+type drainer struct {
+	closed int64
+}
+
+func (d *drainer) IsHealthy(_ context.Context) bool {
+	return atomic.LoadInt64(&d.closed) == 0
+}
+
+func (d *drainer) Close() error {
+	atomic.StoreInt64(&d.closed, 1)
+	return nil
+}
+
+// Drainer creates a HealthCheckCloser implementation that can be used to drain
+// service during graceful shutdown.
+//
+// The HealthCheckCloser returned would start to report healthy once created,
+// and start to report unhealthy as soon as its Close is called.
+//
+// Please refer to the example on how to use this feature in your service.
+// Basically you should create a Drainer in your main function,
+// add it to the PreShutdown closers list in baseplate.Serve,
+// and then fail your readiness health check when drainer is reporting unhealty.
+//
+// Its Close function would never return an error.
+// It's also OK to call Close function multiple times.
+// Calls after the first one are essentially no-ops.
+func Drainer() HealthCheckCloser {
+	return new(drainer)
+}

--- a/drainer_example_test.go
+++ b/drainer_example_test.go
@@ -1,0 +1,68 @@
+package baseplate_test
+
+import (
+	"context"
+	"flag"
+	"io"
+
+	baseplate "github.com/reddit/baseplate.go"
+	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/thriftbp"
+)
+
+// A placeholder thrift service for the example.
+type Service struct {
+	drainer baseplate.HealthCheckCloser
+}
+
+func (s *Service) IsHealthy(ctx context.Context, req *baseplatethrift.IsHealthyRequest) (bool, error) {
+	switch req.GetProbe() {
+	default:
+		// For unknown probes, default to readiness.
+		fallthrough
+	case baseplatethrift.IsHealthyProbe_READINESS:
+		return s.drainer.IsHealthy(ctx) /* && other healthy dependencies */, nil
+
+	case baseplatethrift.IsHealthyProbe_LIVENESS:
+		return true /* && other healthy dependencies */, nil
+	}
+}
+
+// This example demonstrates how to use baseplate.Drainer in your main function
+// and service's IsHealthy handler.
+func ExampleDrainer() {
+	flag.Parse()
+	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
+		// TODO: fill in NewArgs.
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bp.Close()
+
+	// TODO: Other initializations
+	drainer := baseplate.Drainer()
+	// TODO: Other initializations
+
+	processor := baseplatethrift.NewBaseplateServiceV2Processor(&Service{
+		drainer: drainer,
+	})
+	server, err := thriftbp.NewBaseplateServer(bp, thriftbp.ServerConfig{
+		Processor: processor,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Info(baseplate.Serve(ctx, baseplate.ServeArgs{
+		Server: server,
+		PreShutdown: []io.Closer{
+			drainer,
+			// TODO: Other pre-shutdown closers
+		},
+		PostShutdown: []io.Closer{
+			// TODO: Post-shutdown closers
+		},
+	}))
+}

--- a/drainer_test.go
+++ b/drainer_test.go
@@ -1,0 +1,29 @@
+package baseplate_test
+
+import (
+	"context"
+	"testing"
+
+	baseplate "github.com/reddit/baseplate.go"
+)
+
+func TestDrainer(t *testing.T) {
+	ctx := context.Background()
+	drainer := baseplate.Drainer()
+	if !drainer.IsHealthy(ctx) {
+		t.Error("Drainer does not report healthy after created")
+	}
+	if err := drainer.Close(); err != nil {
+		t.Errorf("Drainer.Close did not expect error, got %v", err)
+	}
+	if drainer.IsHealthy(ctx) {
+		t.Error("Drainer reports healthy after Close was called")
+	}
+	// Make sure double close works.
+	if err := drainer.Close(); err != nil {
+		t.Errorf("Drainer.Close did not expect error, got %v", err)
+	}
+	if drainer.IsHealthy(ctx) {
+		t.Error("Drainer reports healthy after Close was called")
+	}
+}

--- a/kafkabp/BUILD.bazel
+++ b/kafkabp/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     ],
     embed = [":kafkabp"],
     deps = [
+        "//:baseplate_go",
         "@com_github_shopify_sarama//:sarama",
         "@com_github_shopify_sarama//mocks",
     ],

--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -43,13 +43,15 @@ type ConsumeMessageFunc func(ctx context.Context, msg *sarama.ConsumerMessage)
 type ConsumeErrorFunc func(err error)
 
 // Consumer defines the interface of a consumer struct.
+//
+// It's also a superset of (implements) baseplate.HealthChecker.
 type Consumer interface {
 	io.Closer
 
 	Consume(ConsumeMessageFunc, ConsumeErrorFunc) error
 
 	// IsHealthy returns false after Consume returns.
-	IsHealthy() bool
+	IsHealthy(ctx context.Context) bool
 }
 
 // consumer implements a Kafka consumer.
@@ -260,6 +262,6 @@ func (kc *consumer) Consume(
 }
 
 // IsHealthy returns true until Consume returns, then false thereafter.
-func (kc *consumer) IsHealthy() bool {
+func (kc *consumer) IsHealthy(_ context.Context) bool {
 	return atomic.LoadInt64(&kc.consumeReturned) == 0
 }

--- a/kafkabp/consumer_test.go
+++ b/kafkabp/consumer_test.go
@@ -9,6 +9,13 @@ import (
 
 	"github.com/Shopify/sarama"
 	"github.com/Shopify/sarama/mocks"
+
+	baseplate "github.com/reddit/baseplate.go"
+)
+
+// Make sure that Consumer also implements baseplate.HealthChecker.
+var (
+	_ baseplate.HealthChecker = Consumer(nil)
 )
 
 func TestKafkaConsumer_Consume(t *testing.T) {

--- a/kafkabp/group_consumer.go
+++ b/kafkabp/group_consumer.go
@@ -80,7 +80,7 @@ func (gc *groupConsumer) Close() error {
 	return gc.consumer.Close()
 }
 
-func (gc *groupConsumer) IsHealthy() bool {
+func (gc *groupConsumer) IsHealthy(_ context.Context) bool {
 	return atomic.LoadInt64(&gc.consumeReturned) == 0
 }
 


### PR DESCRIPTION
Inspired by the Baseplate.py change[1], add Drainer implementation on
top-level package so services can use it to fail their READINESS checks.

Also change kafkabp.Consumer.IsHealthy function signature to add context
arg, so it implements the newly added baseplate.Healthyer interface. The
context arg is used by neither of them right now, but we might want to
start using them in other implementations in the future so adding the
arg now can avoid a future breaking change.

[1]: https://github.com/reddit/baseplate.py/commit/c4a815d2729c3e232849b1e8079d3fb698f621ef