### PR TITLE
tracing: UUID -> Hex

### DIFF
--- a/tracing/BUILD.bazel
+++ b/tracing/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//runtimebp",
         "//timebp",
         "@com_github_getsentry_sentry_go//:sentry-go",
-        "@com_github_gofrs_uuid//:uuid",
         "@com_github_opentracing_opentracing_go//:opentracing-go",
         "@com_github_opentracing_opentracing_go//log",
     ],
@@ -52,7 +51,6 @@ go_test(
         "//randbp",
         "//thriftbp",
         "//timebp",
-        "@com_github_gofrs_uuid//:uuid",
         "@com_github_opentracing_opentracing_go//:opentracing-go",
     ],
 )

--- a/tracing/config.go
+++ b/tracing/config.go
@@ -27,10 +27,10 @@ type Config struct {
 	// SampleRate is the % of new trace's to sample.
 	SampleRate float64 `yaml:"sampleRate"`
 
-	// Generate UUID instead of uint64 for new trace/span IDs.
+	// Generate hex instead of dec uint64 for new trace/span IDs.
 	// NOTE: Only enable this if you know all your upstream services can handle
-	// UUID trace/span IDs (Baseplate.go v0.8.0+ or Baseplate.py v2.0.0+).
-	UseUUID bool `yaml:"useUUID"`
+	// hex trace/span IDs (Baseplate.go v0.8.0+ or Baseplate.py v2.0.0+).
+	UseHex bool `yaml:"useHex"`
 }
 
 // InitFromConfig initializes the global tracer using the given Config and
@@ -46,7 +46,7 @@ func InitFromConfig(cfg Config) (io.Closer, error) {
 		MaxRecordTimeout: cfg.RecordTimeout,
 		QueueName:        cfg.QueueName,
 		MaxQueueSize:     cfg.MaxQueueSize,
-		UseUUID:          cfg.UseUUID,
+		UseHex:           cfg.UseHex,
 		Logger:           log.ErrorWithSentryWrapper(),
 	})
 	if err != nil {

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -484,6 +484,14 @@ func TestHeadersParseTraceID(t *testing.T) {
 			},
 		},
 		{
+			name:    "hex",
+			headers: Headers{TraceID: "6ba7b8109dad11d180b400c04fd430c8"},
+			expected: expectation{
+				id: "6ba7b8109dad11d180b400c04fd430c8",
+				ok: true,
+			},
+		},
+		{
 			name:    "invalid",
 			headers: Headers{TraceID: strings.Repeat("1", maxIDLength+1)},
 			expected: expectation{
@@ -546,6 +554,14 @@ func TestHeadersParseSpanID(t *testing.T) {
 			headers: Headers{SpanID: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"},
 			expected: expectation{
 				id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+				ok: true,
+			},
+		},
+		{
+			name:    "hex",
+			headers: Headers{SpanID: "80b400c04fd430c8"},
+			expected: expectation{
+				id: "80b400c04fd430c8",
 				ok: true,
 			},
 		},

--- a/tracing/trace.go
+++ b/tracing/trace.go
@@ -56,8 +56,8 @@ func newTrace(tracer *Tracer, name string) *trace {
 		tracer: tracer,
 
 		name:    name,
-		traceID: tracer.newID(),
-		spanID:  tracer.newID(),
+		traceID: tracer.newTraceID(),
+		spanID:  tracer.newSpanID(),
 		start:   time.Now(),
 
 		counters: make(map[string]float64),


### PR DESCRIPTION
The major open source tracing libraries/standards, including Zipkin,
OpenTracing, and OpenTelemetry are all using 128-bit hex id for traces
and 64-bit hex id for spans. So change our uuid trace/span id to hex id.

cc: @spladug @praxist