### PR TITLE
Add prometheus metrics for grpc streams client and server.

### DIFF
--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -3,9 +3,13 @@ package grpcbp
 import (
 	"context"
 	"errors"
+	"strconv"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
 
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/tracing"
@@ -99,5 +103,136 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 		opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
 		return nil, errors.New("grpc.ForwardEdgeContextStreaming: not implemented")
+	}
+}
+
+// PrometheusUnaryClientInterceptor is a client-side interceptor that provides Prometheus
+// monitoring for Unary RPCs.
+//
+// It emits the following metrics:
+//
+// * grpc_client_active_requests gauge with labels:
+//
+//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_method: the name of the method called on the gRPC service
+//   - grpc_slug: the name of the remote server the client connects to
+//
+// * grpc_client_latency_seconds histogram and grpc_client_requests_total
+//   counter with labels:
+//
+//   - grpc_service, grpc_method, grpc_slug
+//   - grpc_success: "true" if status is OK, "false" otherwise
+//   - grpc_type: type of request, i.e unary
+//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req interface{},
+		reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) (err error) {
+		start := time.Now()
+		m := methodSlug(method)
+		activeRequestLabels := prometheus.Labels{
+			localServiceLabel:      serviceSlug,
+			methodLabel:            m,
+			remoteServiceSlugLabel: serverSlug,
+		}
+		clientActiveRequests.With(activeRequestLabels).Inc()
+
+		defer func() {
+			success := strconv.FormatBool(err == nil)
+			status, _ := status.FromError(err)
+
+			latencyLabels := prometheus.Labels{
+				localServiceLabel:      serviceSlug,
+				methodLabel:            m,
+				typeLabel:              unary,
+				successLabel:           success,
+				remoteServiceSlugLabel: serverSlug,
+			}
+
+			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+
+			rpcCountLabels := prometheus.Labels{
+				localServiceLabel:      serviceSlug,
+				methodLabel:            m,
+				typeLabel:              unary,
+				successLabel:           success,
+				remoteServiceSlugLabel: serverSlug,
+				codeLabel:              status.Code().String(),
+			}
+			clientRPCRequestCounter.With(rpcCountLabels).Inc()
+			clientActiveRequests.With(activeRequestLabels).Dec()
+		}()
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+// PrometheusStreamClientInterceptor is a client-side interceptor that provides Prometheus
+// monitoring for Streaming RPCs.
+//
+// It emits the following metrics:
+//
+// * grpc_client_active_requests gauge with labels:
+//
+//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_method: the name of the method called on the gRPC service
+//   - grpc_slug: the name of the remote server the client connects to
+//
+// * grpc_client_latency_seconds histogram and grpc_client_requests_total
+//   counter with labels:
+//
+//   - grpc_service, grpc_method, grpc_slug
+//   - grpc_success: "true" if status is OK, "false" otherwise
+//   - grpc_type: type of request, i.e unary
+//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+func PrometheusStreamClientInterceptor(serviceSlug, serverSlug string) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (_ grpc.ClientStream, err error) {
+		start := time.Now()
+		m := methodSlug(method)
+		activeRequestLabels := prometheus.Labels{
+			localServiceLabel:      serviceSlug,
+			methodLabel:            m,
+			remoteServiceSlugLabel: serverSlug,
+		}
+		clientActiveRequests.With(activeRequestLabels).Inc()
+
+		defer func() {
+			success := strconv.FormatBool(err == nil)
+			status, _ := status.FromError(err)
+
+			latencyLabels := prometheus.Labels{
+				localServiceLabel:      serviceSlug,
+				methodLabel:            m,
+				typeLabel:              clientStream,
+				successLabel:           success,
+				remoteServiceSlugLabel: serverSlug,
+			}
+
+			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+
+			rpcCountLabels := prometheus.Labels{
+				localServiceLabel:      serviceSlug,
+				methodLabel:            m,
+				typeLabel:              clientStream,
+				successLabel:           success,
+				remoteServiceSlugLabel: serverSlug,
+				codeLabel:              status.Code().String(),
+			}
+			clientRPCRequestCounter.With(rpcCountLabels).Inc()
+			clientActiveRequests.With(activeRequestLabels).Dec()
+		}()
+		return streamer(ctx, desc, cc, method, opts...)
 	}
 }

