### PR TITLE
Optimize imports

### DIFF
--- a/Style.md
+++ b/Style.md
@@ -38,22 +38,10 @@ import (
 )
 ```
 
-### Exceptions
-
-In whole file examples
-(see the end of https://pkg.go.dev/testing?tab=doc#hdr-Examples),
-merge Groups 2&3.
-The reason is that whole file examples are presented in package users' point of
-view,
-and in that point of view everything under `github.com/reddit/baseplate.go` are
-also third-party packages.
-
-Please note that this exception does not include tests and normal examples.
-
 ## Rename imports
 
-When an imported package name is different from the last element of the import
-path, always rename import it to make it explicit.
+When an imported package name is different from what is implied by the
+final element(s) of the import path, rename the import it to make it explicit.
 
 Example:
 
@@ -66,11 +54,15 @@ import (
 
 ### Exceptions
 
-As recommended by go modules version design,
-in the example of `"github.com/go-redis/redis/v7"`,
-`v7` is the major version number,
-so we consider `redis` as the actual last element of import path.
-As a result there's no need to rename import it.
+The implied package name of all of the following is still "foo", and thus
+they do not need to be renamed:
+
+* `.../foo.v1`
+* `.../foo/v1`
+* `.../foo-go`
+* `.../foo.go`
+
+Most import tools already understand these conventions.
 
 ## One-per-line style
 

--- a/baseplate.go
+++ b/baseplate.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/reddit/baseplate.go/batchcloser"
 	"github.com/reddit/baseplate.go/ecinterface"

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"

--- a/drainer_example_test.go
+++ b/drainer_example_test.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"io"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/thriftbp"

--- a/drainer_test.go
+++ b/drainer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 )
 
 func TestDrainer(t *testing.T) {

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	retry "github.com/avast/retry-go"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/avast/retry-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/retrybp"

--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -14,7 +14,8 @@ import (
 	"testing"
 	"time"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
+
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/tracing"

--- a/httpbp/config.go
+++ b/httpbp/config.go
@@ -1,7 +1,8 @@
 package httpbp
 
 import (
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
+
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/errorsbp"
 )

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"sync"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/log"
 )

--- a/kafkabp/consumer_test.go
+++ b/kafkabp/consumer_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/Shopify/sarama/mocks"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 )
 
 // Make sure that Consumer also implements baseplate.HealthChecker.

--- a/log/sentry.go
+++ b/log/sentry.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	sentry "github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go"
 	"go.uber.org/zap/zapcore"
 )
 

--- a/log/sentry_test.go
+++ b/log/sentry_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	sentry "github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	sentry "github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go"
 )
 
 // DefaultWrapper defines the default one to be used in log.Wrapper.

--- a/log/wrapper_example_test.go
+++ b/log/wrapper_example_test.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"strings"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
-	"gopkg.in/yaml.v2"
 )
 
 // ExtendedLogWrapper extends log.Wrapper to support metricsbp.LogWrapper.

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/metricsbp/config_test.go
+++ b/metricsbp/config_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/reddit/baseplate.go/metricsbp"
 )

--- a/redis/cache/redispipebp/breaker_test.go
+++ b/redis/cache/redispipebp/breaker_test.go
@@ -7,8 +7,9 @@ import (
 	"time"
 
 	"github.com/joomcode/redispipe/redis"
-	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/sony/gobreaker"
+
+	"github.com/reddit/baseplate.go/breakerbp"
 
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"
 	"github.com/reddit/baseplate.go/redis/cache/redisx"

--- a/redis/cache/redispipebp/breaker_test.go
+++ b/redis/cache/redispipebp/breaker_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sony/gobreaker"
 
 	"github.com/reddit/baseplate.go/breakerbp"
-
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"
 	"github.com/reddit/baseplate.go/redis/cache/redisx"
 )

--- a/redis/cache/redispipebp/init_test.go
+++ b/redis/cache/redispipebp/init_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/joomcode/redispipe/redis"
 	"github.com/joomcode/redispipe/redisconn"
+
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/tracing"
 

--- a/redis/cache/redispipebp/retry_test.go
+++ b/redis/cache/redispipebp/retry_test.go
@@ -7,10 +7,9 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/joomcode/redispipe/redis"
 
-	"github.com/reddit/baseplate.go/retrybp"
-
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"
 	"github.com/reddit/baseplate.go/redis/cache/redisx"
+	"github.com/reddit/baseplate.go/retrybp"
 )
 
 type counts struct {

--- a/redis/cache/redispipebp/retry_test.go
+++ b/redis/cache/redispipebp/retry_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/avast/retry-go"
 	"github.com/joomcode/redispipe/redis"
+
 	"github.com/reddit/baseplate.go/retrybp"
 
 	"github.com/reddit/baseplate.go/redis/cache/redispipebp"

--- a/redis/db/redisbp/config_test.go
+++ b/redis/db/redisbp/config_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-redis/redis/v8"
 	"gopkg.in/yaml.v2"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 )
 

--- a/redis/db/redisbp/example_hooks_test.go
+++ b/redis/db/redisbp/example_hooks_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 
 	"github.com/go-redis/redis/v8"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 	"github.com/reddit/baseplate.go/tracing"
 )

--- a/redis/db/redisbp/example_monitored_client_test.go
+++ b/redis/db/redisbp/example_monitored_client_test.go
@@ -4,7 +4,8 @@ import (
 	"context"
 
 	"github.com/go-redis/redis/v8"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/redis/db/redisbp/hooks.go
+++ b/redis/db/redisbp/hooks.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/redis/db/redisbp/hooks_test.go
+++ b/redis/db/redisbp/hooks_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"github.com/go-redis/redis/v8"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 	"github.com/reddit/baseplate.go/thriftbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/redis/db/redisbp/monitored_client.go
+++ b/redis/db/redisbp/monitored_client.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-
 	"github.com/reddit/baseplate.go/metricsbp"
 )
 

--- a/redis/db/redisbp/monitored_client_test.go
+++ b/redis/db/redisbp/monitored_client_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
+
 	"github.com/reddit/baseplate.go/mqsend"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/retrybp/delay.go
+++ b/retrybp/delay.go
@@ -5,7 +5,7 @@ import (
 	"math"
 	"time"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 
 	"github.com/reddit/baseplate.go/randbp"
 )

--- a/retrybp/filters.go
+++ b/retrybp/filters.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"net"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 	"github.com/sony/gobreaker"
 )
 

--- a/retrybp/fixtures_test.go
+++ b/retrybp/fixtures_test.go
@@ -3,7 +3,7 @@ package retrybp_test
 import (
 	"fmt"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 )
 
 const (

--- a/retrybp/retry.go
+++ b/retrybp/retry.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 
 	"github.com/reddit/baseplate.go/errorsbp"
 )

--- a/retrybp/retry_test.go
+++ b/retrybp/retry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/retrybp"

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	retry "github.com/avast/retry-go"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/avast/retry-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/ecinterface"

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/avast/retry-go"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/ecinterface"
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/mqsend"

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 	"github.com/go-kit/kit/metrics"
 
 	"github.com/reddit/baseplate.go/breakerbp"

--- a/thriftbp/doc_client_test.go
+++ b/thriftbp/doc_client_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/thriftbp"
 )

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 
 	"github.com/reddit/baseplate.go/errorsbp"
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"

--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	retry "github.com/avast/retry-go"
+	"github.com/avast/retry-go"
 
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/thriftbp"

--- a/thriftbp/example_client_test.go
+++ b/thriftbp/example_client_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 
 	"github.com/apache/thrift/lib/go/thrift"
-	retry "github.com/avast/retry-go"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/avast/retry-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/retrybp"

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -3,7 +3,7 @@ package thriftbp_test
 import (
 	"context"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/ecinterface"
 	bpgen "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/log"
 )

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	baseplate "github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/batchcloser"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"

--- a/thriftbp/tracing_test.go
+++ b/thriftbp/tracing_test.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/thriftbp"
 	"github.com/reddit/baseplate.go/tracing"
 )

--- a/tracing/example_error_reporter_hooks_test.go
+++ b/tracing/example_error_reporter_hooks_test.go
@@ -3,7 +3,8 @@ package tracing_test
 import (
 	"errors"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/tracing"
 )
 

--- a/tracing/finish_option.go
+++ b/tracing/finish_option.go
@@ -3,7 +3,7 @@ package tracing
 import (
 	"context"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 )
 

--- a/tracing/hooks_test.go
+++ b/tracing/hooks_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/thriftbp"
 	"github.com/reddit/baseplate.go/tracing"

--- a/tracing/span.go
+++ b/tracing/span.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"time"
 
-	sentry "github.com/getsentry/sentry-go"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/getsentry/sentry-go"
+	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 
 	"github.com/reddit/baseplate.go/log"

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -8,7 +8,7 @@ import (
 	"testing/quick"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/randbp"
 )

--- a/tracing/start_options.go
+++ b/tracing/start_options.go
@@ -1,7 +1,7 @@
 package tracing
 
 import (
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 // StartSpanOptions is the additional options for baseplate spans.

--- a/tracing/start_options_example_test.go
+++ b/tracing/start_options_example_test.go
@@ -3,7 +3,8 @@ package tracing_test
 import (
 	"context"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/reddit/baseplate.go/tracing"
 )
 

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -7,7 +7,7 @@ import (
 	"testing/quick"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"


### PR DESCRIPTION
This applies the following import style:
  - All imports are in exactly one block
  - Imports are organized into 3 groups
     "stdlib"
     "external"
     "same-module"
  - Redundant renamed imports are removed