### PR TITLE
Update opentracing-go to v1.2.0

### DIFF
--- a/external.bzl
+++ b/external.bzl
@@ -700,8 +700,8 @@ def go_dependencies():
     go_repository(
         name = "com_github_opentracing_opentracing_go",
         importpath = "github.com/opentracing/opentracing-go",
-        sum = "h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=",
-        version = "v1.1.0",
+        sum = "h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=",
+        version = "v1.2.0",
     )
     go_repository(
         name = "com_github_pelletier_go_toml",

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/joomcode/errorx v1.0.3
 	github.com/joomcode/redispipe v0.9.4
-	github.com/opentracing/opentracing-go v1.1.0
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/sony/gobreaker v0.4.1
 	go.uber.org/zap v1.15.0
 	gopkg.in/fsnotify.v1 v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
-github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
-github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
+github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUMhxq9m9ZXI=
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/tracing/finish_option.go
+++ b/tracing/finish_option.go
@@ -11,8 +11,8 @@ const (
 	ctxKey = "context"
 
 	// Note that this must be the same as
-	// https://github.com/opentracing/opentracing-go/blob/v1.1.0/log/field.go#L128
-	errorKey = "error"
+	// https://github.com/opentracing/opentracing-go/blob/v1.2.0/log/field.go#L128
+	errorKey = "error.object"
 )
 
 // FinishOptions are the options to be converted into opentracing.FinishOptions.


### PR DESCRIPTION
A library I imported in my code depends on `opentracing-go@v1.2.0` which results in the v1.1.0 (which baseplate depends on) being overwritten.

The problem is they have changed the error log key in v1.2.0 which is a breaking change since it results in the `Span.FinishWithOptions` function ignoring errors.

Can we update the version to v1.2.0 ([release notes](https://github.com/opentracing/opentracing-go/releases/tag/v1.2.0))?
Or, otherwise, we might want to respect both `error` and `error.object` keys.