--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -3,7 +3,6 @@ package grpcbp
 import (
 	"context"
 	"errors"
-	"io"
 	"strconv"
 	"time"
 
@@ -176,21 +175,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 // PrometheusStreamClientInterceptor is a client-side interceptor that provides Prometheus
 // monitoring for Streaming RPCs.
 //
-// It emits the following metrics:
-//
-// * grpc_client_active_requests gauge with labels:
-//
-//   - grpc_service: the local service slug, serviceSlug arg
-//   - grpc_method: the name of the method called on the gRPC service
-//   - grpc_slug: the name of the remote server the client connects to
-//
-// * grpc_client_latency_seconds histogram and grpc_client_requests_total
-//   counter with labels:
-//
-//   - grpc_service, grpc_method, grpc_slug
-//   - grpc_success: "true" if status is OK, "false" otherwise
-//   - grpc_type: type of request, i.e unary
-//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+// This is not implemented yet.
 func PrometheusStreamClientInterceptor(serviceSlug, serverSlug string) grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context,
@@ -200,101 +185,6 @@ func PrometheusStreamClientInterceptor(serviceSlug, serverSlug string) grpc.Stre
 		streamer grpc.Streamer,
 		opts ...grpc.CallOption,
 	) (_ grpc.ClientStream, err error) {
-
-		clientStream, err := streamer(ctx, desc, cc, method, opts...)
-		if err != nil {
-			return nil, err
-		}
-		monitoredStream := newMonitoredClientStream(
-			clientStream,
-			method,
-			serviceSlug,
-			serverSlug,
-		)
-		return monitoredStream, nil
+		return nil, errors.New("PrometheusStreamClientInterceptor: not implemented")
 	}
-}
-
-// monitoredClientStream wraps grpc.ClientStream to track Prometheus metrics when streaming starts and finishes.
-type monitoredClientStream struct {
-	grpc.ClientStream
-
-	start       time.Time
-	method      string
-	serviceSlug string
-	serverSlug  string
-}
-
-func newMonitoredClientStream(stream grpc.ClientStream, method, localServiceSlug, remoteServiceSlug string) *monitoredClientStream {
-	s := &monitoredClientStream{
-		stream,
-		time.Now(),
-		method,
-		localServiceSlug,
-		remoteServiceSlug,
-	}
-	s.incActiveRequests()
-	return s
-}
-
-func (s *monitoredClientStream) SendMsg(m interface{}) error {
-	return s.ClientStream.SendMsg(m)
-}
-
-// RecvMsg tracks metrics once streaming is complete. Streaming is complete once a non-nil error
-// is returned from grpc.ClientStream. It returns io.EOF when the client has performed a CloseSend. On
-// any non-EOF error, the stream is aborted and the error contains the RPC status.
-func (s *monitoredClientStream) RecvMsg(m interface{}) error {
-	err := s.ClientStream.RecvMsg(m)
-	if err != nil {
-		s.trackMetrics(err)
-	}
-	return err
-}
-
-func (s *monitoredClientStream) CloseSend() error {
-	s.decActiveRequests()
-	return s.ClientStream.CloseSend()
-}
-
-func (s *monitoredClientStream) incActiveRequests() {
-	activeRequestLabels := prometheus.Labels{
-		localServiceLabel:      s.serviceSlug,
-		methodLabel:            s.method,
-		remoteServiceSlugLabel: s.serverSlug,
-	}
-	clientActiveRequests.With(activeRequestLabels).Inc()
-}
-
-func (s *monitoredClientStream) decActiveRequests() {
-	activeRequestLabels := prometheus.Labels{
-		localServiceLabel:      s.serviceSlug,
-		methodLabel:            s.method,
-		remoteServiceSlugLabel: s.serverSlug,
-	}
-	clientActiveRequests.With(activeRequestLabels).Dec()
-}
-
-func (s *monitoredClientStream) trackMetrics(err error) {
-	success := strconv.FormatBool(err == nil || err == io.EOF)
-	status, _ := status.FromError(err)
-
-	latencyLabels := prometheus.Labels{
-		localServiceLabel:      s.serviceSlug,
-		methodLabel:            s.method,
-		typeLabel:              clientStream,
-		successLabel:           success,
-		remoteServiceSlugLabel: s.serverSlug,
-	}
-	clientLatencyDistribution.With(latencyLabels).Observe(time.Since(s.start).Seconds())
-
-	rpcCountLabels := prometheus.Labels{
-		localServiceLabel:      s.serviceSlug,
-		methodLabel:            s.method,
-		typeLabel:              clientStream,
-		successLabel:           success,
-		codeLabel:              status.Code().String(),
-		remoteServiceSlugLabel: s.serverSlug,
-	}
-	clientRPCRequestCounter.With(rpcCountLabels).Inc()
 }

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -1,0 +1,102 @@
+package grpcbp
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/reddit/baseplate.go/prometheusbp"
+)
+
+const (
+	localServiceLabel      = "grpc_service"
+	methodLabel            = "grpc_method"
+	typeLabel              = "grpc_type"
+	successLabel           = "grpc_success"
+	codeLabel              = "grpc_code"
+	remoteServiceSlugLabel = "grpc_slug"
+)
+
+const (
+	unary        = "unary"
+	clientStream = "client_stream"
+	serverStream = "server_stream"
+)
+
+var (
+	serverLatencyLabels = []string{
+		localServiceLabel,
+		methodLabel,
+		typeLabel,
+		successLabel,
+	}
+
+	serverLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "grpc_server_latency_seconds",
+		Help:    "RPC latencies",
+		Buckets: prometheusbp.DefaultBuckets,
+	}, serverLatencyLabels)
+
+	serverRequestLabels = []string{
+		localServiceLabel,
+		methodLabel,
+		typeLabel,
+		successLabel,
+		codeLabel,
+	}
+
+	serverRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "grpc_server_requests_total",
+		Help: "Total RPC request count",
+	}, serverRequestLabels)
+
+	serverActiveRequestsLabels = []string{
+		localServiceLabel,
+		methodLabel,
+	}
+
+	serverActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "grpc_server_active_requests",
+		Help: "The number of in-flight requests being handled by the service",
+	}, serverActiveRequestsLabels)
+)
+
+var (
+	clientLatencyLabels = []string{
+		localServiceLabel,
+		methodLabel,
+		typeLabel,
+		successLabel,
+		remoteServiceSlugLabel,
+	}
+
+	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "grpc_client_latency_seconds",
+		Help:    "RPC latencies",
+		Buckets: prometheusbp.DefaultBuckets,
+	}, clientLatencyLabels)
+
+	clientRequestLabels = []string{
+		localServiceLabel,
+		methodLabel,
+		typeLabel,
+		successLabel,
+		codeLabel,
+		remoteServiceSlugLabel,
+	}
+
+	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "grpc_client_requests_total",
+		Help: "Total RPC request count",
+	}, clientRequestLabels)
+
+	clientActiveRequestsLabels = []string{
+		localServiceLabel,
+		methodLabel,
+		remoteServiceSlugLabel,
+	}
+
+	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "grpc_client_active_requests",
+		Help: "The number of in-flight requests",
+	}, clientActiveRequestsLabels)
+)

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -205,54 +205,9 @@ func InjectPrometheusUnaryServerInterceptor(serviceSlug string) grpc.UnaryServer
 // InjectPrometheusStreamServerInterceptor is a server middleware that tracks
 // Prometheus metrics.
 //
