### PR TITLE
thriftbp: Add background refresh for ttlClients

### DIFF
--- a/thriftbp/ttl_client.go
+++ b/thriftbp/ttl_client.go
@@ -1,12 +1,17 @@
 package thriftbp
 
 import (
+	"context"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/go-kit/kit/metrics"
 
+	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/randbp"
 )
+
+type ttlClientGenerator func() (thrift.TClient, thrift.TTransport, error)
 
 // DefaultMaxConnectionAge is the default max age for a Thrift client connection.
 const DefaultMaxConnectionAge = time.Minute * 5
@@ -17,50 +22,136 @@ const DefaultMaxConnectionAgeJitter = 0.1
 
 var _ Client = (*ttlClient)(nil)
 
+type ttlClientState struct {
+	client     thrift.TClient
+	transport  thrift.TTransport
+	expiration time.Time // if expiration is zero, then the client will be kept open indefinetly.
+	timer      *time.Timer
+	closed     bool
+}
+
+// renew updates expiration and timer in s base on the given timestamp and
+// client.
+func (s *ttlClientState) renew(now time.Time, client *ttlClient) {
+	if client.ttl < 0 {
+		return
+	}
+	s.expiration = now.Add(client.ttl)
+	s.timer = time.AfterFunc(client.ttl, client.refresh)
+}
+
 // ttlClient is a Client implementation wrapping thrift's TTransport with a TTL.
 type ttlClient struct {
-	thrift.TClient
+	// configs needed for refresh to work
+	generator ttlClientGenerator
+	ttl       time.Duration
 
-	transport thrift.TTransport
+	replaceCounter metrics.Counter
 
-	// if expiration is zero, then the client will be kept open indefinetly.
-	expiration time.Time
+	// state guarded by lock (buffer-1 channel)
+	state chan *ttlClientState
 }
 
 // Close implements Client interface.
 //
 // It calls underlying TTransport's Close function.
 func (c *ttlClient) Close() error {
-	return c.transport.Close()
+	state := <-c.state
+	defer func() {
+		c.state <- state
+	}()
+	state.closed = true
+	if state.timer != nil {
+		state.timer.Stop()
+	}
+	return state.transport.Close()
+}
+
+func (c *ttlClient) Call(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
+	state := <-c.state
+	defer func() {
+		c.state <- state
+	}()
+	return state.client.Call(ctx, method, args, result)
 }
 
 // IsOpen implements Client interface.
 //
