### PR TITLE
Add iobp.CountingSink

### DIFF
--- a/iobp/BUILD.bazel
+++ b/iobp/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "iobp",
+    srcs = [
+        "counting_sink.go",
+        "doc.go",
+    ],
+    importpath = "github.com/reddit/baseplate.go/iobp",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "iobp_test",
+    size = "small",
+    srcs = [
+        "counting_sink_example_test.go",
+        "counting_sink_test.go",
+    ],
+    deps = [":iobp"],
+)

--- a/iobp/counting_sink.go
+++ b/iobp/counting_sink.go
@@ -1,0 +1,27 @@
+package iobp
+
+import (
+	"io"
+)
+
+// CountingSink is an io.Writer implementation that discards all incoming data
+// but tracks how many bytes were "written".
+//
+// This can be used as a sink for encoders or as an additional output via a
+// MultiWriter to track data sizes without buffering all of the data in memory.
+//
+// A Write to a CountingSink cannot fail.
+// A CountingSink is not safe for concurrent use.
+type CountingSink int64
+
+var _ io.Writer = (*CountingSink)(nil)
+
+func (cs *CountingSink) Write(buf []byte) (int, error) {
+	*cs += CountingSink(len(buf))
+	return len(buf), nil
+}
+
+// Size returns the current counted size.
+func (cs CountingSink) Size() int64 {
+	return int64(cs)
+}

--- a/iobp/counting_sink_example_test.go
+++ b/iobp/counting_sink_example_test.go
@@ -1,0 +1,24 @@
+package iobp_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/reddit/baseplate.go/iobp"
+)
+
+// This example demonstrates how to use CountingSink to count the size of a
+// json-serialized object.
+func ExampleCountingSink() {
+	// The json string would be "[0,1,2,3,4]\n", so the size should be 12.
+	object := []int{0, 1, 2, 3, 4}
+
+	var sink iobp.CountingSink
+	if err := json.NewEncoder(&sink).Encode(object); err != nil {
+		panic(err)
+	}
+	fmt.Printf("JSON size for %#v: %d\n", object, sink.Size())
+
+	// Output:
+	// JSON size for []int{0, 1, 2, 3, 4}: 12
+}

--- a/iobp/counting_sink_test.go
+++ b/iobp/counting_sink_test.go
@@ -1,0 +1,97 @@
+package iobp_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"testing"
+	"testing/quick"
+
+	"github.com/reddit/baseplate.go/iobp"
+)
+
+func TestCountingSink(t *testing.T) {
+	f := func(s uint16) bool {
+		buf := make([]byte, s)
+		var sink iobp.CountingSink
+		if _, err := io.Copy(&sink, bytes.NewReader(buf)); err != nil {
+			t.Errorf("Failed to copy into CountingSink: %v", err)
+		}
+		if size := sink.Size(); size != int64(s) {
+			t.Errorf("Expected size %d, got %d", s, size)
+		}
+		return !t.Failed()
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkCountingSink(b *testing.B) {
+	bufPool := sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+	cases := []struct {
+		label   string
+		counter func(testing.TB, io.Reader) int64
+	}{
+		{
+			label: "pooled-buffer",
+			counter: func(tb testing.TB, r io.Reader) int64 {
+				buf := bufPool.Get().(*bytes.Buffer)
+				buf.Reset()
+				defer func() {
+					bufPool.Put(buf)
+				}()
+				if _, err := io.Copy(buf, r); err != nil {
+					tb.Error(err)
+				}
+				return int64(buf.Len())
+			},
+		},
+		{
+			label: "unpooled-buffer",
+			counter: func(tb testing.TB, r io.Reader) int64 {
+				var buf bytes.Buffer
+				if _, err := io.Copy(&buf, r); err != nil {
+					tb.Error(err)
+				}
+				return int64(buf.Len())
+			},
+		},
+		{
+			label: "CountingSink",
+			counter: func(tb testing.TB, r io.Reader) int64 {
+				var sink iobp.CountingSink
+				if _, err := io.Copy(&sink, r); err != nil {
+					tb.Error(err)
+				}
+				return sink.Size()
+			},
+		},
+	}
+	for _, size := range []int{10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("size-%d", size), func(b *testing.B) {
+			buf := make([]byte, size)
+			for _, c := range cases {
+				b.Run(c.label, func(b *testing.B) {
+					b.ReportAllocs()
+
+					if actual := c.counter(b, bytes.NewReader(buf)); actual != int64(size) {
+						b.Fatalf("Expected counted size to be %d, got %d", size, actual)
+					}
+					b.ResetTimer()
+
+					b.RunParallel(func(pb *testing.PB) {
+						for pb.Next() {
+							c.counter(b, bytes.NewReader(buf))
+						}
+					})
+				})
+			}
+		})
+	}
+}

--- a/iobp/doc.go
+++ b/iobp/doc.go
@@ -1,0 +1,3 @@
+// Package iobp provides useful implementations of interfaces defined in stdlib
+// io package.
+package iobp

--- a/thriftbp/BUILD.bazel
+++ b/thriftbp/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//ecinterface",
         "//errorsbp",
         "//internal/gen-go/reddit/baseplate",
+        "//iobp",
         "//log",
         "//metricsbp",
         "//randbp",


### PR DESCRIPTION
I've seen devs using bytes.Buffer when they need to get the size of a
serialized object, and usually the unpooled version, which is very
inefficient. So I think it warrants the need to provide CountingSink
from baseplate.go. Here's the benchmark result:

    $ go test -bench CountingSink
    goos: linux
    goarch: amd64
    pkg: github.com/reddit/baseplate.go/iobp
    cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
    BenchmarkCountingSink/size-10/pooled-buffer-12          72058828                16.20 ns/op           48 B/op          1 allocs/op
    BenchmarkCountingSink/size-10/unpooled-buffer-12        37453972                32.76 ns/op          160 B/op          3 allocs/op
    BenchmarkCountingSink/size-10/CountingSink-12           79914986                15.73 ns/op           56 B/op          2 allocs/op
    BenchmarkCountingSink/size-100/pooled-buffer-12         70162328                17.98 ns/op           48 B/op          1 allocs/op
    BenchmarkCountingSink/size-100/unpooled-buffer-12       29901730                41.47 ns/op          208 B/op          3 allocs/op
    BenchmarkCountingSink/size-100/CountingSink-12          73037241                16.48 ns/op           56 B/op          2 allocs/op
    BenchmarkCountingSink/size-1000/pooled-buffer-12        58766536                21.09 ns/op           48 B/op          1 allocs/op
    BenchmarkCountingSink/size-1000/unpooled-buffer-12       6827634               180.5 ns/op          1120 B/op          3 allocs/op
    BenchmarkCountingSink/size-1000/CountingSink-12         79129803                17.48 ns/op           56 B/op          2 allocs/op
    BenchmarkCountingSink/size-10000/pooled-buffer-12       25310442                42.77 ns/op           48 B/op          1 allocs/op
    BenchmarkCountingSink/size-10000/unpooled-buffer-12      1370032               844.8 ns/op         10336 B/op          3 allocs/op
    BenchmarkCountingSink/size-10000/CountingSink-12        75087396                17.84 ns/op           56 B/op          2 allocs/op
    PASS
    ok      github.com/reddit/baseplate.go/iobp     16.115s

Also switch thriftbp's countingTransport to use CountingSink.