### PR TITLE
Add internal/limitreader package

### DIFF
--- a/filewatcher/BUILD.bazel
+++ b/filewatcher/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/reddit/baseplate.go/filewatcher",
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/limitreader",
         "//log",
         "@in_gopkg_fsnotify_v1//:fsnotify_v1",
     ],

--- a/filewatcher/limit_parser_test.go
+++ b/filewatcher/limit_parser_test.go
@@ -15,14 +15,13 @@ func TestLimitParser(t *testing.T) {
 
 	parser := func(data io.Reader) (interface{}, error) {
 		buf, err := io.ReadAll(data)
-		if err != nil {
-			t.Error(err)
-			return nil, err
-		}
 		if string(buf) != expected {
 			t.Errorf("Data expected %q, got %q", expected, buf)
 		}
-		return nil, nil
+		if err == nil {
+			t.Error("Expected error, got nothing")
+		}
+		return nil, err
 	}
 	limitParser(parser, limit)(strings.NewReader(origin))
 }

--- a/internal/limitreader/BUILD.bazel
+++ b/internal/limitreader/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "limitreader",
+    srcs = [
+        "doc.go",
+        "reader.go",
+    ],
+    importpath = "github.com/reddit/baseplate.go/internal/limitreader",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "limitreader_test",
+    size = "small",
+    srcs = ["reader_test.go"],
+    deps = [":limitreader"],
+)

--- a/internal/limitreader/doc.go
+++ b/internal/limitreader/doc.go
@@ -1,0 +1,2 @@
+// Package limitreader provides an alternative implementation of io.LimitReader.
+package limitreader

--- a/internal/limitreader/reader.go
+++ b/internal/limitreader/reader.go
@@ -1,0 +1,48 @@
+package limitreader
+
+import (
+	"bufio"
+	"errors"
+	"io"
+)
+
+// ErrReadLimitExceeded is the error returned when there's more data on the
+// underlying reader and a read operation is trying to read beyond that.
+var ErrReadLimitExceeded = errors.New("limitreader: read limit exceeded")
+
+// New wraps reader with a limit.
+//
+// It's similar to io.LimitReader,
+// but instead of always returning io.EOF when read beyond the limit,
+// it would return a different error (which would cause the read operation to
+// fail) when there's more data on the underlying reader.
+func New(r io.Reader, limit int64) io.Reader {
+	return &reader{
+		reader:    bufio.NewReaderSize(r, 16),
+		remaining: limit,
+	}
+}
+
+type reader struct {
+	reader    *bufio.Reader
+	remaining int64
+}
+
+func (r *reader) Read(p []byte) (int, error) {
+	// EOF handling
+	if r.remaining <= 0 {
+		_, err := r.reader.Peek(1)
+		if err != nil {
+			// NOTE: This also includes io.EOF error, which is the expected behavior.
+			return 0, err
+		}
+		return 0, ErrReadLimitExceeded
+	}
+
+	if len(p) > int(r.remaining) {
+		p = p[:r.remaining]
+	}
+	read, err := r.reader.Read(p)
+	r.remaining -= int64(read)
+	return read, err
+}

--- a/internal/limitreader/reader.go
+++ b/internal/limitreader/reader.go
@@ -16,6 +16,9 @@ var ErrReadLimitExceeded = errors.New("limitreader: read limit exceeded")
 // but instead of always returning io.EOF when read beyond the limit,
 // it would return a different error (which would cause the read operation to
 // fail) when there's more data on the underlying reader.
+//
+// r passed in shall not be read again directly,
+// unless it's of type *bufio.Reader.
 func New(r io.Reader, limit int64) io.Reader {
 	return &reader{
 		reader:    bufio.NewReaderSize(r, 16),

--- a/internal/limitreader/reader_test.go
+++ b/internal/limitreader/reader_test.go
@@ -1,0 +1,70 @@
+package limitreader_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/reddit/baseplate.go/internal/limitreader"
+)
+
+func TestReader(t *testing.T) {
+	const (
+		content = "Hello, world!"
+		max     = int64(len(content))
+	)
+
+	for _, c := range []struct {
+		label    string
+		limit    int64
+		n        int64
+		expected string
+		err      error
+	}{
+		{
+			label:    "normal",
+			limit:    max,
+			n:        max,
+			expected: content,
+			err:      nil,
+		},
+		{
+			// When n is larger than limit, it should return EOF.
+			label:    "larger-n",
+			limit:    max,
+			n:        max + 1,
+			expected: content,
+			err:      io.EOF,
+		},
+		{
+			// When limit is larger than the reader, it should return EOF.
+			label:    "larger-limit",
+			limit:    max + 1,
+			n:        max + 1,
+			expected: content,
+			err:      io.EOF,
+		},
+		{
+			// When limit is smaller than the size and n is larger than limit,
+			// it should return ErrReadBeyondLimit.
+			label:    "smaller-limit",
+			limit:    max - 1,
+			n:        max,
+			expected: content[:max-1],
+			err:      limitreader.ErrReadLimitExceeded,
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			r := limitreader.New(strings.NewReader(content), c.limit)
+			var sb strings.Builder
+			_, err := io.CopyN(&sb, r, c.n)
+			if s := sb.String(); s != c.expected {
+				t.Errorf("Expected to read %q, got %q", c.expected, s)
+			}
+			if !errors.Is(err, c.err) {
+				t.Errorf("Expected error %v, got %v", c.err, err)
+			}
+		})
+	}
+}

--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -160,6 +160,7 @@ func StdWrapper(logger *stdlog.Logger) Wrapper {
 // It fails the test when called.
 func TestWrapper(tb testing.TB) Wrapper {
 	return func(_ context.Context, msg string) {
+		tb.Helper()
 		tb.Errorf("logger called with msg: %q", msg)
 	}
 }


### PR DESCRIPTION
This implements something similar to io.LimitReader, but reports error
when it's read beyond the limit.

It's under internal as this is a special case that we don't want to make
as part of our public API. We can move it out of internal in the future
if there are wider demands for it.

Switch filewatcher to use that instead of io.LimitReader. It could also
be used in https://github.com/reddit/baseplate.go/pull/385.