### PR TITLE
prevent overwriting server logger config

### DIFF
--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -106,12 +106,14 @@ func NewBaseplateServer(
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)
 	cfg.Middlewares = middlewares
-	cfg.Logger = log.ZapWrapper(log.ZapWrapperArgs{
-		Level: bp.GetConfig().Log.Level,
-		KVPairs: map[string]interface{}{
-			"from": "thrift",
-		},
-	}).ToThriftLogger()
+	if cfg.Logger == nil {
+		cfg.Logger = log.ZapWrapper(log.ZapWrapperArgs{
+			Level: bp.GetConfig().Log.Level,
+			KVPairs: map[string]interface{}{
+				"from": "thrift",
+			},
+		}).ToThriftLogger()
+	}
 	cfg.Addr = bp.GetConfig().Addr
 	cfg.Socket = nil
 	srv, err := NewServer(cfg)


### PR DESCRIPTION
`thriftbp.ServerConfig.Logger` is an optional configuration field that is currently always being overwritten. This PR adds a `nil` check to prevent losing the original configuration