### PR TITLE
retrybp: Add BreakerErrorFilter

### DIFF
--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -278,7 +278,7 @@ func TestRetry(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error to be non-nil")
 		}
-		expected := uint(2)
+		expected := uint(1)
 		if attempts != expected {
 			t.Errorf("expected %d, actual: %d", expected, attempts)
 		}

--- a/retrybp/BUILD.bazel
+++ b/retrybp/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//errorsbp",
         "//randbp",
         "@com_github_avast_retry_go//:retry-go",
+        "@com_github_sony_gobreaker//:gobreaker",
     ],
 )
 
@@ -30,6 +31,7 @@ go_test(
     ],
     embed = [":retrybp"],
     deps = [
+        "//breakerbp",
         "//clientpool",
         "//errorsbp",
         "//internal/gen-go/reddit/baseplate",


### PR DESCRIPTION
Add BreakerErrorFilter, and an example on how to use retrybp with
breakerbp.

Also fix an issue that we are not taking advantage of retry.Context
option to end retries as soon as ctx is canceled.