### PR TITLE
mqsend: Support non-blocking mode

### DIFF
--- a/events/events_test.go
+++ b/events/events_test.go
@@ -27,8 +27,9 @@ func (mockTStruct) Write(ctx context.Context, p thrift.TProtocol) error {
 
 func TestV2Put(t *testing.T) {
 	const queueSize = 100
-	const doubleTime = DefaultMaxPutTimeout * 2
-	const tripleTime = DefaultMaxPutTimeout * 3
+	const timeout = time.Millisecond * 10
+	const doubleTime = timeout * 2
+	const tripleTime = timeout * 3
 
 	// init
 	queue := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
@@ -36,7 +37,9 @@ func TestV2Put(t *testing.T) {
 		MaxQueueSize:   queueSize,
 	})
 	v2 := v2WithConfig(
-		Config{},
+		Config{
+			MaxPutTimeout: timeout,
+		},
 		queue,
 	)
 
@@ -61,7 +64,7 @@ func TestV2Put(t *testing.T) {
 			if elapsed > tripleTime {
 				t.Errorf(
 					"Expected timeout at %v, actual elapsed time is %v",
-					DefaultMaxPutTimeout,
+					timeout,
 					elapsed,
 				)
 			}

--- a/mqsend/errors.go
+++ b/mqsend/errors.go
@@ -8,8 +8,8 @@ import (
 // TimedOutError is the error returned by MessageQueue.Send when the operation
 // timed out because of the queue was full.
 //
-// On linux systems it usually wraps one of syscall.ETIMEDOUT, context.Canceled,
-// or context.DeadlineExceeded.
+// On linux systems it usually wraps one of syscall.ETIMEDOUT, syscall.EAGAIN,
+// context.Canceled, or context.DeadlineExceeded.
 // On other systems (or with MockMessageQueue) it usually wraps either
 // context.Canceled or context.DeadlineExceeded.
 type TimedOutError struct {

--- a/mqsend/interface.go
+++ b/mqsend/interface.go
@@ -14,8 +14,10 @@ type MessageQueue interface {
 
 	// Send sends a message to the queue.
 	//
-	// Caller should always call Send with a context object with deadline set,
-	// or Send might block forever when the queue is full.
+	// If the context object does not have a deadline set,
+	// or if the deadline had already passed when Send is called,
+	// Send will be running in non-blocking mode and fail immediately when the
+	// queue is full.
 	Send(ctx context.Context, data []byte) error
 }
 

--- a/mqsend/mqsend_mock_test.go
+++ b/mqsend/mqsend_mock_test.go
@@ -3,6 +3,7 @@ package mqsend_test
 import (
 	"context"
 	"errors"
+	"syscall"
 	"testing"
 	"time"
 
@@ -16,50 +17,11 @@ func TestMockMessageQueue(t *testing.T) {
 
 	mq := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 		MaxMessageSize: int64(max),
-		MaxQueueSize:   1,
+		MaxQueueSize:   4,
 	})
 	defer mq.Close()
 
-	t.Run(
-		"message-too-large",
-		func(t *testing.T) {
-			data := make([]byte, max+1)
-			err := mq.Send(context.Background(), data)
-			if !errors.As(err, new(mqsend.MessageTooLargeError)) {
-				t.Errorf(
-					"Expected MessageTooLargeError when message is larger than the max size, got %v",
-					err,
-				)
-			}
-		},
-	)
-
-	t.Run(
-		"send",
-		func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			err := mq.Send(ctx, []byte(msg))
-			if err != nil {
-				t.Errorf("Send returned error: %v", err)
-			}
-		},
-	)
-
-	t.Run(
-		"send-timeout",
-		func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), timeout)
-			defer cancel()
-			err := mq.Send(ctx, []byte(msg))
-			if !errors.As(err, new(mqsend.TimedOutError)) {
-				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
-			}
-			if !errors.Is(err, context.DeadlineExceeded) {
-				t.Errorf("Expected DeadlineExceeded when the queue is full, got %v", err)
-			}
-		},
-	)
+	sharedTest(t, mq, msg, max, timeout)
 
 	t.Run(
 		"receive",
@@ -84,6 +46,140 @@ func TestMockMessageQueue(t *testing.T) {
 			err := mq.Send(ctx, []byte(msg))
 			if err != nil {
 				t.Errorf("Send returned error: %v", err)
+			}
+		},
+	)
+}
+
+func sharedTest(t *testing.T, mq mqsend.MessageQueue, msg string, max int, timeout time.Duration) {
+	t.Run(
+		"message-too-large",
+		func(t *testing.T) {
+			data := make([]byte, max+1)
+			err := mq.Send(context.Background(), data)
+			if !errors.As(err, new(mqsend.MessageTooLargeError)) {
+				t.Errorf(
+					"Expected MessageTooLargeError when message is larger than the max size, got %v",
+					err,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"send-1-with-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if err != nil {
+				t.Errorf("Send returned error: %v", err)
+			}
+		},
+	)
+
+	t.Run(
+		"send-2-neg-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), -1)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if err != nil {
+				t.Errorf("Send returned error: %v", err)
+			}
+		},
+	)
+
+	t.Run(
+		"send-3-zero-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if err != nil {
+				t.Errorf("Send returned error: %v", err)
+			}
+		},
+	)
+
+	t.Run(
+		"send-4-non-block",
+		func(t *testing.T) {
+			ctx := context.Background()
+			err := mq.Send(ctx, []byte(msg))
+			if err != nil {
+				t.Errorf("Send returned error: %v", err)
+			}
+		},
+	)
+
+	t.Run(
+		"send-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if !errors.As(err, new(mqsend.TimedOutError)) {
+				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
+			}
+			if !errors.Is(err, syscall.ETIMEDOUT) && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf(
+					"Expected either ETIMEDOUT or context.DeadlineExceeded when the queue is full, got %v",
+					err,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"send-neg-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), -1)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if !errors.As(err, new(mqsend.TimedOutError)) {
+				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
+			}
+			if !errors.Is(err, syscall.ETIMEDOUT) && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf(
+					"Expected either ETIMEDOUT or context.DeadlineExceeded when the queue is full, got %v",
+					err,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"send-zero-timeout",
+		func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			err := mq.Send(ctx, []byte(msg))
+			if !errors.As(err, new(mqsend.TimedOutError)) {
+				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
+			}
+			if !errors.Is(err, syscall.ETIMEDOUT) && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf(
+					"Expected either ETIMEDOUT or context.DeadlineExceeded when the queue is full, got %v",
+					err,
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"send-non-block",
+		func(t *testing.T) {
+			ctx := context.Background()
+			err := mq.Send(ctx, []byte(msg))
+			if !errors.As(err, new(mqsend.TimedOutError)) {
+				t.Errorf("Expected TimedOutError when the queue is full, got %v", err)
+			}
+			if !errors.Is(err, syscall.ETIMEDOUT) && !errors.Is(err, syscall.EAGAIN) && !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf(
+					"Expected either ETIMEDOUT or context.DeadlineExceeded when the queue is full, got %v",
+					err,
+				)
 			}
 		},
 	)

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -32,8 +32,6 @@ const (
 	MaxQueueSize = 10000
 	// Prefix added to the queue name.
 	QueueNamePrefix = "traces-"
-	// The default MaxRecordTimeout used in Tracers.
-	DefaultMaxRecordTimeout = time.Millisecond * 50
 )
 
 func init() {
@@ -79,10 +77,10 @@ type TracerConfig struct {
 	//
 	// If the passed in context object has an earlier deadline set,
 	// that deadline will be respected instead.
-	// But if the passed in context is already canceled,
-	// then we ignore it and create a new background context with this timeout.
 	//
-	// If MaxRecordTimeout <= 0, DefaultMaxRecordTimeout will be used.
+	// If MaxRecordTimeout <= 0,
+	// Record function would run in non-blocking mode,
+	// that it fails immediately if the queue is full.
 	MaxRecordTimeout time.Duration
 
 	// The name of the message queue to be used to actually send sampled spans to
@@ -165,11 +163,7 @@ func InitGlobalTracer(cfg TracerConfig) error {
 	}
 	tracer.logger = logger
 
-	timeout := cfg.MaxRecordTimeout
-	if timeout <= 0 {
-		timeout = DefaultMaxRecordTimeout
-	}
-	tracer.maxRecordTimeout = timeout
+	tracer.maxRecordTimeout = cfg.MaxRecordTimeout
 
 	ip, err := runtimebp.GetFirstIPv4()
 	if err != nil {

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -18,6 +18,9 @@ import (
 const testTimeout = time.Millisecond * 100
 
 func TestTracer(t *testing.T) {
+	const timeout = time.Millisecond * 10
+	const doubleTimeout = timeout * 2
+
 	loggerFunc := func(t *testing.T) (logger log.Wrapper, called *bool) {
 		called = new(bool)
 		logger = func(_ context.Context, msg string) {
@@ -72,6 +75,7 @@ func TestTracer(t *testing.T) {
 	InitGlobalTracer(TracerConfig{
 		SampleRate:               1,
 		Logger:                   logger,
+		MaxRecordTimeout:         timeout,
 		TestOnlyMockMessageQueue: recorder,
 	})
 	// The above InitGlobalTracer might call the logger once for unable to get ip,
@@ -104,10 +108,10 @@ func TestTracer(t *testing.T) {
 			start := span.trace.start
 			err := span.Stop(ctx, nil)
 			duration := time.Since(start)
-			if duration > DefaultMaxRecordTimeout*2 {
+			if duration > doubleTimeout {
 				t.Errorf(
 					"Expected duration of around %v, got %v",
-					DefaultMaxRecordTimeout,
+					timeout,
 					duration,
 				)
 			}


### PR DESCRIPTION
Also switch tracing and events default timeout to 0 so that by default
they run in non-blocking mode, which matches the behavior on bp.py.