### PR TITLE
Add prometheus metrics for Thrift client

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -328,13 +328,13 @@ var (
 //
 //   - thrift_service: the serviceSlug arg
 //   - thrift_method: the method of the endpoint called
-//   - thrift_slug: the service being contacted
 //
-// * thrift_client_handling_seconds histogram with labels above plus:
+// * thrift_client_latency_seconds histogram with labels above plus:
 //
 //   - thrift_success: "true" if err == nil, "false" otherwise
+//   - thrift_slug: the service being contacted
 //
-// * thrift_client_handled_total counter with all labels above plus:
+// * thrift_client_requests_total counter with all labels above plus:
 //
 //   - thrift_exception_type: the human-readable exception type, e.g.
 //     baseplate.Error, etc
@@ -350,7 +350,6 @@ func PrometheusClientMiddleware(serviceSlug, serverSlug string) thrift.ClientMid
 				activeRequestLabels := prometheus.Labels{
 					serviceLabel: serviceSlug,
 					methodLabel:  method,
-					slugLabel:    serverSlug,
 				}
 				clientActiveRequests.With(activeRequestLabels).Inc()
 

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -328,11 +328,11 @@ var (
 //
 //   - thrift_service: the serviceSlug arg
 //   - thrift_method: the method of the endpoint called
+//   - thrift_slug: the service being contacted
 //
 // * thrift_client_latency_seconds histogram with labels above plus:
 //
 //   - thrift_success: "true" if err == nil, "false" otherwise
-//   - thrift_slug: the service being contacted
 //
 // * thrift_client_requests_total counter with all labels above plus:
 //
@@ -350,6 +350,7 @@ func PrometheusClientMiddleware(serviceSlug, serverSlug string) thrift.ClientMid
 				activeRequestLabels := prometheus.Labels{
 					serviceLabel: serviceSlug,
 					methodLabel:  method,
+					slugLabel:    serverSlug,
 				}
 				clientActiveRequests.With(activeRequestLabels).Inc()
 

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -8,18 +8,18 @@ import (
 )
 
 const (
-	serviceLabel             = "thrift_service"
+	localServiceLabel        = "thrift_service"
 	methodLabel              = "thrift_method"
 	successLabel             = "thrift_success"
 	exceptionLabel           = "thrift_exception_type"
 	baseplateStatusLabel     = "thrift_baseplate_status"
 	baseplateStatusCodeLabel = "thrift_baseplate_status_code"
-	slugLabel                = "thrift_slug"
+	remoteServiceSlugLabel   = "thrift_slug"
 )
 
 var (
 	serverLatencyLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
 		successLabel,
 	}
@@ -31,7 +31,7 @@ var (
 	}, serverLatencyLabels)
 
 	serverRequestLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -45,7 +45,7 @@ var (
 	}, serverRequestLabels)
 
 	serverActiveRequestsLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
 	}
 
@@ -57,10 +57,10 @@ var (
 
 var (
 	clientLatencyLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
 		successLabel,
-		slugLabel,
+		remoteServiceSlugLabel,
 	}
 
 	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -70,13 +70,13 @@ var (
 	}, clientLatencyLabels)
 
 	clientRequestLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
 		baseplateStatusLabel,
 		baseplateStatusCodeLabel,
-		slugLabel,
+		remoteServiceSlugLabel,
 	}
 
 	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -85,9 +85,9 @@ var (
 	}, clientRequestLabels)
 
 	clientActiveRequestsLabels = []string{
-		serviceLabel,
+		localServiceLabel,
 		methodLabel,
-		slugLabel,
+		remoteServiceSlugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -87,7 +87,6 @@ var (
 	clientActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
-		slugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -18,7 +18,7 @@ const (
 )
 
 var (
-	serverThriftLatencyLabels = []string{
+	serverLatencyLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
@@ -28,9 +28,9 @@ var (
 		Name:    "thrift_server_latency_seconds",
 		Help:    "RPC latencies",
 		Buckets: prometheusbp.DefaultBuckets,
-	}, serverThriftLatencyLabels)
+	}, serverLatencyLabels)
 
-	serverThriftRequestLabels = []string{
+	serverRequestLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
@@ -42,7 +42,7 @@ var (
 	serverRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "thrift_server_requests_total",
 		Help: "Total RPC request count",
-	}, serverThriftRequestLabels)
+	}, serverRequestLabels)
 
 	serverActiveRequestsLabels = []string{
 		serviceLabel,
@@ -56,7 +56,7 @@ var (
 )
 
 var (
-	clientThriftLatencyLabels = []string{
+	clientLatencyLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
@@ -67,9 +67,9 @@ var (
 		Name:    "thrift_client_latency_seconds",
 		Help:    "RPC latencies",
 		Buckets: prometheusbp.DefaultBuckets,
-	}, clientThriftLatencyLabels)
+	}, clientLatencyLabels)
 
