### PR TITLE
Revert "prevent overwriting server logger config (#452)"

### DIFF
--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -106,14 +106,12 @@ func NewBaseplateServer(
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)
 	cfg.Middlewares = middlewares
-	if cfg.Logger == nil {
-		cfg.Logger = log.ZapWrapper(log.ZapWrapperArgs{
-			Level: bp.GetConfig().Log.Level,
-			KVPairs: map[string]interface{}{
-				"from": "thrift",
-			},
-		}).ToThriftLogger()
-	}
+	cfg.Logger = log.ZapWrapper(log.ZapWrapperArgs{
+		Level: bp.GetConfig().Log.Level,
+		KVPairs: map[string]interface{}{
+			"from": "thrift",
+		},
+	}).ToThriftLogger()
 	cfg.Addr = bp.GetConfig().Addr
 	cfg.Socket = nil
 	srv, err := NewServer(cfg)


### PR DESCRIPTION
This reverts commit bc086bdc11206042e0bde3e7ee5bbd3926a5194d.

As mentioned in [1], this override is supposed to happen.

[1]: https://github.com/reddit/baseplate.go/pull/454#discussion_r770998691