### PR TITLE
fix config override for server TSocket

### DIFF
--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -115,7 +115,6 @@ func NewBaseplateServer(
 		}).ToThriftLogger()
 	}
 	cfg.Addr = bp.GetConfig().Addr
-	cfg.Socket = nil
 	srv, err := NewServer(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`thriftbp.ServerConfig.Socket` is currently always being overwritten.