### PR TITLE
thriftbp: Fix bug in ttl client

### DIFF
--- a/thriftbp/ttl_client.go
+++ b/thriftbp/ttl_client.go
@@ -17,8 +17,8 @@ type ttlClient struct {
 
 	trans thrift.TTransport
 
-	// if expiration is nil, then the client will be kept open indefinetly.
-	expiration *time.Time
+	// if expiration is zero, then the client will be kept open indefinetly.
+	expiration time.Time
 }
 
 // Close implements Client interface.
@@ -36,7 +36,7 @@ func (c *ttlClient) IsOpen() bool {
 	if !c.trans.IsOpen() {
 		return false
 	}
-	if c.expiration != nil && time.Now().After(*c.expiration) {
+	if !c.expiration.IsZero() && time.Now().After(c.expiration) {
 		c.trans.Close()
 		return false
 	}
@@ -55,6 +55,6 @@ func newTTLClient(trans thrift.TTransport, client thrift.TClient, ttl time.Durat
 	return &ttlClient{
 		TClient:    client,
 		trans:      trans,
-		expiration: &expiration,
+		expiration: expiration,
 	}
 }

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -26,3 +26,23 @@ func TestTTLClient(t *testing.T) {
 		t.Error("Expected IsOpen call after sleep to return false, got true.")
 	}
 }
+
+func TestTTLClientNegativeTTL(t *testing.T) {
+	trans := thrift.NewTMemoryBuffer()
+	factory := thrift.NewTBinaryProtocolFactoryConf(nil)
+	tc := thrift.NewTStandardClient(
+		factory.GetProtocol(trans),
+		factory.GetProtocol(trans),
+	)
+	ttl := time.Millisecond
+
+	client := newTTLClient(trans, tc, -ttl)
+	if !client.IsOpen() {
+		t.Error("Expected immediate IsOpen call to return true, got false.")
+	}
+
+	time.Sleep(ttl)
+	if !client.IsOpen() {
+		t.Error("Expected IsOpen call after sleep to return true, got false.")
+	}
+}


### PR DESCRIPTION
In the current implementation ttlClient.expiration could never be nil,
so when user set MaxConnectionAge to a negative value to disable TTL it
doesn't really work as intended.

Also add a test for it.