-	clientThriftRequestLabels = []string{
+	clientRequestLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
@@ -82,11 +82,12 @@ var (
 	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "thrift_client_requests_total",
 		Help: "Total RPC request count",
-	}, clientThriftRequestLabels)
+	}, clientRequestLabels)
 
 	clientActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
+		slugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -14,22 +14,23 @@ const (
 	exceptionLabel           = "thrift_exception_type"
 	baseplateStatusLabel     = "thrift_baseplate_status"
 	baseplateStatusCodeLabel = "thrift_baseplate_status_code"
+	slugLabel                = "thrift_slug"
 )
 
 var (
-	thriftLatencyLabels = []string{
+	serverThriftLatencyLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
 	}
 
-	latencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	serverLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "thrift_server_latency_seconds",
 		Help:    "RPC latencies",
 		Buckets: prometheusbp.DefaultBuckets,
-	}, thriftLatencyLabels)
+	}, serverThriftLatencyLabels)
 
-	thriftRequestLabels = []string{
+	serverThriftRequestLabels = []string{
 		serviceLabel,
 		methodLabel,
 		successLabel,
@@ -38,18 +39,59 @@ var (
 		baseplateStatusCodeLabel,
 	}
 
-	rpcRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	serverRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "thrift_server_requests_total",
 		Help: "Total RPC request count",
-	}, thriftRequestLabels)
+	}, serverThriftRequestLabels)
 
-	activeRequestsLabels = []string{
+	serverActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
 	}
 
-	activeRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	serverActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "thrift_server_active_requests",
-		Help: "The number of in-flight requests being handled by the service.",
-	}, activeRequestsLabels)
+		Help: "The number of in-flight requests being handled by the service",
+	}, serverActiveRequestsLabels)
+)
+
+var (
+	clientThriftLatencyLabels = []string{
+		serviceLabel,
+		methodLabel,
+		successLabel,
+		slugLabel,
+	}
+
+	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thrift_client_latency_seconds",
+		Help:    "RPC latencies",
+		Buckets: prometheusbp.DefaultBuckets,
+	}, clientThriftLatencyLabels)
+
+	clientThriftRequestLabels = []string{
+		serviceLabel,
+		methodLabel,
+		successLabel,
+		exceptionLabel,
+		baseplateStatusLabel,
+		baseplateStatusCodeLabel,
+		slugLabel,
+	}
+
+	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "thrift_client_requests_total",
+		Help: "Total RPC request count",
+	}, clientThriftRequestLabels)
+
+	clientActiveRequestsLabels = []string{
+		serviceLabel,
+		methodLabel,
+		slugLabel,
+	}
+
+	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "thrift_client_active_requests",
+		Help: "The number of in-flight requests",
+	}, clientActiveRequestsLabels)
 )

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -125,7 +125,6 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 	requestLabelValues := []string{
 		service,
 		method,
-		server,
 	}
 
 	defer prometheusbp.MetricTest(t, "latency", clientLatencyDistribution).CheckExists()

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/reddit/baseplate.go/prometheusbp"
 )
 
