### PR TITLE
thriftbp: Fix DNS resolution in client pool

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -453,15 +453,11 @@ func newClient(
 		return nil, fmt.Errorf("thriftbp: error getting next address for new Thrift client: %w", err)
 	}
 
-	trans, err := thrift.NewTSocketConf(addr, cfg)
+	conn, err := net.DialTimeout("tcp", addr, cfg.GetConnectTimeout())
 	if err != nil {
-		return nil, fmt.Errorf("thriftbp: error building TSocket for new Thrift client: %w", err)
+		return nil, fmt.Errorf("thriftbp: error opening connection for new Thrift client: %w", err)
 	}
-
-	err = trans.Open()
-	if err != nil {
-		return nil, fmt.Errorf("thriftbp: error opening TSocket for new Thrift client: %w", err)
-	}
+	trans := thrift.NewTSocketFromConnConf(conn, cfg)
 
 	client := thrift.NewTStandardClient(
 		protoFactory.GetProtocol(trans),


### PR DESCRIPTION
This is the same fix as the upstream Thrift fix [1] [2] that will be
included in Thrift 0.15.0. Doing it here because:

1. We don't have to wait for Thrift 0.15.0 release to get the fix.
2. Thrift 0.15.0 release will actually be a breaking change, but with
   this this fix we are no longer being affected by the breaking change,
   so that users using Baseplate.go 0.9.0 can upgrade to Thrift 0.15.0
   once that's released.

We can potentially revert this fix in the future once we upgraded to
Thrift 0.15.0.

[1] https://github.com/apache/thrift/pull/2435
[2] https://issues.apache.org/jira/browse/THRIFT-5453