### PR TITLE
Update baseplate.go to meet upcoming requirements for environment substitution in configs

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,13 +16,13 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//batchcloser",
+        "//configbp",
         "//ecinterface",
         "//log",
         "//metricsbp",
         "//runtimebp",
         "//secrets",
         "//tracing",
-        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
     ],
     deps = [
         ":baseplate_go",
+        "//configbp",
         "//ecinterface",
         "//internal/gen-go/reddit/baseplate",
         "//log",

--- a/baseplate.go
+++ b/baseplate.go
@@ -232,7 +232,8 @@ func Serve(ctx context.Context, args ServeArgs) error {
 //       log.Fatalf("Parsing config: %s", err)
 //     }
 //     ctx, bp, err := baseplate.New(baseplate.NewArgs{
-//       ServiceCfg: cfg,
+//       EdgeContextFactory: edgecontext.Factory(...),
+//       ServiceCfg:         cfg,
 //     })
 //
 // If you do have customized configurations to decode from YAML,
@@ -250,7 +251,8 @@ func Serve(ctx context.Context, args ServeArgs) error {
 //       log.Fatalf("Parsing config: %s", err)
 //     }
 //     ctx, bp, err := baseplate.New(baseplate.NewArgs{
-//       ServiceCfg: cfg,
+//       EdgeContextFactory: edgecontext.Factory(...),
+//       ServiceCfg:         cfg,
 //     })
 //
 // Environment variable references (e.g. $FOO and ${FOO}) are substituted into the

--- a/configbp/BUILD.bazel
+++ b/configbp/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "configbp",
+    srcs = ["config.go"],
+    importpath = "github.com/reddit/baseplate.go/configbp",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//log",
+        "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "configbp_test",
+    srcs = ["config_test.go"],
+    deps = [
+        ":configbp",
+        "//:baseplate_go",
+        "//log",
+        "@com_github_google_go_cmp//cmp",
+    ],
+)

--- a/configbp/BUILD.bazel
+++ b/configbp/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/configbp",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/limitopen",
         "//log",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_uber_go_zap//:zap",

--- a/configbp/config.go
+++ b/configbp/config.go
@@ -1,0 +1,94 @@
+// Package configbp parses configurations per the baseplate spec.
+package configbp
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+// BaseplateConfigPath points to the default config file per baseplate.spec.
+var BaseplateConfigPath = os.Getenv("BASEPLATE_CONFIG_PATH")
+
+type envsubstReader struct {
+	buffer bytes.Buffer
+	lines  bufio.Scanner
+}
+
+func (r *envsubstReader) Read(buf []byte) (int, error) {
+	// Keep flushing pending data if we have it
+	if r.buffer.Len() > 0 {
+		return r.buffer.Read(buf)
+	}
+
+	// Fill the buffer with some data
+	if r.lines.Scan() {
+		r.buffer.WriteString(os.ExpandEnv(r.lines.Text()))
+		r.buffer.WriteString("\n")
+	} else {
+		return 0, io.EOF
+	}
+
+	// Return some data to satisfy the reader
+	return r.buffer.Read(buf)
+}
+
+// ParseStrictFile parses configuration from the file at the given path.
+//
+// Environment variables (e.g. $FOO and ${FOO}) are substituted from the environment before parsing.
+// The configuration is parsed into each of the targets, which will typically be pointers to structs.
+func ParseStrictFile(path string, ptr interface{}) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err // contains filename
+	}
+	defer f.Close() // safe to blindly close read-only files
+
+	switch ext := filepath.Ext(path); strings.ToLower(ext) {
+	case ".yaml", ".yml":
+		return ParseStrictYAML(f, ptr)
+	default:
+		return fmt.Errorf("unsupported config extension %q", ext)
+	}
+}
+
+// ParseStrictYAML parses YAML read from the given Reader.
+//
+// Environment variables (e.g. $FOO and ${FOO}) are substituted from the environment before parsing.
+// The configuration is parsed into each of the targets, which will typically be pointers to structs.
+func ParseStrictYAML(reader io.Reader, ptr interface{}) error {
+	reader = &envsubstReader{
+		lines: *bufio.NewScanner(reader),
+	}
+
+	var debugOutput strings.Builder
+	if log.With().Desugar().Core().Enabled(zap.DebugLevel) {
+		reader = io.TeeReader(reader, &debugOutput)
+	}
+
+	dec := yaml.NewDecoder(reader)
+	dec.SetStrict(true)
+	if err := dec.Decode(ptr); err != nil {
+		// Print out the partial configuration to aid in debugging decode errors now that the file isn't used literally
+		if debugOutput.Len() > 0 {
+			log.Debugf("Partial configuration for decoding into %T: (error: %s)\n%s", ptr, err, debugOutput.String())
+		}
+		return fmt.Errorf("parsing YAML into %T: %w", ptr, err)
+	}
+
+	// Print out the interpolated YAML configuration in debug mode (which doesn't have JSON logging enabled)
+	if debugOutput.Len() > 0 {
+		log.Debugf("Parsed configuration as %T:\n%s", ptr, debugOutput.String())
+	}
+
+	return nil
+}

