### PR TITLE
log: Attach attaches both sentry hub and logger

### DIFF
--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -206,7 +206,7 @@ func (t *Tracer) StartSpan(operationName string, opts ...opentracing.StartSpanOp
 	} else {
 		span.trace.traceID = t.newTraceID()
 		span.trace.sampled = randbp.ShouldSampleWithRate(t.sampleRate)
-		initRootSpan(span)
+		initRootSpan(context.Background(), span)
 	}
 
 	if span.spanType == SpanTypeServer {


### PR DESCRIPTION
Creating a contextual sentry hub is not very straight forward, and when
user uses the ctx returned from log.Attach with log.ErrorWithSentry,
they would expect the sentry report also have the info they attached.

Also remove tracing/span.InjectTraceContext, as it's really just a
shorthand for log.Attach and it's not really used anywhere else.