### PR TITLE
baseplate: Implement two-step New

### DIFF
--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -94,13 +94,16 @@ var (
 // This example demonstrates what a typical main function should look like for a
 // Baseplate HTTP service.
 func ExampleNewBaseplateServer() {
-	var cfg config
 	// In real code this MUST be replaced by the factory from the actual implementation.
 	var ecFactory ecinterface.Factory
+
+	var cfg config
+	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+		panic(err)
+	}
 	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
-		ConfigPath:         "example.yaml",
+		Config:             cfg,
 		EdgeContextFactory: ecFactory,
-		ServiceCfg:         &cfg,
 	})
 	if err != nil {
 		panic(err)

--- a/redis/db/redisbp/BUILD.bazel
+++ b/redis/db/redisbp/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         ":redisbp",
         "//:baseplate_go",
+        "//ecinterface",
         "//metricsbp",
         "//mqsend",
         "//thriftbp",

--- a/redis/db/redisbp/example_config_test.go
+++ b/redis/db/redisbp/example_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 )
 
@@ -16,10 +17,17 @@ type Config struct {
 // This example shows how you can embed a redis config in a struct and parse
 // that with `baseplate.New`.
 func ExampleClientConfig() {
+	// In real code this MUST be replaced by the factory from the actual implementation.
+	var ecFactory ecinterface.Factory
+
 	var cfg Config
+	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+		panic(err)
+	}
+
 	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
-		ConfigPath: "example.yaml",
-		ServiceCfg: &cfg,
+		Config:             cfg,
+		EdgeContextFactory: ecFactory,
 	})
 	if err != nil {
 		panic(err)

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -15,8 +15,13 @@ import (
 func ExampleNewBaseplateServer() {
 	// In real code this MUST be replaced by the factory from the actual implementation.
 	var ecFactory ecinterface.Factory
+
+	var cfg baseplate.Config
+	if err := baseplate.ParseConfigYAML("example.yaml", &cfg); err != nil {
+		panic(err)
+	}
 	ctx, bp, err := baseplate.New(context.Background(), baseplate.NewArgs{
-		ConfigPath:         "example.yaml",
+		Config:             cfg,
 		EdgeContextFactory: ecFactory,
 	})
 	if err != nil {


### PR DESCRIPTION
Remove NewArgs.ConfigPath in favor of two-step New, and change
DecodeConfigYAML into ParseConfigYAML to support two-step New.

Two-step New gives service code a chance to override some of the parsed
config before using them to initialize Baseplate packages. For example
Config.Sentry.BeforeSend cannot be deserialized from yaml so this is the
only chance for service code to set it.