### PR TITLE
Add explicit yaml tag for Thrift circuit breaker

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -167,7 +167,7 @@ type ClientPoolConfig struct {
 	// When BreakerConfig is non-nil,
 	// a breakerbp.FailureRatioBreaker will be created for the pool,
 	// and its middleware will be set for the pool.
-	BreakerConfig *breakerbp.Config
+	BreakerConfig *breakerbp.Config `yaml:"breakerConfig"`
 
 	// The edge context implementation. Optional.
 	//


### PR DESCRIPTION
Thanks to YAML strict parsing I noticed that we do not explicitly map the breaker configuration for Thrift pool clients.