--- a/configbp/config_test.go
+++ b/configbp/config_test.go
@@ -1,0 +1,68 @@
+package configbp_test // to break dep cycle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/configbp"
+	"github.com/reddit/baseplate.go/log"
+)
+
+func init() {
+	log.InitLogger(log.DebugLevel)
+}
+
+func TestParseStrictFile(t *testing.T) {
+	valueFromEnv := "_value_from_environment_var_"
+	t.Setenv("VALUE_FROM_ENV", valueFromEnv)
+
+	tests := []struct {
+		desc    string
+		content string
+		target  interface{}
+		want    interface{}
+	}{
+		{
+			desc: "basic_env",
+			content: `
+addr: localhost:1234
+log:
+  level: debug
+sentry:
+  dsn: $VALUE_FROM_ENV
+  serverName: ${VALUE_FROM_ENV}
+`,
+			target: &baseplate.Config{},
+			want: &baseplate.Config{
+				Addr: "localhost:1234",
+				Log: log.Config{
+					Level: log.DebugLevel,
+				},
+				Sentry: log.SentryConfig{
+					DSN:        valueFromEnv,
+					ServerName: valueFromEnv,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			dir := t.TempDir() // automatically cleaned up
+			filename := filepath.Join(dir, "test.yaml")
+			if err := os.WriteFile(filename, []byte(test.content), 0600); err != nil {
+				t.Fatalf("SETUP: failed to write file: %s", err)
+			}
+			if err := configbp.ParseStrictFile(filename, test.target); err != nil {
+				t.Fatalf("ParseStrictFile(%q): %s", filename, err)
+			}
+			if diff := cmp.Diff(test.target, test.want); diff != "" {
+				t.Errorf("Parsed config incorrect: (-got +want)\n%s", diff)
+			}
+		})
+	}
+}

--- a/external.bzl
+++ b/external.bzl
@@ -352,8 +352,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_google_go_cmp",
         importpath = "github.com/google/go-cmp",
-        sum = "h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=",
-        version = "v0.5.5",
+        sum = "h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=",
+        version = "v0.5.6",
     )
     go_repository(
         name = "com_github_google_go_querystring",

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/go-redis/redis/v8 v8.10.0
 	github.com/gofrs/uuid v3.2.0+incompatible
+	github.com/google/go-cmp v0.5.6
 	github.com/joomcode/errorx v1.0.3
 	github.com/joomcode/redispipe v0.9.4
 	github.com/opentracing/opentracing-go v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,9 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -98,7 +98,7 @@ func ExampleNewBaseplateServer() {
 	var ecFactory ecinterface.Factory
 
 	var cfg config
-	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+	if err := baseplate.ParseConfigYAML(&cfg); err != nil {
 		panic(err)
 	}
 	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{

--- a/randbp/seed_test.go
+++ b/randbp/seed_test.go
@@ -53,6 +53,9 @@ func TestGetSeed(t *testing.T) {
 	)
 	for i := 0; i <= maxBytes; i++ {
 		t.Run(fmt.Sprintf("read-%d-bytes", i), func(t *testing.T) {
+			if i == 0 {
+				t.Skipf("Time is not random enough to pass this test if zero bytes are read")
+			}
 			cryptoReader = readerGenerator(t, i)
 			set := make(map[int64]bool)
 			var lock sync.Mutex

--- a/redis/cache/redispipebp/BUILD.bazel
+++ b/redis/cache/redispipebp/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     deps = [
         ":redispipebp",
         "//breakerbp",
+        "//configbp",
         "//mqsend",
         "//redis/cache/redisx",
         "//retrybp",
@@ -52,6 +53,5 @@ go_test(
         "@com_github_joomcode_redispipe//rediscluster",
         "@com_github_joomcode_redispipe//redisconn",
         "@com_github_sony_gobreaker//:gobreaker",
-        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/redis/cache/redispipebp/config_test.go
+++ b/redis/cache/redispipebp/config_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/joomcode/redispipe/redisconn"
 
 	"github.com/reddit/baseplate.go/configbp"
-
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"
 )
 

--- a/redis/cache/redispipebp/config_test.go
+++ b/redis/cache/redispipebp/config_test.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/joomcode/redispipe/rediscluster"
 	"github.com/joomcode/redispipe/redisconn"
-	"gopkg.in/yaml.v2"
+
+	"github.com/reddit/baseplate.go/configbp"
 
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"
 )
@@ -59,7 +60,7 @@ options:
 		c := _c
 		t.Run(c.name, func(t *testing.T) {
 			var cfg redispipebp.ClientConfig
-			if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+			if err := configbp.ParseStrictYAML(strings.NewReader(c.raw), &cfg); err != nil {
 				t.Fatal(err)
 			}
 			if cfg.Addr != c.addr {
@@ -129,7 +130,7 @@ options:
 		c := _c
 		t.Run(c.name, func(t *testing.T) {
 			var cfg redispipebp.ClusterConfig
-			if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+			if err := configbp.ParseStrictYAML(strings.NewReader(c.raw), &cfg); err != nil {
 				t.Fatal(err)
 			}
 			sort.Strings(cfg.Addrs)

--- a/redis/db/redisbp/BUILD.bazel
+++ b/redis/db/redisbp/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         ":redisbp",
         "//:baseplate_go",
+        "//configbp",
         "//ecinterface",
         "//metricsbp",
         "//mqsend",

--- a/redis/db/redisbp/BUILD.bazel
+++ b/redis/db/redisbp/BUILD.bazel
@@ -41,6 +41,5 @@ go_test(
         "@com_github_alicebob_miniredis_v2//:miniredis",
         "@com_github_go_redis_redis_v8//:redis",
         "@com_github_opentracing_opentracing_go//:opentracing-go",
-        "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )

--- a/redis/db/redisbp/config_test.go
+++ b/redis/db/redisbp/config_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/go-redis/redis/v8"
+
+	"github.com/reddit/baseplate.go/configbp"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 )
 
@@ -100,7 +100,7 @@ timeouts:
 			c.name,
 			func(t *testing.T) {
 				var cfg redisbp.ClientConfig
-				if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+				if err := configbp.ParseStrictYAML(strings.NewReader(c.raw), &cfg); err != nil {
 					t.Fatal(err)
 				}
 				if !reflect.DeepEqual(c.expected, cfg) {
@@ -209,7 +209,7 @@ timeouts:
 			c.name,
 			func(t *testing.T) {
 				var cfg redisbp.ClusterConfig
-				if err := yaml.NewDecoder(strings.NewReader(c.raw)).Decode(&cfg); err != nil {
+				if err := configbp.ParseStrictYAML(strings.NewReader(c.raw), &cfg); err != nil {
 					t.Fatal(err)
 				}
 				if !reflect.DeepEqual(c.expected, cfg) {

--- a/redis/db/redisbp/example_config_test.go
+++ b/redis/db/redisbp/example_config_test.go
@@ -21,7 +21,7 @@ func ExampleClientConfig() {
 	var ecFactory ecinterface.Factory
 
 	var cfg Config
-	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+	if err := baseplate.ParseConfigYAML(&cfg); err != nil {
 		panic(err)
 	}
 

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -17,7 +17,7 @@ func ExampleNewBaseplateServer() {
 	var ecFactory ecinterface.Factory
 
 	var cfg baseplate.Config
-	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+	if err := baseplate.ParseConfigYAML(&cfg); err != nil {
 		panic(err)
 	}
 	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{


### PR DESCRIPTION
# API CHANGE

This commit introduces a breaking API change:
* baseplate.ParseConfigYAML(file, ptr) -> baseplate.ParseConfigYAML(ptr)

    According to the new baseplate spec, the config file location should be
    determined based on the environment variable BASEPLATE_CONFIG_PATH

There is also a new piece of functionality:
* YAML configuration files interpolate $ENV and ${ENV} from the environment

    This is also a new addition to the baseplate spec.