### PR TITLE
errorsbp: Export PrefixError and PrefixedError

### DIFF
--- a/errorsbp/BUILD.bazel
+++ b/errorsbp/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "batch.go",
         "doc.go",
+        "prefix.go",
         "suppressor.go",
     ],
     importpath = "github.com/reddit/baseplate.go/errorsbp",
@@ -17,6 +18,7 @@ go_test(
     srcs = [
         "batch_example_test.go",
         "batch_test.go",
+        "prefix_example_test.go",
         "suppressor_example_test.go",
         "suppressor_test.go",
     ],

--- a/errorsbp/prefix.go
+++ b/errorsbp/prefix.go
@@ -1,0 +1,48 @@
+package errorsbp
+
+// PrefixError appends prefix to err.
+//
+// If err is nil, nil will be returned.
+// If prefix is empty, err will be returned as-is.
+// Otherwise, the returned error will be of type *PrefixedError,
+// and the error message would be:
+//
+//     "prefix: err.Error()"
+//
+// NOTE: A reason to use PrefixError over fmt.Errorf(prefix + ": %w", err)
+// is that prefix could contain format verbs, e.g. prefix = "foo%sbar".
+func PrefixError(prefix string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if prefix == "" {
+		return err
+	}
+
+	return &PrefixedError{
+		prefix: prefix,
+		msg:    prefix + ": " + err.Error(),
+		err:    err,
+	}
+}
+
+// PrefixedError defines the type of error returned by PrefixError.
+type PrefixedError struct {
+	prefix string
+	msg    string
+	err    error
+}
+
+func (e *PrefixedError) Error() string {
+	return e.msg
+}
+
+func (e *PrefixedError) Unwrap() error {
+	return e.err
+}
+
+// Prefix returns the prefix of this error.
+func (e *PrefixedError) Prefix() string {
+	return e.prefix
+}

--- a/errorsbp/prefix_example_test.go
+++ b/errorsbp/prefix_example_test.go
@@ -1,0 +1,40 @@
+package errorsbp_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/reddit/baseplate.go/errorsbp"
+)
+
+// This example demonstrates how to use PrefixError.
+func ExamplePrefixError() {
+	// Two worker functions that could potentially return error.
+	const works = 2
+	var (
+		workerA = func() error {
+			// workerA will succeed, and it will be auto skipped in the batch.
+			return nil
+		}
+		workerB = func() error {
+			// workerB will fail, and the error will be prefixed in the batch.
+			return errors.New("b")
+		}
+	)
+	errs := make(chan error, works)
+	go func() {
+		errs <- errorsbp.PrefixError("workerA", workerA())
+	}()
+	go func() {
+		errs <- errorsbp.PrefixError("workerB", workerB())
+	}()
+
+	var batch errorsbp.Batch
+	for i := 0; i < works; i++ {
+		batch.Add(<-errs)
+	}
+	fmt.Println(batch.Compile())
+
+	// Output:
+	// workerB: b
+}


### PR DESCRIPTION
They used to be used inside Batch.AddPrefix, but that won't be usable in
the use case that the user need to run some workers in parallel and add
the errors to a batch. Export PrefixError and PrefixedError to support
that use case.