### PR TITLE
thriftbp.WrapBaseplateError: Avoid double wrapping

### DIFF
--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -147,6 +147,11 @@ func (e wrappedBaseplateError) Unwrap() error {
 // thrift IDL by the thrift server, and the client would get a generic
 // TApplicationException instead.
 func WrapBaseplateError(e error) error {
+	if errors.As(e, new(wrappedBaseplateError)) {
+		// Already wrapped, return e as-is to avoid double wrapping
+		return e
+	}
+
 	var bpErr baseplateError
 	if errors.As(e, &bpErr) {
 		return wrappedBaseplateError{

--- a/thriftbp/errors_test.go
+++ b/thriftbp/errors_test.go
@@ -276,6 +276,15 @@ func TestWrapBaseplateError(t *testing.T) {
 			},
 			expected: `baseplate.Error: "message" (code=1, retryable=true)`,
 		},
+		{
+			label: "already-wrapped",
+			orig: fmt.Errorf("already wrapped: %w", thriftbp.WrapBaseplateError(&baseplatethrift.Error{
+				Message:   thrift.StringPtr("message"),
+				Code:      thrift.Int32Ptr(1),
+				Retryable: thrift.BoolPtr(true),
+			})),
+			expected: `already wrapped: baseplate.Error: "message" (code=1, retryable=true)`,
+		},
 	} {
 		c := _c
 		t.Run(c.label, func(t *testing.T) {


### PR DESCRIPTION
Although we already added BaseplateErrorWrapper to client pool's default
middlewares, since all extra middlewares will be added after the default
middlewares, if user tries to add some error logging custom middleware,
they would need to add BaseplateErrorWrapper again so they can get the
wrapped error in their error logging middleware, and we end up having
double BaseplateErrorWrapper middleware in the chain.