-// It emits the following metrics:
-//
-// * grpc_server_active_requests gauge with labels:
-//
-//   - grpc_service: the local service slug, serviceSlug arg
-//   - grpc_method: the name of the method called on the gRPC service
-//
-// * grpc_server_latency_seconds histogram and grpc_server_requests_total
-//   counter with labels:
-//
-//   - grpc_service and grpc_method
-//   - grpc_success: "true" if status is OK, "false" otherwise
-//   - grpc_type: type of request, i.e unary
-//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+// This is not implemented yet.
 func InjectPrometheusStreamServerInterceptor(serviceSlug string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
-		start := time.Now()
-
-		method := methodSlug(info.FullMethod)
-		activeRequestLabels := prometheus.Labels{
-			localServiceLabel: serviceSlug,
-			methodLabel:       method,
-		}
-		serverActiveRequests.With(activeRequestLabels).Inc()
-
-		defer func() {
-			success := strconv.FormatBool(err == nil)
-			status, _ := status.FromError(err)
-
-			latencyLabels := prometheus.Labels{
-				localServiceLabel: serviceSlug,
-				methodLabel:       method,
-				typeLabel:         serverStream,
-				successLabel:      success,
-			}
-			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
-
-			rpcCountLabels := prometheus.Labels{
-				localServiceLabel: serviceSlug,
-				methodLabel:       method,
-				typeLabel:         serverStream,
-				successLabel:      success,
-				codeLabel:         status.Code().String(),
-			}
-			serverRPCRequestCounter.With(rpcCountLabels).Inc()
-			serverActiveRequests.With(activeRequestLabels).Dec()
-		}()
-
-		return handler(srv, stream)
+		return errors.New("InjectPrometheusStreamServerInterceptor: not implemented")
 	}
 }

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -3,10 +3,14 @@ package grpcbp
 import (
 	"context"
 	"errors"
+	"strconv"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/tracing"
@@ -141,4 +145,114 @@ func StartSpanFromGRPCContext(ctx context.Context, name string) (context.Context
 	}
 
 	return tracing.StartSpanFromHeaders(ctx, name, headers)
+}
+
+// InjectPrometheusUnaryServerInterceptor is a server middleware that tracks
+// Prometheus metrics.
+//
+// It emits the following metrics:
+//
+// * grpc_server_active_requests gauge with labels:
+//
+//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_method: the name of the method called on the gRPC service
+//
+// * grpc_server_latency_seconds histogram and grpc_server_requests_total
+//   counter with labels:
+//
+//   - grpc_service and grpc_method
+//   - grpc_success: "true" if status is OK, "false" otherwise
+//   - grpc_type: type of request, i.e unary
+//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+func InjectPrometheusUnaryServerInterceptor(serviceSlug string) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
+		start := time.Now()
+
+		method := methodSlug(info.FullMethod)
+		activeRequestLabels := prometheus.Labels{
+			localServiceLabel: serviceSlug,
+			methodLabel:       method,
+		}
+		serverActiveRequests.With(activeRequestLabels).Inc()
+
+		defer func() {
+			success := strconv.FormatBool(err == nil)
+			status, _ := status.FromError(err)
+
+			latencyLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         unary,
+				successLabel:      success,
+			}
+			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+
+			rpcCountLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         unary,
+				successLabel:      success,
+				codeLabel:         status.Code().String(),
+			}
+			serverRPCRequestCounter.With(rpcCountLabels).Inc()
+			serverActiveRequests.With(activeRequestLabels).Dec()
+		}()
+
+		return handler(ctx, req)
+	}
+}
+
+// InjectPrometheusStreamServerInterceptor is a server middleware that tracks
+// Prometheus metrics.
+//
+// It emits the following metrics:
+//
+// * grpc_server_active_requests gauge with labels:
+//
+//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_method: the name of the method called on the gRPC service
+//
+// * grpc_server_latency_seconds histogram and grpc_server_requests_total
+//   counter with labels:
+//
+//   - grpc_service and grpc_method
+//   - grpc_success: "true" if status is OK, "false" otherwise
+//   - grpc_type: type of request, i.e unary
+//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
+func InjectPrometheusStreamServerInterceptor(serviceSlug string) grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
+		start := time.Now()
+
+		method := methodSlug(info.FullMethod)
+		activeRequestLabels := prometheus.Labels{
+			localServiceLabel: serviceSlug,
+			methodLabel:       method,
+		}
+		serverActiveRequests.With(activeRequestLabels).Inc()
+
+		defer func() {
+			success := strconv.FormatBool(err == nil)
+			status, _ := status.FromError(err)
+
+			latencyLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         serverStream,
+				successLabel:      success,
+			}
+			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+
+			rpcCountLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         serverStream,
+				successLabel:      success,
+				codeLabel:         status.Code().String(),
+			}
+			serverRPCRequestCounter.With(rpcCountLabels).Inc()
+			serverActiveRequests.With(activeRequestLabels).Dec()
+		}()
+
+		return handler(srv, stream)
+	}
 }

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -205,9 +205,54 @@ func InjectPrometheusUnaryServerInterceptor(serviceSlug string) grpc.UnaryServer
 // InjectPrometheusStreamServerInterceptor is a server middleware that tracks
 // Prometheus metrics.
 //
