### PR TITLE
Consolidate config types and YAML annotations

### DIFF
--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -297,10 +297,10 @@ redis:
 		},
 
 		Tracing: tracing.Config{
-			Namespace:     "baseplate-test",
-			QueueName:     "test",
-			RecordTimeout: time.Millisecond,
-			SampleRate:    0.01,
+			Namespace:        "baseplate-test",
+			QueueName:        "test",
+			MaxRecordTimeout: time.Millisecond,
+			SampleRate:       0.01,
 		},
 	}
 
@@ -400,10 +400,10 @@ redis:
 		},
 
 		Tracing: tracing.Config{
-			Namespace:     "baseplate-test",
-			QueueName:     "test",
-			RecordTimeout: time.Millisecond,
-			SampleRate:    0.01,
+			Namespace:        "baseplate-test",
+			QueueName:        "test",
+			MaxRecordTimeout: time.Millisecond,
+			SampleRate:       0.01,
 		},
 	}
 

--- a/events/events.go
+++ b/events/events.go
@@ -33,11 +33,13 @@ type Queue struct {
 }
 
 // The Config used to initialize an event queue.
+//
+// Can be deserialized from YAML.
 type Config struct {
 	// The name of the message queue, should not contain the "events-" prefix.
 	//
 	// For v2 events, the default name (when passed in Name is empty) is "v2".
-	Name string
+	Name string `yaml:"name"`
 
 	// The max timeout applied to Put function.
 	//
@@ -47,13 +49,13 @@ type Config struct {
 	// If MaxPutTimeout <= 0,
 	// Put function would run in non-blocking mode,
 	// that it fails immediately if the queue is full.
-	MaxPutTimeout time.Duration
+	MaxPutTimeout time.Duration `yaml:"maxPutTimeout"`
 
 	// The max size of the message queue (number of messages).
 	//
 	// If it <=0 or > MaxQueueSize (the constant, 10000),
 	// MaxQueueSize constant will be used instead.
-	MaxQueueSize int64
+	MaxQueueSize int64 `yaml:"maxQueueSize"`
 }
 
 // V2 initializes a new v2 event queue with default configurations.

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -132,9 +132,11 @@ var (
 )
 
 // Config defines the config to be used in New function.
+//
+// Can be deserialized from YAML.
 type Config struct {
 	// The path to the file to be watched, required.
-	Path string
+	Path string `yaml:"path"`
 
 	// The parser to parse the data load, required.
 	Parser Parser
@@ -143,7 +145,7 @@ type Config struct {
 	// either returned by parser or by the underlying file system watcher.
 	// Please note that this does not include errors returned by the first parser
 	// call, which will be returned directly.
-	Logger log.Wrapper
+	Logger log.Wrapper `yaml:"logger"`
 
 	// Optional. When <=0 DefaultMaxFileSize will be used instead.
 	//
@@ -157,7 +159,7 @@ type Config struct {
 	//
 	// If the hard limit is violated,
 	// The loading of the file will fail immediately.
-	MaxFileSize int64
+	MaxFileSize int64 `yaml:"maxFileSize"`
 }
 
 // New creates a new file watcher.

--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -59,7 +59,7 @@ func TestNewClient(t *testing.T) {
 			MaxQueueSize:   tracing.MaxQueueSize,
 			MaxMessageSize: tracing.MaxSpanSize,
 		})
-		err := tracing.InitGlobalTracer(tracing.TracerConfig{
+		err := tracing.InitGlobalTracer(tracing.Config{
 			SampleRate:               1,
 			TestOnlyMockMessageQueue: recorder,
 		})
@@ -152,7 +152,7 @@ func TestMonitorClient(t *testing.T) {
 		MaxQueueSize:   tracing.MaxQueueSize,
 		MaxMessageSize: tracing.MaxSpanSize,
 	})
-	err := tracing.InitGlobalTracer(tracing.TracerConfig{
+	err := tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               1,
 		TestOnlyMockMessageQueue: recorder,
 	})

--- a/httpbp/middlewares_test.go
+++ b/httpbp/middlewares_test.go
@@ -42,14 +42,14 @@ func TestInjectServerSpan(t *testing.T) {
 
 	defer func() {
 		tracing.CloseTracer()
-		tracing.InitGlobalTracer(tracing.TracerConfig{})
+		tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	mmq := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 		MaxQueueSize:   100,
 		MaxMessageSize: 1024,
 	})
 	logger, startFailing := tracing.TestWrapper(t)
-	tracing.InitGlobalTracer(tracing.TracerConfig{
+	tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               0,
 		MaxRecordTimeout:         testTimeout,
 		Logger:                   logger,

--- a/httpbp/server_test.go
+++ b/httpbp/server_test.go
@@ -289,14 +289,14 @@ func TestServerArgsSetupEndpoints(t *testing.T) {
 
 			defer func() {
 				tracing.CloseTracer()
-				tracing.InitGlobalTracer(tracing.TracerConfig{})
+				tracing.InitGlobalTracer(tracing.Config{})
 			}()
 			mmq := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 				MaxQueueSize:   100,
 				MaxMessageSize: 1024,
 			})
 			logger, startFailing := tracing.TestWrapper(t)
-			tracing.InitGlobalTracer(tracing.TracerConfig{
+			tracing.InitGlobalTracer(tracing.Config{
 				SampleRate:               1,
 				MaxRecordTimeout:         testTimeout,
 				Logger:                   logger,

--- a/log/sentry.go
+++ b/log/sentry.go
@@ -27,33 +27,33 @@ type SentryConfig struct {
 	// The Sentry DSN to use.
 	// If empty, SENTRY_DSN environment variable will be used instead.
 	// If that's also empty, then all sentry operations will be nop.
-	DSN string
+	DSN string `yaml:"dsn"`
 
 	// SampleRate between 0 and 1, default is 1.
-	SampleRate *float64
+	SampleRate *float64 `yaml:"sampleRate"`
 
 	// The name of your service.
 	//
 	// By default sentry extracts hostname reported by the kernel for this field.
 	// Set it to non-empty to override that
 	// (and hostname tag will be used to report hostname automatically).
-	ServerName string
+	ServerName string `yaml:"serverName"`
 
 	// An environment string like "prod", "staging".
-	Environment string
+	Environment string `yaml:"environment"`
 
 	// List of regexp strings that will be used to match against event's message
 	// and if applicable, caught errors type and value.
 	// If the match is found, then a whole event will be dropped.
-	IgnoreErrors []string
+	IgnoreErrors []string `yaml:"ignoreErrors"`
 
 	// FlushTimeout is the timeout to be used to call sentry.Flush when closing
 	// the Closer returned by InitSentry.
 	// If <=0, DefaultSentryFlushTimeout will be used.
-	FlushTimeout time.Duration
+	FlushTimeout time.Duration `yaml:"flushTimeout"`
 
 	// BeforeSend is a callback modifier before emitting an event to Sentry.
-	BeforeSend func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event
+	BeforeSend func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event `yaml:"-"`
 }
 
 // InitSentry initializes sentry reporting.

--- a/metricsbp/baseplate_hooks_internal_test.go
+++ b/metricsbp/baseplate_hooks_internal_test.go
@@ -19,7 +19,7 @@ func (h createServerSpanHook) OnCreateServerSpan(span *tracing.Span) error {
 func TestCountActiveRequestsHook(t *testing.T) {
 	st := NewStatsd(
 		context.Background(),
-		StatsdConfig{},
+		Config{},
 	)
 
 	createServerHook := createServerSpanHook{

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -60,7 +60,7 @@ func foundHistogram(histograms []string, pattern *regexp.Regexp) bool {
 func TestOnCreateServerSpan(t *testing.T) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{},
+		metricsbp.Config{},
 	)
 
 	hook := metricsbp.CreateServerSpanHook{Metrics: st}
@@ -292,7 +292,7 @@ func TestWithStartAndFinishTimes(t *testing.T) {
 
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{},
+		metricsbp.Config{},
 	)
 
 	hook := metricsbp.CreateServerSpanHook{Metrics: st}

--- a/metricsbp/config.go
+++ b/metricsbp/config.go
@@ -28,6 +28,27 @@ type Config struct {
 	// Optional, defaults to 1 (100%).
 	HistogramSampleRate *float64 `yaml:"histogramSampleRate"`
 
+	// When Endpoint is configured,
+	// BufferSize can be used to buffer writes to statsd collector together.
+	//
+	// Set it to an appropriate number will reduce the number of UDP messages sent
+	// to the statsd collector. (Recommendation: 4KB)
+	//
+	// It's guaranteed that every single UDP message will not exceed BufferSize,
+	// unless a single metric line exceeds it
+	// (usually around 100 bytes depending on the length of the metric path).
+	//
+	// When it's 0 (default), DefaultBufferSize will be used.
+	//
+	// To disable buffering, set it to negative value (e.g. -1) or a value smaller
+	// than a single statsd metric line (usually around 100, so 1 works),
+	// on ReporterTickerInterval we will write one UDP message per metric to the
+	// statsd collector.
+	BufferSize int `yaml:"bufferSize"`
+
+	// The log level used by the reporting goroutine.
+	LogLevel log.Level `yaml:"logLevel"`
+
 	// RunSysStats indicates that you want to publish system stats.
 	//
 	// Optional, defaults to false.
@@ -41,13 +62,7 @@ type Config struct {
 // It also registers CreateServerSpanHook and ConcurrencyCreateServerSpanHook
 // with the global tracing hook registry.
 func InitFromConfig(ctx context.Context, cfg Config) io.Closer {
-	M = NewStatsd(ctx, StatsdConfig{
-		HistogramSampleRate: cfg.HistogramSampleRate,
-		Prefix:              cfg.Namespace,
-		Address:             cfg.Endpoint,
-		LogLevel:            log.ErrorLevel,
-		Tags:                cfg.Tags,
-	})
+	M = NewStatsd(ctx, cfg)
 	tracing.RegisterCreateServerSpanHooks(CreateServerSpanHook{Metrics: M})
 	if cfg.RunSysStats {
 		M.RunSysStats()

--- a/metricsbp/example_nil_check_test.go
+++ b/metricsbp/example_nil_check_test.go
@@ -33,9 +33,9 @@ func ExampleCheckNilFields() {
 	defer cancel()
 	metricsbp.M = metricsbp.NewStatsd(
 		ctx,
-		metricsbp.StatsdConfig{
-			Prefix:              prefix,
-			Address:             statsdAddr,
+		metricsbp.Config{
+			Namespace:           prefix,
+			Endpoint:            statsdAddr,
 			HistogramSampleRate: metricsbp.Float64Ptr(sampleRate),
 		},
 	)

--- a/metricsbp/log_test.go
+++ b/metricsbp/log_test.go
@@ -31,7 +31,7 @@ func TestLogWrapper(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	statsd := metricsbp.NewStatsd(ctx, metricsbp.StatsdConfig{})
+	statsd := metricsbp.NewStatsd(ctx, metricsbp.Config{})
 	wrapped := metricsbp.LogWrapper(metricsbp.LogWrapperArgs{
 		Counter: path,
 		Statsd:  statsd,

--- a/metricsbp/sampled_test.go
+++ b/metricsbp/sampled_test.go
@@ -18,17 +18,17 @@ func TestSampledHistogram(t *testing.T) {
 
 	statsd := NewStatsd(
 		context.Background(),
-		StatsdConfig{},
+		Config{},
 	)
 	statsdSampled := NewStatsd(
 		context.Background(),
-		StatsdConfig{
+		Config{
 			HistogramSampleRate: Float64Ptr(rate),
 		},
 	)
 	statsdWithTags := NewStatsd(
 		context.Background(),
-		StatsdConfig{
+		Config{
 			Tags: map[string]string{
 				"foo": "bar",
 			},
@@ -36,7 +36,7 @@ func TestSampledHistogram(t *testing.T) {
 	)
 	statsdWithTagsSampled := NewStatsd(
 		context.Background(),
-		StatsdConfig{
+		Config{
 			HistogramSampleRate: Float64Ptr(rate),
 			Tags: map[string]string{
 				"foo": "bar",
@@ -203,11 +203,11 @@ func TestSampledCounter(t *testing.T) {
 
 	statsd := NewStatsd(
 		context.Background(),
-		StatsdConfig{},
+		Config{},
 	)
 	statsdWithTags := NewStatsd(
 		context.Background(),
-		StatsdConfig{
+		Config{
 			Tags: map[string]string{
 				"foo": "bar",
 			},

--- a/metricsbp/statsd_test.go
+++ b/metricsbp/statsd_test.go
@@ -48,8 +48,8 @@ func TestNoFallback(t *testing.T) {
 	prefix := "counter"
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
-			Prefix: prefix,
+		metricsbp.Config{
+			Namespace: prefix,
 		},
 	)
 	st.Counter("foo").Add(1)
@@ -63,8 +63,8 @@ func TestNoFallback(t *testing.T) {
 	prefix = "histogram"
 	st = metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
-			Prefix: prefix,
+		metricsbp.Config{
+			Namespace: prefix,
 		},
 	)
 	st.Histogram("foo").Observe(1)
@@ -78,8 +78,8 @@ func TestNoFallback(t *testing.T) {
 	prefix = "timing"
 	st = metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
-			Prefix: prefix,
+		metricsbp.Config{
+			Namespace: prefix,
 		},
 	)
 	st.Timing("foo").Observe(1)
@@ -93,8 +93,8 @@ func TestNoFallback(t *testing.T) {
 	prefix = "gauge"
 	st = metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
-			Prefix: prefix,
+		metricsbp.Config{
+			Namespace: prefix,
 		},
 	)
 	st.Gauge("foo").Set(1)
@@ -123,7 +123,7 @@ func BenchmarkStatsd(b *testing.B) {
 
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.StatsdConfig{
+		metricsbp.Config{
 			Tags: initialTags,
 		},
 	)

--- a/redis/cache/redispipebp/init_test.go
+++ b/redis/cache/redispipebp/init_test.go
@@ -22,13 +22,13 @@ var (
 func TestMain(m *testing.M) {
 	defer func() {
 		_ = tracing.CloseTracer()
-		_ = tracing.InitGlobalTracer(tracing.TracerConfig{})
+		_ = tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	mmq = mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 		MaxQueueSize:   100,
 		MaxMessageSize: 1024,
 	})
-	if err := tracing.InitGlobalTracer(tracing.TracerConfig{
+	if err := tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               1,
 		MaxRecordTimeout:         testTimeout,
 		Logger:                   nil,

--- a/redis/db/redisbp/monitored_client_test.go
+++ b/redis/db/redisbp/monitored_client_test.go
@@ -20,14 +20,14 @@ const (
 func TestNewMonitoredClient(t *testing.T) {
 	defer func() {
 		tracing.CloseTracer()
-		tracing.InitGlobalTracer(tracing.TracerConfig{})
+		tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	mmq := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 		MaxQueueSize:   100,
 		MaxMessageSize: 1024,
 	})
 	logger, startFailing := tracing.TestWrapper(t)
-	if err := tracing.InitGlobalTracer(tracing.TracerConfig{
+	if err := tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               1,
 		MaxRecordTimeout:         testTimeout,
 		Logger:                   logger,

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -51,7 +51,7 @@ func initServerSpan(ctx context.Context, t *testing.T) (context.Context, *mqsend
 		MaxQueueSize:   100,
 		MaxMessageSize: 1024,
 	})
-	tracing.InitGlobalTracer(tracing.TracerConfig{
+	tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               1.0,
 		TestOnlyMockMessageQueue: recorder,
 	})
@@ -135,7 +135,7 @@ func TestWrapMonitoredClient(t *testing.T) {
 			func(t *testing.T) {
 				defer func() {
 					tracing.CloseTracer()
-					tracing.InitGlobalTracer(tracing.TracerConfig{})
+					tracing.InitGlobalTracer(tracing.Config{})
 				}()
 
 				mock, recorder, client := initClients(nil)

--- a/thriftbp/server_middlewares_test.go
+++ b/thriftbp/server_middlewares_test.go
@@ -40,14 +40,14 @@ func TestInjectServerSpan(t *testing.T) {
 
 	defer func() {
 		tracing.CloseTracer()
-		tracing.InitGlobalTracer(tracing.TracerConfig{})
+		tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	mmq := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
 		MaxQueueSize:   100,
 		MaxMessageSize: 1024,
 	})
 	logger, startFailing := tracing.TestWrapper(t)
-	tracing.InitGlobalTracer(tracing.TracerConfig{
+	tracing.InitGlobalTracer(tracing.Config{
 		SampleRate:               1,
 		MaxRecordTimeout:         testTimeout,
 		Logger:                   logger,
@@ -122,10 +122,10 @@ func TestStartSpanFromThriftContext(t *testing.T) {
 
 	defer func() {
 		tracing.CloseTracer()
-		tracing.InitGlobalTracer(tracing.TracerConfig{})
+		tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	logger, startFailing := tracing.TestWrapper(t)
-	tracing.InitGlobalTracer(tracing.TracerConfig{
+	tracing.InitGlobalTracer(tracing.Config{
 		Logger: logger,
 	})
 	startFailing()

--- a/thriftbp/tracing_test.go
+++ b/thriftbp/tracing_test.go
@@ -21,10 +21,10 @@ func TestCreateThriftContextFromSpan(t *testing.T) {
 
 	defer func() {
 		tracing.CloseTracer()
-		tracing.InitGlobalTracer(tracing.TracerConfig{})
+		tracing.InitGlobalTracer(tracing.Config{})
 	}()
 	logger, startFailing := tracing.TestWrapper(t)
-	tracing.InitGlobalTracer(tracing.TracerConfig{
+	tracing.InitGlobalTracer(tracing.Config{
 		Logger: logger,
 	})
 	startFailing()

--- a/tracing/config.go
+++ b/tracing/config.go
@@ -5,32 +5,75 @@ import (
 	"time"
 
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/mqsend"
 )
 
-// Config is the confuration struct for the tracing package.
+// Config is the configuration struct for the tracing package containing
+// configuration values to be used in InitGlobalTracer.
 //
 // Can be deserialized from YAML.
 type Config struct {
-	// Namespace the name of your service.
+	// The name of the service that will be attached to every span.
 	Namespace string `yaml:"namespace"`
 
-	// QueueName is the name of the POSIX queue your service publishes traces to
-	// to be read by a trace publisher sidecar.
+	// SampleRate should be in the range of [0, 1].
+	// When SampleRate >= 1, all traces will be recoreded;
+	// When SampleRate <= 0, none of the traces will be recorded,
+	// except the ones with debug flag set.
+	//
+	// Please note that SampleRate only affect top level spans created inside this
+	// service. For most services the sample status will be inherited from the
+	// headers from the client.
+	SampleRate float64 `yaml:"sampleRate"`
+
+	// Logger, if non-nil, will be used to log additional informations Record
+	// returned certain errors.
+	Logger log.Wrapper `yaml:"logger"`
+
+	// The max timeout applied to Record function.
+	//
+	// If the passed in context object has an earlier deadline set,
+	// that deadline will be respected instead.
+	//
+	// If MaxRecordTimeout <= 0,
+	// Record function would run in non-blocking mode,
+	// that it fails immediately if the queue is full.
+	MaxRecordTimeout time.Duration `yaml:"recordTimeout"`
+
+	// The name of the message queue to be used to actually send sampled spans to
+	// backend service (requires Baseplate.py tracing publishing sidecar with the
+	// same name configured).
+	//
+	// QueueName should not contain "traces-" prefix, it will be auto added.
+	//
+	// If QueueName is empty, no spans will be sampled,
+	// including the ones with debug flag set.
 	QueueName string `yaml:"queueName"`
 
 	// The max size of the message queue (number of messages).
+	//
+	// If it <=0 or > MaxQueueSize (the constant, 10000),
+	// MaxQueueSize constant will be used instead.
+	//
+	// This is only used when QueueName is non-empty.
 	MaxQueueSize int64 `yaml:"maxQueueSize"`
 
-	// RecordTimeout is the timeout on writing a trace to the POSIX queue.
-	RecordTimeout time.Duration `yaml:"recordTimeout"`
-
-	// SampleRate is the % of new trace's to sample.
-	SampleRate float64 `yaml:"sampleRate"`
-
-	// Generate hex instead of dec uint64 for new trace/span IDs.
-	// NOTE: Only enable this if you know all your upstream services can handle
-	// hex trace/span IDs (Baseplate.go v0.8.0+ or Baseplate.py v2.0.0+).
+	// If UseHex is set to true, when generating new trace/span IDs we will use
+	// hex instead of dec uint64.
+	//
+	// You should only set this to true if you know all of your upstream servers
+	// can handle hex trace ids (Baseplate.go v0.8.0+ or Baseplate.py v2.0.0+).
 	UseHex bool `yaml:"useHex"`
+
+	// In test code,
+	// this field can be used to set the message queue the tracer publishes to,
+	// usually an *mqsend.MockMessageQueue.
+	//
+	// This field will be ignored when QueueName is non-empty,
+	// to help avoiding footgun prod code.
+	//
+	// DO NOT USE IN PROD CODE.
+	TestOnlyMockMessageQueue mqsend.MessageQueue `yaml:"-"`
 }
 
 // InitFromConfig initializes the global tracer using the given Config and
@@ -40,15 +83,7 @@ type Config struct {
 // It returns an io.Closer that can be used to close out the tracer when the
 // server is done executing.
 func InitFromConfig(cfg Config) (io.Closer, error) {
-	closer, err := InitGlobalTracerWithCloser(TracerConfig{
-		ServiceName:      cfg.Namespace,
-		SampleRate:       cfg.SampleRate,
-		MaxRecordTimeout: cfg.RecordTimeout,
-		QueueName:        cfg.QueueName,
-		MaxQueueSize:     cfg.MaxQueueSize,
-		UseHex:           cfg.UseHex,
-		Logger:           log.ErrorWithSentryWrapper(),
-	})
+	closer, err := InitGlobalTracerWithCloser(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/tracing/span_test.go
+++ b/tracing/span_test.go
@@ -187,10 +187,10 @@ var (
 func TestChildSpan(t *testing.T) {
 	defer func() {
 		CloseTracer()
-		InitGlobalTracer(TracerConfig{})
+		InitGlobalTracer(Config{})
 	}()
 	logger, startFailing := TestWrapper(t)
-	InitGlobalTracer(TracerConfig{
+	InitGlobalTracer(Config{
 		SampleRate: 0.2,
 		Logger:     logger,
 	})

--- a/tracing/tracer_test.go
+++ b/tracing/tracer_test.go
@@ -38,9 +38,9 @@ func TestTracer(t *testing.T) {
 			logger, called := loggerFunc(t)
 			defer func() {
 				CloseTracer()
-				InitGlobalTracer(TracerConfig{})
+				InitGlobalTracer(Config{})
 			}()
-			InitGlobalTracer(TracerConfig{
+			InitGlobalTracer(Config{
 				SampleRate:               1,
 				Logger:                   logger,
 				TestOnlyMockMessageQueue: recorder,
@@ -68,9 +68,9 @@ func TestTracer(t *testing.T) {
 	logger, called := loggerFunc(t)
 	defer func() {
 		CloseTracer()
-		InitGlobalTracer(TracerConfig{})
+		InitGlobalTracer(Config{})
 	}()
-	InitGlobalTracer(TracerConfig{
+	InitGlobalTracer(Config{
 		SampleRate:               1,
 		Logger:                   logger,
 		MaxRecordTimeout:         timeout,


### PR DESCRIPTION
This change consolidates `tracing.Config` and `tracing.TracerConfig` into one type with corresponding YAML tags which would allow allow us configure the tracing logger. In addition, this provides YAML tags for any other configuration type.

Closes #364