### PR TITLE
thriftbp: Don't suppress baseplate.Error in range [500, 600)

### DIFF
--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -143,6 +143,27 @@ func TestIDLExceptionSuppressor(t *testing.T) {
 			expected: true,
 		},
 		{
+			label: "baseplate.Error-500",
+			err: &baseplatethrift.Error{
+				Code: thrift.Int32Ptr(500),
+			},
+			expected: false,
+		},
+		{
+			label: "baseplate.Error-400",
+			err: &baseplatethrift.Error{
+				Code: thrift.Int32Ptr(400),
+			},
+			expected: true,
+		},
+		{
+			label: "baseplate.Error-1000",
+			err: &baseplatethrift.Error{
+				Code: thrift.Int32Ptr(1000),
+			},
+			expected: true,
+		},
+		{
 			label:    "TTransportException",
 			err:      thrift.NewTTransportException(0, ""),
 			expected: false,


### PR DESCRIPTION
To follow the Baseplate spec update, don't suppress baseplate.Error when
the code is in range [500, 600).

Also remove thriftbp.BaseplateErrorCode. We added an unexported
baseplateError which is a super set of BaseplateErrorCode, and
maintaining an exported version of that is not really in our best
interest. I did an internal code search and didn't see any service using
BaseplateErrorCode so I'll skip the deprecation process and just remove
it directly.