-// This is not implemented yet.
+// It emits the following metrics:
+//
+// * grpc_server_active_requests gauge with labels:
+//
+//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_method: the name of the method called on the gRPC service
+//
+// * grpc_server_latency_seconds histogram and grpc_server_requests_total
+//   counter with labels:
+//
+//   - grpc_service and grpc_method
+//   - grpc_success: "true" if status is OK, "false" otherwise
+//   - grpc_type: type of request, i.e unary
+//   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
 func InjectPrometheusStreamServerInterceptor(serviceSlug string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
-		return errors.New("InjectPrometheusStreamServerInterceptor: not implemented")
+		start := time.Now()
+
+		method := methodSlug(info.FullMethod)
+		activeRequestLabels := prometheus.Labels{
+			localServiceLabel: serviceSlug,
+			methodLabel:       method,
+		}
+		serverActiveRequests.With(activeRequestLabels).Inc()
+
+		defer func() {
+			success := strconv.FormatBool(err == nil)
+			status, _ := status.FromError(err)
+
+			latencyLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         serverStream,
+				successLabel:      success,
+			}
+			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+
+			rpcCountLabels := prometheus.Labels{
+				localServiceLabel: serviceSlug,
+				methodLabel:       method,
+				typeLabel:         serverStream,
+				successLabel:      success,
+				codeLabel:         status.Code().String(),
+			}
+			serverRPCRequestCounter.With(rpcCountLabels).Inc()
+			serverActiveRequests.With(activeRequestLabels).Dec()
+		}()
+
+		return handler(srv, stream)
 	}
 }

