### PR TITLE
thriftbp: Change ClientPool from implementing TClient to return it

### DIFF
--- a/cmd/lib/healthcheck/healthcheck.go
+++ b/cmd/lib/healthcheck/healthcheck.go
@@ -149,7 +149,7 @@ func checkThrift(addr string, probe baseplate.IsHealthyProbe, timeout time.Durat
 		return fmt.Errorf("failed to create thrift client pool: %w", err)
 	}
 	defer pool.Close()
-	client := baseplate.NewBaseplateServiceV2Client(pool)
+	client := baseplate.NewBaseplateServiceV2Client(pool.TClient())
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	ret, err := client.IsHealthy(ctx, &baseplate.IsHealthyRequest{

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -359,7 +359,7 @@ func TestRetry(t *testing.T) {
 	handler.server = server
 	server.Start(ctx)
 
-	client := baseplatethrift.NewBaseplateServiceV2Client(server.ClientPool)
+	client := baseplatethrift.NewBaseplateServiceV2Client(server.ClientPool.TClient())
 	ctx, cancel = context.WithTimeout(ctx, retryTestTimeout)
 	defer cancel()
 	_, err = client.IsHealthy(

--- a/thriftbp/thrifttest/mocks.go
+++ b/thriftbp/thrifttest/mocks.go
@@ -233,6 +233,11 @@ func (m MockClientPool) IsExhausted() bool {
 	return m.Exhausted
 }
 
+// TClient implements thriftbp.ClientPool.
+func (m MockClientPool) TClient() thrift.TClient {
+	return m
+}
+
 // Call implements TClient.
 //
 // If Exhausted is set to true,

--- a/thriftbp/thrifttest/server_test.go
+++ b/thriftbp/thrifttest/server_test.go
@@ -92,7 +92,7 @@ func TestNewBaseplateServer(t *testing.T) {
 				// cancelling the context will close the server.
 				server.Start(ctx)
 
-				client := baseplatethrift.NewBaseplateServiceV2Client(server.ClientPool)
+				client := baseplatethrift.NewBaseplateServiceV2Client(server.ClientPool.TClient())
 				result, err := client.IsHealthy(
 					ctx,
 					&baseplatethrift.IsHealthyRequest{


### PR DESCRIPTION
Fixes https://github.com/reddit/baseplate.go/issues/362.

Currently there's a semi-widespread footgun of services sharing the
concrete thrift client rather than the client pool between goroutines.
As described in #362, this breaking change hopefully can force them to
fix the issue.