### PR TITLE
log: Add kv support to ZapWrapper

### DIFF
--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "sentry_test.go",
         "wrapper_example_test.go",
         "wrapper_test.go",
+        "zap_wrapper_test.go",
     ],
     embed = [":log"],
     deps = [

--- a/log/wrapper_test.go
+++ b/log/wrapper_test.go
@@ -57,6 +57,18 @@ func TestLogWrapperUnmarshalText(t *testing.T) {
 			expected: "log.ZapWrapper",
 		},
 		{
+			text: "zap:error:key",
+			err:  true, // expect error because of dangling key.
+		},
+		{
+			text: "zap:error:key=value:extra",
+			err:  true, // expect error because of extra.
+		},
+		{
+			text:     "zap:info:key1=value1,key2=value2 with space",
+			expected: "log.ZapWrapper",
+		},
+		{
 			text: "zaperror",
 			err:  true,
 		},

--- a/log/zap_wrapper_test.go
+++ b/log/zap_wrapper_test.go
@@ -1,0 +1,31 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func TestZapWrapper(t *testing.T) {
+	const (
+		yamlLine        = "zap:debug:key with space=value with space"
+		expectedLogLine = `{"level":"debug","msg":"This is a log","key with space":"value with space"}`
+	)
+
+	var w Wrapper
+	if err := w.UnmarshalText([]byte(yamlLine)); err != nil {
+		t.Fatalf("Failed to parse yaml line %q: %v", yamlLine, err)
+	}
+
+	buf := new(bytes.Buffer)
+	core := initCore(buf)
+	ctx := context.WithValue(context.Background(), contextKey, zap.New(core).Sugar())
+	w.Log(ctx, "This is a log")
+	actual := strings.TrimSpace(buf.String())
+	if actual != expectedLogLine {
+		t.Errorf("Expected log line %s, got %s", expectedLogLine, actual)
+	}
+}

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -115,7 +115,12 @@ func NewBaseplateServer(
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)
 	cfg.Middlewares = middlewares
-	cfg.Logger = log.ZapWrapper(bp.GetConfig().Log.Level).ToThriftLogger()
+	cfg.Logger = log.ZapWrapper(log.ZapWrapperArgs{
+		Level: bp.GetConfig().Log.Level,
+		KVPairs: map[string]interface{}{
+			"from": "thrift",
+		},
+	}).ToThriftLogger()
 	cfg.Addr = bp.GetConfig().Addr
 	cfg.Timeout = bp.GetConfig().Timeout
 	cfg.Socket = nil


### PR DESCRIPTION
This would help people search for logs from certain upstream
dependencies, for example they can search for "from:thrift" for logs
produced from thrift's TSimpleServer.

This is a breaking change. But the majority of the internal usage are
from yaml config parsing, and there are only 19 direct usages of
log.ZapWrapper from internal code search, and the majority of the 19 are
from my team's monorepo.