--- a/grpcbp/server_middlewares_test.go
+++ b/grpcbp/server_middlewares_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -421,21 +422,11 @@ func TestInjectPrometheusStreamServerClientInterceptor(t *testing.T) {
 				if err == io.EOF {
 					break
 				}
-				if tt.success == "false" {
-					if err != nil {
-						status, _ := status.FromError(err)
-						if want, got := tt.wantErr.String(), status.Code().String(); want != got {
-							t.Fatalf("error mismatch: want %v, got %v", want, got)
-						}
-					}
-					if err == nil {
-						t.Fatal("clientStream Recv: expected err got nil")
-					}
+
+				if got, want := tt.success, fmt.Sprint(err == nil || err == io.EOF); got != want {
+					t.Errorf("tt.success = %q, want %q (err: %v)", got, want, err)
 				}
 
-				if err != nil && tt.success == "true" {
-					t.Fatalf("clientStream Recv: %v", err)
-				}
 				count++
 			}
 		})

--- a/grpcbp/server_middlewares_test.go
+++ b/grpcbp/server_middlewares_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"io"
 	"testing"
 	"time"
 
@@ -13,7 +11,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/mqsend"
@@ -164,7 +161,6 @@ func initTracing(t *testing.T) *mqsend.MockMessageQueue {
 
 type mockService struct {
 	ctx context.Context
-	err error
 }
 
 func (t *mockService) Ping(ctx context.Context, req *pb.PingRequest) (*pb.PingResponse, error) {
@@ -186,20 +182,7 @@ func (t *mockService) PingList(req *pb.PingRequest, c pb.TestService_PingListSer
 }
 
 func (t *mockService) PingStream(c pb.TestService_PingStreamServer) error {
-	if t.err != nil {
-		return t.err
-	}
-	for {
-		if _, err := c.Recv(); err != nil {
-			if err == io.EOF {
-				return nil
-			}
-			return err
-		}
-		if err := c.Send(&pb.PingResponse{}); err != nil {
-			return err
-		}
-	}
+	panic("not implemented")
 }
 
 func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
@@ -302,132 +285,6 @@ func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 			ctx = service.ctx
 			if ctx == nil {
 				t.Error("got nil context")
-			}
-		})
-	}
-}
-
-func TestInjectPrometheusStreamServerClientInterceptor(t *testing.T) {
-	const (
-		serviceName = "testSvc"
-		serverName  = "testServer"
-		method      = "Ping"
-	)
-
-	l, service := setupServer(t, grpc.StreamInterceptor(
-		InjectPrometheusStreamServerInterceptor(serviceName),
-	))
-
-	// create test client
-	conn := setupClient(t, l, grpc.WithStreamInterceptor(
-		PrometheusStreamClientInterceptor(serviceName, serverName),
-	))
-
-	// instantiate gRPC client
-	client := pb.NewTestServiceClient(conn)
-
-	testCases := []struct {
-		name    string
-		wantErr codes.Code
-		code    string
-		success string
-		method  string
-	}{
-		{
-			name:    "success",
-			wantErr: codes.OK,
-			code:    "OK",
-			success: "true",
-			method:  "PingStream",
-		},
-		{
-			name:    "err",
-			wantErr: codes.NotFound,
-			code:    "NotFound",
-			success: "false",
-			method:  "PingStream",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			serverLatencyDistribution.Reset()
-			serverRPCRequestCounter.Reset()
-			serverActiveRequests.Reset()
-			clientLatencyDistribution.Reset()
-			clientRPCRequestCounter.Reset()
-			clientActiveRequests.Reset()
-
-			if tt.success == "false" {
-				service.err = status.Errorf(tt.wantErr, "test err: %v", tt.wantErr.String())
-			}
-
-			serverLabelValues := []string{
-				serviceName,
-				tt.method,
-				serverStream,
-				tt.success,
-				tt.code,
-			}
-
-			serverRequestsLabelValues := []string{
-				serviceName,
-				tt.method,
-			}
-
-			clientLabelValues := []string{
-				serviceName,
-				"/mwitkow.testproto.TestService/" + tt.method,
-				clientStream,
-				tt.success,
-				tt.code,
-				serverName,
-			}
-
-			clientRequestsLabelValues := []string{
-				serviceName,
-				tt.method,
-				serverName,
-			}
-
-			defer prometheusbp.MetricTest(t, "server latency", serverLatencyDistribution).CheckExists()
-			defer prometheusbp.MetricTest(t, "server rpc count", serverRPCRequestCounter, serverLabelValues...).CheckDelta(1)
-			defer prometheusbp.MetricTest(t, "server active requests", serverActiveRequests, serverRequestsLabelValues...).CheckDelta(0)
-			defer prometheusbp.MetricTest(t, "client latency", clientLatencyDistribution).CheckExists()
-			defer prometheusbp.MetricTest(t, "client rpc count", clientRPCRequestCounter, clientLabelValues...).CheckDelta(1)
-			defer prometheusbp.MetricTest(t, "client active requests", clientActiveRequests, clientRequestsLabelValues...).CheckDelta(0)
-
-			ctx := context.Background()
-			clientStream, err := client.PingStream(ctx)
-			if err != nil {
-				t.Fatalf("PingStream: %v", err)
-			}
-
-			var count int
-			for {
-				switch {
-				case count < 2:
-					err = clientStream.Send(&pb.PingRequest{})
-				default:
-					err = clientStream.CloseSend()
-				}
-				if err != nil && err != io.EOF {
-					t.Fatalf("clientStream Send or CloseSend: %v", err)
-				}
-				if err == io.EOF {
-					break
-				}
-
-				_, err := clientStream.Recv()
-				if err == io.EOF {
-					break
-				}
-
-				if got, want := tt.success, fmt.Sprint(err == nil || err == io.EOF); got != want {
-					t.Errorf("tt.success = %q, want %q (err: %v)", got, want, err)
-				}
-
-				count++
 			}
 		})
 	}