-// If TTL has passed, it closes the underlying TTransport and returns false.
-// Otherwise it just calls the underlying TTransport's IsOpen function.
+// It checks underlying TTransport's IsOpen first,
+// if that returns false, it returns false.
+// Otherwise it checks TTL,
+// returns false if TTL has passed and also close the underlying TTransport.
 func (c *ttlClient) IsOpen() bool {
-	if !c.transport.IsOpen() {
+	state := <-c.state
+	defer func() {
+		c.state <- state
+	}()
+	if !state.transport.IsOpen() {
 		return false
 	}
-	if !c.expiration.IsZero() && time.Now().After(c.expiration) {
-		c.transport.Close()
+	if !state.expiration.IsZero() && time.Now().After(state.expiration) {
+		state.transport.Close()
 		return false
 	}
 	return true
 }
 
-// newTTLClient creates a ttlClient with a thrift TTransport and a ttl+jitter.
-func newTTLClient(transport thrift.TTransport, client thrift.TClient, ttl time.Duration, jitter float64) *ttlClient {
-	var expiration time.Time
+// refresh is called when the ttl hits to try to refresh the connection.
+func (c *ttlClient) refresh() {
+	client, transport, err := c.generator()
+	if err != nil {
+		// We cannot replace this connection in the background,
+		// leave client and transport be,
+		// this connection will be replaced by the pool upon next use.
+		c.replaceCounter.With("success", "False").Add(1)
+		return
+	}
+
+	// replace with the refreshed connection
+	state := <-c.state
+	defer func() {
+		c.state <- state
+	}()
+	if state.closed {
+		// If Close was called after we entered this function,
+		// close the newly created connection and return early.
+		transport.Close()
+		return
+	}
+	state.renew(time.Now(), c)
+	state.client = client
+	if state.transport != nil {
+		// close the old transport before replacing it, to avoid connection leaks.
+		state.transport.Close()
+	}
+	state.transport = transport
+	c.replaceCounter.With("success", "True").Add(1)
+}
+
+// newTTLClient creates a ttlClient with a thrift TTransport and ttl+jitter.
+func newTTLClient(generator ttlClientGenerator, ttl time.Duration, jitter float64, slug string, tags metricsbp.Tags) (*ttlClient, error) {
+	client, transport, err := generator()
+	if err != nil {
+		return nil, err
+	}
+
 	if ttl == 0 {
 		ttl = DefaultMaxConnectionAge
 	}
-	if ttl > 0 {
-		expiration = time.Now().Add(randbp.JitterDuration(ttl, jitter))
+	duration := randbp.JitterDuration(ttl, jitter)
+	c := &ttlClient{
+		generator: generator,
+		ttl:       duration,
+
+		replaceCounter: metricsbp.M.Counter(slug + ".connection-housekeeping").With(tags.AsStatsdTags()...),
+
+		state: make(chan *ttlClientState, 1),
 	}
-	return &ttlClient{
-		TClient:    client,
-		transport:  transport,
-		expiration: expiration,
+	state := &ttlClientState{
+		client:    client,
+		transport: transport,
 	}
+	state.renew(time.Now(), c)
+	c.state <- state
+	return c, nil
 }

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -1,23 +1,41 @@
 package thriftbp
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 )
 
-func TestTTLClient(t *testing.T) {
-	transport := thrift.NewTMemoryBuffer()
+// firstSuccessGenerator is a ttlClientGenerator implementation that would
+// return client and transport on the first call, and errors afterwards.
+func firstSuccessGenerator(transport thrift.TTransport) ttlClientGenerator {
 	factory := thrift.NewTBinaryProtocolFactoryConf(nil)
-	tc := thrift.NewTStandardClient(
+	client := thrift.NewTStandardClient(
 		factory.GetProtocol(transport),
 		factory.GetProtocol(transport),
 	)
+	first := true
+	return func() (thrift.TClient, thrift.TTransport, error) {
+		if first {
+			first = false
+			return client, transport, nil
+		}
+		return nil, nil, errors.New("error")
+	}
+}
+
+func TestTTLClient(t *testing.T) {
+	transport := thrift.NewTMemoryBuffer()
 	ttl := time.Millisecond
 	jitter := 0.1
 
-	client := newTTLClient(transport, tc, ttl, jitter)
+	client, err := newTTLClient(firstSuccessGenerator(transport), ttl, jitter, "", nil)
+	if err != nil {
+		t.Fatalf("newTTLClient returned error: %v", err)
+	}
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}
@@ -27,7 +45,10 @@ func TestTTLClient(t *testing.T) {
 		t.Error("Expected IsOpen call after sleep to return false, got true.")
 	}
 
-	client = newTTLClient(transport, tc, ttl, -jitter)
+	client, err = newTTLClient(firstSuccessGenerator(transport), ttl, -jitter, "", nil)
+	if err != nil {
+		t.Fatalf("newTTLClient returned error: %v", err)
+	}
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}
@@ -40,14 +61,12 @@ func TestTTLClient(t *testing.T) {
 
 func TestTTLClientNegativeTTL(t *testing.T) {
 	transport := thrift.NewTMemoryBuffer()
-	factory := thrift.NewTBinaryProtocolFactoryConf(nil)
-	tc := thrift.NewTStandardClient(
-		factory.GetProtocol(transport),
-		factory.GetProtocol(transport),
-	)
 	ttl := time.Millisecond
 
-	client := newTTLClient(transport, tc, -ttl, 0.1)
+	client, err := newTTLClient(firstSuccessGenerator(transport), -ttl, 0.1, "", nil)
+	if err != nil {
+		t.Fatalf("newTTLClient returned error: %v", err)
+	}
 	if !client.IsOpen() {
 		t.Error("Expected immediate IsOpen call to return true, got false.")
 	}
@@ -56,4 +75,119 @@ func TestTTLClientNegativeTTL(t *testing.T) {
 	if !client.IsOpen() {
 		t.Error("Expected IsOpen call after sleep to return true, got false.")
 	}
+}
+
+func TestTTLClientRenew(t *testing.T) {
+	t.Run("no-ttl", func(t *testing.T) {
+		c := &ttlClient{
+			ttl: -1,
+		}
+		state := new(ttlClientState)
+		state.renew(time.Now(), c)
+		if !state.expiration.IsZero() {
+			t.Errorf("Expected expiration to be zero with negative ttl, got %v", state.expiration)
+		}
+		if state.timer != nil {
+			t.Errorf("Expected timer to be nil with negative ttl, got %#v", state.timer)
+		}
+	})
+	t.Run("with-ttl", func(t *testing.T) {
+		const ttl = time.Millisecond * 100
+		c := &ttlClient{
+			ttl: ttl,
+		}
+		state := new(ttlClientState)
+		now := time.Now()
+		state.renew(now, c)
+		want := now.Add(ttl)
+		if !state.expiration.Equal(want) {
+			t.Errorf("expiration want %v, got %v", want, state.expiration)
+		}
+		if state.timer == nil {
+			t.Fatal("timer is nil")
+		}
+
+		state.timer.Stop()
+	})
+}
+
+// alwaysSuccessGenerator is a ttlClientGenerator implementation that would
+// always return client, transport, and no error.
+type alwaysSuccessGenerator struct {
+	transport thrift.TTransport
+
+	called int64
+}
+
+func (g *alwaysSuccessGenerator) generator() ttlClientGenerator {
+	factory := thrift.NewTBinaryProtocolFactoryConf(nil)
+	client := thrift.NewTStandardClient(
+		factory.GetProtocol(g.transport),
+		factory.GetProtocol(g.transport),
+	)
+	return func() (thrift.TClient, thrift.TTransport, error) {
+		atomic.AddInt64(&g.called, 1)
+		return client, g.transport, nil
+	}
+}
+
+func (g *alwaysSuccessGenerator) numCalls() int64 {
+	return atomic.LoadInt64(&g.called)
+}
+
+type mockTTransport struct {
+	thrift.TTransport
+
+	closeCalled int64
+}
+
+func (m *mockTTransport) Close() error {
+	atomic.AddInt64(&m.closeCalled, 1)
+	return nil
+}
+
+func (m *mockTTransport) numCloses() int64 {
+	return atomic.LoadInt64(&m.closeCalled)
+}
+
+func TestTTLClientRefresh(t *testing.T) {
+	t.Run("no-connection-leak", func(t *testing.T) {
+		var transport mockTTransport
+		const (
+			buffer = time.Millisecond * 10
+			ttl    = buffer * 5
+			jitter = 0
+		)
+
+		g := alwaysSuccessGenerator{transport: &transport}
+		client, err := newTTLClient(g.generator(), ttl, jitter, "", nil)
+		if err != nil {
+			t.Fatalf("newTTLClient returned error: %v", err)
+		}
+		defer func() {
+			state := <-client.state
+			state.timer.Stop()
+		}()
+
+		if got := transport.numCloses(); got != 0 {
+			t.Errorf("Expected transport.Close to be called 0 times, got %d", got)
+		}
+
+		time.Sleep(ttl + buffer)
+		want := int64(1)
+		if got := transport.numCloses(); got != want {
+			t.Errorf("Expected transport.Close to be called %d time after sleep, got %d", want, got)
+		}
+
+		time.Sleep(ttl + buffer)
+		want = 2
+		if got := transport.numCloses(); got < want {
+			t.Errorf("Expected transport.Close to be called at least %d time after second sleep, got %d", want, got)
+		}
+		// generator should always be called one more time than close
+		want++
+		if got := g.numCalls(); got < want {
+			t.Errorf("Expected generator to be called at least %d time after second sleep, got %d", want, got)
+		}
+	})
 }


### PR DESCRIPTION
For every ttlClient that has a ttl, add a background goroutine to
refresh the connection when ttl hits.

This adds one goroutine per connection in the pool, until the connection
fails to refresh.

Both IsOpen and Call are protected by a locked state now. When ttlClient
is used, we always call IsOpen first then Call, and in theory these 2
calls might not be using the same connection (e.g. IsOpen is called
right before the connection expires), but even in that scenario, Call
would use a freshly refreshed connection, so things should still work.