### PR TITLE
errorsbp: Add BatchSize

### DIFF
--- a/errorsbp/batch.go
+++ b/errorsbp/batch.go
@@ -40,6 +40,11 @@ func (be Batch) Error() string {
 	return sb.String()
 }
 
+// Len returns the size of the batch.
+func (be Batch) Len() int {
+	return len(be.errors)
+}
+
 // As implements helper interface for errors.As.
 //
 // If v is pointer to either Batch or *Batch,
@@ -208,4 +213,25 @@ func (e *prefixedError) Error() string {
 
 func (e *prefixedError) Unwrap() error {
 	return e.err
+}
+
+// BatchSize returns the size of the batch for error err.
+//
+// If err is either errorsbp.Batch or *errorsbp.Batch,
+// this function returns its Len().
+// Otherwise, it returns 1 if err is non-nil, and 0 if err is nil.
+//
+// It's useful in tests,
+// for example to verify that a function indeed returns the exact number of
+// errors as expected.
+func BatchSize(err error) int {
+	if err == nil {
+		return 0
+	}
+	var be Batch
+	if errors.As(err, &be) {
+		return be.Len()
+	}
+	// single, non-batch error.
+	return 1
 }

--- a/errorsbp/batch_size_example_test.go
+++ b/errorsbp/batch_size_example_test.go
@@ -1,0 +1,83 @@
+package errorsbp_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/reddit/baseplate.go/errorsbp"
+)
+
+var (
+	errOne   = errors.New("dummy error #1")
+	errTwo   = errors.New("dummy error #2")
+	errThree = errors.New("dummy error #3")
+)
+
+// MyFunction is the function to be tested by MyFunctionTest.
+func MyFunction(i int) error {
+	var be errorsbp.Batch
+	switch i {
+	case 0:
+		// do nothing
+	case 1:
+		be.Add(errOne)
+	case 2:
+		be.Add(errOne)
+		be.Add(errTwo)
+	case 3:
+		be.Add(errOne)
+		be.Add(errTwo)
+		be.Add(errThree)
+	}
+	return be.Compile()
+}
+
+// NOTE: In real unit test code this function signature should be:
+//
+//     func TestMyFunction(t *testing.T)
+//
+// But doing that will break this example.
+func MyFunctionTest() {
+	var (
+		t *testing.T
+	)
+	for _, c := range []struct {
+		arg  int
+		want []error
+	}{
+		{
+			arg: 0,
+		},
+		{
+			arg:  1,
+			want: []error{errOne},
+		},
+		{
+			arg:  2,
+			want: []error{errOne, errTwo},
+		},
+		{
+			arg:  3,
+			want: []error{errOne, errTwo, errThree},
+		},
+	} {
+		t.Run(fmt.Sprintf("%v", c.arg), func(t *testing.T) {
+			got := MyFunction(c.arg)
+			t.Logf("got error: %v", got)
+			if len(c.want) != errorsbp.BatchSize(got) {
+				t.Errorf("Expected %d errors, got %d", len(c.want), errorsbp.BatchSize(got))
+			}
+			for _, target := range c.want {
+				if !errors.Is(got, target) {
+					t.Errorf("Expected error %v to be returned but it's not", target)
+				}
+			}
+		})
+	}
+}
+
+// This example demonstrates how to use errorsbp.BatchSize in a unit test.
+func ExampleBatchSize() {
+	// See MyFuncionTest above for the real example.
+}

--- a/errorsbp/batch_size_test.go
+++ b/errorsbp/batch_size_test.go
@@ -1,0 +1,50 @@
+package errorsbp
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestBatchSize(t *testing.T) {
+	for _, c := range []struct {
+		label string
+		err   error
+		want  int
+	}{
+		{
+			label: "nil",
+			err:   nil,
+			want:  0,
+		},
+		{
+			label: "non-batch",
+			err:   errors.New("foo"),
+			want:  1,
+		},
+		{
+			label: "batch-0",
+			err:   new(Batch),
+			want:  0,
+		},
+		{
+			label: "batch-1",
+			err: Batch{
+				errors: []error{errors.New("bar")},
+			},
+			want: 1,
+		},
+		{
+			label: "batch-2",
+			err: &Batch{
+				errors: []error{errors.New("foo"), errors.New("bar")},
+			},
+			want: 2,
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			if got := BatchSize(c.err); got != c.want {
+				t.Errorf("Expected BatchSize(%v) to return %d, got %d", c.err, c.want, got)
+			}
+		})
+	}
+}