-func TestPrometheusMetricsMiddleware(t *testing.T) {
+func TestPrometheusServerMiddleware(t *testing.T) {
 	testCases := []struct {
 		name          string
 		wantErr       thrift.TException
@@ -53,9 +53,9 @@ func TestPrometheusMetricsMiddleware(t *testing.T) {
 	)
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			latencyDistribution.Reset()
-			rpcRequestCounter.Reset()
-			activeRequests.Reset()
+			serverLatencyDistribution.Reset()
+			serverRPCRequestCounter.Reset()
+			serverActiveRequests.Reset()
 
 			var baseplateCodeStatus string
 			var exceptionType string
@@ -64,7 +64,7 @@ func TestPrometheusMetricsMiddleware(t *testing.T) {
 			}
 
 			success := strconv.FormatBool(tt.wantErr == nil)
-			thriftLabelValues := []string{
+			labelValues := []string{
 				serviceName,
 				method,
 				success,
@@ -78,16 +78,16 @@ func TestPrometheusMetricsMiddleware(t *testing.T) {
 				method,
 			}
 
-			defer prometheusbp.MetricTest(t, "latency", latencyDistribution).CheckExists()
-			defer prometheusbp.MetricTest(t, "rpc count", rpcRequestCounter, thriftLabelValues...).CheckDelta(1)
-			defer prometheusbp.MetricTest(t, "active requests", activeRequests, requestLabelValues...).CheckDelta(0)
+			defer prometheusbp.MetricTest(t, "latency", serverLatencyDistribution).CheckExists()
+			defer prometheusbp.MetricTest(t, "rpc count", serverRPCRequestCounter, labelValues...).CheckDelta(1)
+			defer prometheusbp.MetricTest(t, "active requests", serverActiveRequests, requestLabelValues...).CheckDelta(0)
 
 			next := thrift.WrappedTProcessorFunction{
 				Wrapped: func(ctx context.Context, seqId int32, in, out thrift.TProtocol) (bool, thrift.TException) {
 					return tt.wantOK, tt.wantErr
 				},
 			}
-			promMiddleware := PrometheusMetricMiddleware(serviceName)
+			promMiddleware := PrometheusServerMiddleware(serviceName)
 			wrapped := promMiddleware(method, next)
 			gotOK, gotErr := wrapped.Process(context.Background(), 1, nil, nil)
 
@@ -100,3 +100,49 @@ func TestPrometheusMetricsMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestPrometheusClientMiddleware(t *testing.T) {
+	clientLatencyDistribution.Reset()
+	clientRPCRequestCounter.Reset()
+	clientActiveRequests.Reset()
+
+	const (
+		service = "testService"
+		server  = "testServer"
+		method  = "testMethod"
+	)
+
+	labelValues := []string{
+		service,
+		method,
+		"true",
+		"",
+		"",
+		"",
+		server,
+	}
+
+	requestLabelValues := []string{
+		service,
+		method,
+		server,
+	}
+
+	defer prometheusbp.MetricTest(t, "latency", clientLatencyDistribution).CheckExists()
+	defer prometheusbp.MetricTest(t, "rpc count", clientRPCRequestCounter, labelValues...).CheckDelta(1)
+	defer prometheusbp.MetricTest(t, "active requests", clientActiveRequests, requestLabelValues...).CheckDelta(0)
+
+	client := thrift.WrapClient(mockClient{}, PrometheusClientMiddleware(service, server))
+	if _, err := client.Call(context.Background(), method, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type mockClient struct {
+}
+
+func (c mockClient) Call(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
+	return thrift.ResponseMeta{}, nil
+}
+
+var _ thrift.TClient = (*mockClient)(nil)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -393,13 +393,12 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //
 //   - thrift_service: the serviceSlug arg
 //   - thrift_method: the method of the endpoint called
-//   - thrift_slug: the service being contacted
 //
-// * thrift_server_handling_seconds histogram with labels above plus:
+// * thrift_server_latency_seconds histogram with labels above plus:
 //
 //   - thrift_success: "true" if err == nil, "false" otherwise
 //
-// * thrift_server_handled_total counter with all labels above plus:
+// * thrift_server_requests_total counter with all labels above plus:
 //
 //   - thrift_exception_type: the human-readable exception type, e.g.
 //     baseplate.Error, etc


### PR DESCRIPTION
This PR adds Prometheus metrics for Thriftbp client based on the [baseplate.spec](https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#thrift).

Background:
All Prometheus metrics changes will be merged in the `prometheus` branch. We are adding this `prometheus` branch because if we cut a point release and the master branch only has partial support for Prometheus metrics it could leave some upgraded repos in a confusing state where they have some metrics and not others. Additionally the prometheus metrics changes are too big for a single PR. So the compromise is to merge all incremental Prometheus metrics into this new branch, then once complete we can merge into the master branch.

The expected work that will need to be merged into this `prometheus` branch is:
- this PR for thrift server metric with some testing helpers (PR [#433](https://github.com/reddit/baseplate.go/pull/433)).
- another PR for adding thrift client metrics (PR #[442](https://github.com/reddit/baseplate.go/pull/442) )
- another PR that adds spec-validation tests
- a PR that adds http client and server prometheus metrics
- a PR that adds grpc client and server prometheus metrics