### PR TITLE
thriftbp: Add jitter to client pool TTL

### DIFF
--- a/randbp/jitter.go
+++ b/randbp/jitter.go
@@ -1,0 +1,33 @@
+package randbp
+
+import (
+	"time"
+)
+
+// JitterRatio calculates the ratio to be multiplied by base, with +/- jitter.
+//
+// For example, JitterRatio(0.1) would return a float64 between (0.9, 1.1)
+// (exclusive on both ends).
+//
+// jitter > 1 will be normalized to 1. jitter <= 0 will always return 1.
+func JitterRatio(jitter float64) float64 {
+	if jitter <= 0 {
+		return 1
+	}
+	if jitter > 1 {
+		jitter = 1
+	}
+	return 1 - (R.Float64()*2-1)*jitter
+}
+
+// JitterDuration applies jitter on the center time duration so the returned
+// duration is center +/- jitter.
+//
+// It uses JitterRatio under-the-hood.  See doc of JitterRatio for more info.
+//
+// NOTE: If center is very large,
+// some precision loss could occur when casting it into float64 to apply jitter,
+// but that would only happen when the time duration is prohibitively long.
+func JitterDuration(center time.Duration, jitter float64) time.Duration {
+	return time.Duration(float64(center) * JitterRatio(jitter))
+}

--- a/randbp/jitter_test.go
+++ b/randbp/jitter_test.go
@@ -1,0 +1,79 @@
+package randbp_test
+
+import (
+	"math"
+	"testing"
+	"testing/quick"
+
+	"github.com/reddit/baseplate.go/randbp"
+)
+
+func TestJitterRatio(t *testing.T) {
+	t.Run("quick", func(t *testing.T) {
+		f := func() bool {
+			jitter := randbp.R.Float64()
+			min := 1 - jitter
+			max := 1 + jitter
+			ratio := randbp.JitterRatio(jitter)
+			if ratio < max && ratio > min {
+				return true
+			}
+			t.Errorf(
+				"Expected JitterRatio(%v) to be in range (%v, %v), got %v",
+				jitter,
+				min,
+				max,
+				ratio,
+			)
+			return false
+		}
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("<=0", func(t *testing.T) {
+		const epsilon = 1e-9
+		f := func() bool {
+			jitter := -randbp.R.Float64()
+			ratio := randbp.JitterRatio(jitter)
+			if math.Abs(1-ratio) > epsilon {
+				t.Errorf(
+					"Expected JitterRatio(%v) to be 1, got %v",
+					jitter,
+					ratio,
+				)
+				return false
+			}
+			return true
+		}
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run(">=1", func(t *testing.T) {
+		const (
+			min = 0
+			max = 2
+		)
+		f := func() bool {
+			jitter := 1 + randbp.R.Float64()
+			ratio := randbp.JitterRatio(jitter)
+			if ratio < max && ratio > min {
+				return true
+			}
+			t.Errorf(
+				"Expected JitterRatio(%v) to be in range (%v, %v), got %v",
+				jitter,
+				min,
+				max,
+				ratio,
+			)
+			return false
+		}
+		if err := quick.Check(f, nil); err != nil {
+			t.Error(err)
+		}
+	})
+}

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -15,8 +15,19 @@ func TestTTLClient(t *testing.T) {
 		factory.GetProtocol(transport),
 	)
 	ttl := time.Millisecond
+	jitter := 0.1
 
-	client := newTTLClient(transport, tc, ttl)
+	client := newTTLClient(transport, tc, ttl, jitter)
+	if !client.IsOpen() {
+		t.Error("Expected immediate IsOpen call to return true, got false.")
+	}
+
+	time.Sleep(ttl + time.Duration(float64(ttl)*jitter))
+	if client.IsOpen() {
+		t.Error("Expected IsOpen call after sleep to return false, got true.")
+	}
+
+	client = newTTLClient(transport, tc, ttl, -jitter)
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}
@@ -36,7 +47,7 @@ func TestTTLClientNegativeTTL(t *testing.T) {
 	)
 	ttl := time.Millisecond
 
-	client := newTTLClient(transport, tc, -ttl)
+	client := newTTLClient(transport, tc, -ttl, 0.1)
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}


### PR DESCRIPTION
This should help us smooth out the creation of new clients for the pool
and reduce the impact on DNS blips.

As a "side-effect", also add randbp.JitterRatio & randbp.JitterDuration.