### PR TITLE
log: No longer swap sentry error type and message by default

### DIFF
--- a/log/sentry_test.go
+++ b/log/sentry_test.go
@@ -213,9 +213,11 @@ func TestSentryBeforeSend(t *testing.T) {
 	t.Run("swap-exception-type-and-value", func(t *testing.T) {
 		var exception sentry.Exception
 		closer, err := InitSentry(SentryConfig{
-			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
-				exception = event.Exception[0]
-				return event
+			BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) (ret *sentry.Event) {
+				defer func() {
+					exception = ret.Exception[0]
+				}()
+				return SentryBeforeSendSwapExceptionTypeAndValue(event, hint)
 			},
 		})
 		if err != nil {


### PR DESCRIPTION
Doing so can cause sentry to no longer cluster errors with slightly
different error messages as the same error. Change it to opt-in instead.