### PR TITLE
httpbp: Fix CircuitBreaker

### DIFF
--- a/httpbp/BUILD.bazel
+++ b/httpbp/BUILD.bazel
@@ -61,5 +61,6 @@ go_test(
         "//secrets",
         "//tracing",
         "@com_github_avast_retry_go//:retry-go",
+        "@com_github_sony_gobreaker//:gobreaker",
     ],
 )


### PR DESCRIPTION
Fix one bug: when status code >= 500 and closing the body does not error
(it won't error in majority of cases), we do not actually report error
to the circuit breaker.

Also fix a few inefficiencies:

1. When loaded is true, newBreaker is not used, so we can return it back
   to the pool immediately, instead of defer'd.
2. Use DrainAndClose instead of ReadAll and Close, as
   io.Copy(io.Discard) is more efficient than ReadAll.
3. Use pointer for the breaker in the pool and the map.

Also avoid dealing with interface{} from breaker.Execute, and add a test
to CircuitBreaker.