### PR TITLE
Add panic recovery middleware to httpbp

### DIFF
--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -263,10 +263,9 @@ func recoverPanic(name string, next HandlerFunc) HandlerFunc {
 				} else {
 					rErr = fmt.Errorf("panic in %q: %+v", name, r)
 				}
-				log.ErrorWithSentry(
-					ctx,
+				log.C(ctx).Errorw(
 					"recovered from panic:",
-					rErr,
+					"err", rErr,
 					"endpoint", name,
 				)
 				metricsbp.M.Counter("panic.recover").With(

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -244,5 +245,38 @@ func SupportedMethods(method string, additional ...string) Middleware {
 			}
 			return next(ctx, w, r)
 		}
+	}
+}
+
+// recoverPanic recovers from any panics, logs them, and sets the returned error
+// to a generic 500 error. recoverPanic is always the last middleware in the
+// middleware chain, so it is the first one when returning, this lets the error
+// bubble up into other middlewares. Since it is always added to the middleware
+// chain is a specific position, it is not exported.
+func recoverPanic(name string, next HandlerFunc) HandlerFunc {
+	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				var rErr error
+				if asErr, ok := r.(error); ok {
+					rErr = asErr
+				} else {
+					rErr = fmt.Errorf("panic in %q: %+v", name, r)
+				}
+				log.ErrorWithSentry(
+					ctx,
+					"recovered from panic:",
+					rErr,
+					"endpoint", name,
+				)
+				metricsbp.M.Counter("panic.recover").With(
+					"name", name,
+				).Add(1)
+
+				// change named return value to a generic 500 error
+				err = RawError(InternalServerError(), rErr, PlainTextContentType)
+			}
+		}()
+		return next(ctx, w, r)
 	}
 }

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -250,7 +250,7 @@ func SupportedMethods(method string, additional ...string) Middleware {
 
 // recoverPanic recovers from any panics, logs them, and sets the returned error
 // to a generic 500 error. recoverPanic is always the last middleware in the
-// middleware chain, so it is the first one when returning, this lets the error
+// middleware chain, so it is the first one when returning which lets the error
 // bubble up into other middlewares. Since it is always added to the middleware
 // chain is a specific position, it is not exported.
 func recoverPanic(name string, next HandlerFunc) HandlerFunc {

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -45,6 +45,7 @@ type httpHandlerFactory struct {
 }
 
 func (f httpHandlerFactory) NewHandler(endpoint Endpoint) http.Handler {
+	// +2 because we always add SupportedMethods and recoverPanic
 	wrappers := make([]Middleware, 0, len(f.middlewares)+len(endpoint.Middlewares)+2)
 	wrappers = append(wrappers, SupportedMethods(endpoint.Methods[0], endpoint.Methods[1:]...))
 	wrappers = append(wrappers, f.middlewares...)

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -45,10 +45,14 @@ type httpHandlerFactory struct {
 }
 
 func (f httpHandlerFactory) NewHandler(endpoint Endpoint) http.Handler {
-	wrappers := make([]Middleware, 0, len(f.middlewares)+len(endpoint.Middlewares)+1)
+	wrappers := make([]Middleware, 0, len(f.middlewares)+len(endpoint.Middlewares)+2)
 	wrappers = append(wrappers, SupportedMethods(endpoint.Methods[0], endpoint.Methods[1:]...))
 	wrappers = append(wrappers, f.middlewares...)
 	wrappers = append(wrappers, endpoint.Middlewares...)
+	// Always inject recoverPanic as the final middleware in the chain. This
+	// allows it to capture any panics before other middlewares return and bubble
+	// up the panic as an error to those middlewares.
+	wrappers = append(wrappers, recoverPanic)
 	return NewHandler(endpoint.Name, endpoint.Handle, wrappers...)
 }
 
@@ -205,7 +209,8 @@ func (args ServerArgs) SetupEndpoints() (ServerArgs, error) {
 //
 // The Endpoints given in the ServerArgs will be wrapped using the
 // default Baseplate Middleware as well as any additional Middleware
-// passed in.
+// passed in. In addition, panics will be automatically recovered from, reported,
+// and passed up the middleware chain as an HTTPError with the status code 500.
 func NewBaseplateServer(args ServerArgs) (baseplate.Server, error) {
 	args, err := args.SetupEndpoints()
 	if err != nil {


### PR DESCRIPTION
While recovering from panics isn't necessary to avoid the server crashing like it is in thrift, the monitoring from baseplate.go is blind to panics in httpbp. This change adds an unexported middleware that is always applied to http requests that will recover from any panics and bubble those up the call as an HTTPError.