### PR TITLE
Deprecate server timeout from thrift and http servers

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -37,8 +37,7 @@ type Config struct {
 	// or simply ":${Port}".
 	Addr string `yaml:"addr"`
 
-	// Timeout is the socket connection timeout for Servers that
-	// support that.
+	// Deprecated: No-op for now, will be removed in a future release.
 	Timeout time.Duration `yaml:"timeout"`
 
 	// StopTimeout is the timeout for the Stop command for the service.

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -213,10 +213,8 @@ func NewBaseplateServer(args ServerArgs) (baseplate.Server, error) {
 	}
 
 	srv := &http.Server{
-		Addr:         args.Baseplate.GetConfig().Addr,
-		Handler:      args.EndpointRegistry,
-		ReadTimeout:  args.Baseplate.GetConfig().Timeout,
-		WriteTimeout: args.Baseplate.GetConfig().Timeout,
+		Addr:    args.Baseplate.GetConfig().Addr,
+		Handler: args.EndpointRegistry,
 	}
 	for _, f := range args.OnShutdown {
 		srv.RegisterOnShutdown(f)

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -54,23 +54,14 @@ type ServerConfig struct {
 	// This is ignored if Socket is non-nil.
 	Addr string
 
-	// Optional, used only by NewServer.
-	// In NewBaseplateServer the timeout set in bp.Config() will be used instead.
-	//
-	// The timeout for the underlying thrift.TServerSocket transport.
-	//
-	// If your clients use client pool,
-	// it's recommended to either not set a Timeout on your server,
-	// or set it to a long value that's longer than your clients' pool TTL.
-	//
-	// This is ignored if Socket is non-nil.
+	// Deprecated: No-op for now, will be removed in a future release.
 	Timeout time.Duration
 
 	// Optional, used only by NewServer.
 	// In NewBaseplateServer the address and timeout set in bp.Config() will be
 	// used instead.
 	//
-	// You can choose to set Socket instead of Addr plus Timeout.
+	// You can choose to set Socket instead of Addr.
 	Socket *thrift.TServerSocket
 }
 
@@ -81,7 +72,7 @@ func NewServer(cfg ServerConfig) (*thrift.TSimpleServer, error) {
 	var transport *thrift.TServerSocket
 	if cfg.Socket == nil {
 		var err error
-		transport, err = thrift.NewTServerSocketTimeout(cfg.Addr, cfg.Timeout)
+		transport, err = thrift.NewTServerSocket(cfg.Addr)
 		if err != nil {
 			return nil, err
 		}
@@ -122,7 +113,6 @@ func NewBaseplateServer(
 		},
 	}).ToThriftLogger()
 	cfg.Addr = bp.GetConfig().Addr
-	cfg.Timeout = bp.GetConfig().Timeout
 	cfg.Socket = nil
 	srv, err := NewServer(cfg)
 	if err != nil {


### PR DESCRIPTION
Deprecate (make them no-op) for now, will remove in next breaking
release (v0.10.0).