--- a/prometheusbp/testutil.go
+++ b/prometheusbp/testutil.go
@@ -18,6 +18,7 @@ type PrometheusMetricTest struct {
 
 // CheckDelta checks that the metric value changes exactly delta from when Helper was called.
 func (p *PrometheusMetricTest) CheckDelta(delta float64) {
+	p.tb.Helper()
 	got := p.getValue()
 	got -= float64(p.initValue)
 	if got != delta {
@@ -27,6 +28,7 @@ func (p *PrometheusMetricTest) CheckDelta(delta float64) {
 
 // CheckExists confirms that the metric exists and returns the count of metrics.
 func (p *PrometheusMetricTest) CheckExists() {
+	p.tb.Helper()
 	got := testutil.CollectAndCount(p.metric)
 	if got != 1 {
 		p.tb.Errorf("%s metric count: wanted %v, got %v", p.name, 1, got)


### PR DESCRIPTION
These changes are branched off of https://github.com/reddit/baseplate.go/pull/447.

This PR adds Prometheus metrics for GRPC streaming client and server based on the [baseplate.spec](https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#grpc).

Background:
All Prometheus metrics changes will be merged in the `prometheus` branch. We are adding this `prometheus` branch because if we cut a point release and the master branch only has partial support for Prometheus metrics it could leave some upgraded repos in a confusing state where they have some metrics and not others. Additionally the prometheus metrics changes are too big for a single PR. So the compromise is to merge all incremental Prometheus metrics into this new branch, then once complete we can merge into the master branch.

The expected work that will need to be merged into this `prometheus` branch is:
- this PR for thrift server metric with some testing helpers (PR [#433](https://github.com/reddit/baseplate.go/pull/433)).
- another PR for adding thrift client metrics (PR #[442](https://github.com/reddit/baseplate.go/pull/442) )
- another PR that adds spec-validation tests (PR #[445](https://github.com/reddit/baseplate.go/pull/445))
- a PR -  PR that adds grpc client and server prometheus metrics  (PR #[447](https://github.com/reddit/baseplate.go/pull/447))
- a PR that adds http client and server prometheus metrics (PR #451)