--- a/errorsbp/batch_test.go
+++ b/errorsbp/batch_test.go
@@ -10,18 +10,18 @@ import (
 
 func TestAdd(t *testing.T) {
 	var err errorsbp.Batch
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("A new BatchError should contain zero errors: %#v", err.GetErrors())
 	}
 
 	err.Add(nil)
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("Nil errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err0 := errors.New("foo")
 	err.Add(err0)
-	if len(err.GetErrors()) != 1 {
+	if err.Len() != 1 {
 		t.Errorf("Non-nil errors should be added to the batch: %#v", err.GetErrors())
 	}
 	actual := err.GetErrors()[0]
@@ -31,7 +31,7 @@ func TestAdd(t *testing.T) {
 
 	var another errorsbp.Batch
 	err.Add(another)
-	if len(err.GetErrors()) != 1 {
+	if err.Len() != 1 {
 		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err1 := errors.New("bar")
@@ -39,7 +39,7 @@ func TestAdd(t *testing.T) {
 	err2 := errors.New("foobar")
 	another.Add(err2)
 	err.Add(another)
-	if len(err.GetErrors()) != 3 {
+	if err.Len() != 3 {
 		t.Errorf(
 			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
@@ -58,7 +58,7 @@ func TestAdd(t *testing.T) {
 	}
 
 	err.Clear()
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf(
 			"A cleared BatchError should contain zero errors: %#v",
 			err.GetErrors(),
@@ -67,7 +67,7 @@ func TestAdd(t *testing.T) {
 
 	pointer := new(errorsbp.Batch)
 	err.Add(pointer)
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err1 = errors.New("bar")
@@ -75,7 +75,7 @@ func TestAdd(t *testing.T) {
 	err2 = errors.New("foobar")
 	pointer.Add(err2)
 	err.Add(pointer)
-	if len(err.GetErrors()) != 2 {
+	if err.Len() != 2 {
 		t.Errorf(
 			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
@@ -85,24 +85,24 @@ func TestAdd(t *testing.T) {
 
 func TestAddMultiple(t *testing.T) {
 	var err errorsbp.Batch
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("A new BatchError should contain zero errors: %#v", err.GetErrors())
 	}
 
 	err.Add()
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("empty errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err.Add(nil, nil)
-	if len(err.GetErrors()) != 0 {
+	if err.Len() != 0 {
 		t.Errorf("empty errors should be skipped: %#v", err.GetErrors())
 	}
 
 	err0 := errors.New("foo")
 	err1 := errors.New("bar")
 	err.Add(err0, err1)
-	if len(err.GetErrors()) != 2 {
+	if err.Len() != 2 {
 		t.Errorf("Non-nil errors should be added to the batch: %v", err.GetErrors())
 	}
 	actual0 := err.GetErrors()[0]
@@ -116,7 +116,7 @@ func TestAddMultiple(t *testing.T) {
 
 	var another errorsbp.Batch
 	err.Add(another)
-	if len(err.GetErrors()) != 2 {
+	if err.Len() != 2 {
 		t.Errorf("Empty batch should be skipped: %#v", err.GetErrors())
 	}
 	err2 := errors.New("fizz")
@@ -124,7 +124,7 @@ func TestAddMultiple(t *testing.T) {
 	err4 := errors.New("alpha")
 	another.Add(err2, err3)
 	err.Add(another, err4)
-	if len(err.GetErrors()) != 5 {
+	if err.Len() != 5 {
 		t.Errorf(
 			"The underlying errors should be added instead of the batch: %#v",
 			err.GetErrors(),
@@ -225,12 +225,12 @@ func TestAddPrefix(t *testing.T) {
 	err2 := errors.New(msg2)
 
 	batch.AddPrefix(prefix1, nil)
-	if len(batch.GetErrors()) != 0 {
+	if batch.Len() != 0 {
 		t.Errorf("Nil errors should be skipped: %#v", batch.GetErrors())
 	}
 
 	batch.AddPrefix(prefix1, err0)
-	if len(batch.GetErrors()) != 1 {
+	if batch.Len() != 1 {
 		t.Errorf("Non-nil errors should be added to the batch: %#v", batch.GetErrors())
 	}
 


### PR DESCRIPTION
This is helpful in unit tests to verify that a function returned the
exact number of errors in a batch as expected.

Also add Batch.Len() helper function.