### PR TITLE
Fix "_service" vs "_slug" labels

### DIFF
--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -113,7 +113,7 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 //
 // * grpc_client_active_requests gauge with labels:
 //
-//   - grpc_service: the fully qualified name of the gRPC service, serviceSlug arg
+//   - grpc_service: the fully qualified name of the gRPC service, the serviceName arg
 //   - grpc_method: the name of the method called on the gRPC service
 //   - grpc_slug: an arbitray short string representing the backend the client is connecting to
 //
@@ -124,7 +124,7 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 //   - grpc_success: "true" if status is OK, "false" otherwise
 //   - grpc_type: type of request, i.e unary
 //   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
-func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.UnaryClientInterceptor {
+func PrometheusUnaryClientInterceptor(serviceName, serverSlug string) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
@@ -137,7 +137,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 		start := time.Now()
 		m := methodSlug(method)
 		activeRequestLabels := prometheus.Labels{
-			serviceLabel:           serviceSlug,
+			serviceLabel:           serviceName,
 			methodLabel:            m,
 			remoteServiceSlugLabel: serverSlug,
 		}
@@ -148,7 +148,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{
-				serviceLabel:           serviceSlug,
+				serviceLabel:           serviceName,
 				methodLabel:            m,
 				typeLabel:              unary,
 				successLabel:           success,
@@ -158,7 +158,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 			rpcCountLabels := prometheus.Labels{
-				serviceLabel:           serviceSlug,
+				serviceLabel:           serviceName,
 				methodLabel:            m,
 				typeLabel:              unary,
 				successLabel:           success,

--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -113,9 +113,9 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 //
 // * grpc_client_active_requests gauge with labels:
 //
-//   - grpc_service: the fully qualified name of the gRPC service, the serviceName arg
+//   - grpc_service: the fully qualified name of the gRPC service
 //   - grpc_method: the name of the method called on the gRPC service
-//   - grpc_slug: an arbitray short string representing the backend the client is connecting to
+//   - grpc_slug: an arbitray short string representing the backend the client is connecting to, the serverSlug arg
 //
 // * grpc_client_latency_seconds histogram and grpc_client_requests_total
 //   counter with labels:
@@ -124,7 +124,7 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 //   - grpc_success: "true" if status is OK, "false" otherwise
 //   - grpc_type: type of request, i.e unary
 //   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
-func PrometheusUnaryClientInterceptor(serviceName, serverSlug string) grpc.UnaryClientInterceptor {
+func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,
 		method string,
@@ -135,7 +135,8 @@ func PrometheusUnaryClientInterceptor(serviceName, serverSlug string) grpc.Unary
 		opts ...grpc.CallOption,
 	) (err error) {
 		start := time.Now()
-		m := methodSlug(method)
+		serviceName, m := serviceAndMethodSlug(method)
+
 		activeRequestLabels := prometheus.Labels{
 			serviceLabel:           serviceName,
 			methodLabel:            m,

--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -138,9 +138,9 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 		serviceName, m := serviceAndMethodSlug(method)
 
 		activeRequestLabels := prometheus.Labels{
-			serviceLabel:           serviceName,
-			methodLabel:            m,
-			remoteServiceSlugLabel: serverSlug,
+			serviceLabel:          serviceName,
+			methodLabel:           m,
+			remoteServerSlugLabel: serverSlug,
 		}
 		clientActiveRequests.With(activeRequestLabels).Inc()
 
@@ -149,22 +149,22 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{
-				serviceLabel:           serviceName,
-				methodLabel:            m,
-				typeLabel:              unary,
-				successLabel:           success,
-				remoteServiceSlugLabel: serverSlug,
+				serviceLabel:          serviceName,
+				methodLabel:           m,
+				typeLabel:             unary,
+				successLabel:          success,
+				remoteServerSlugLabel: serverSlug,
 			}
 
 			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 			rpcCountLabels := prometheus.Labels{
-				serviceLabel:           serviceName,
-				methodLabel:            m,
-				typeLabel:              unary,
-				successLabel:           success,
-				remoteServiceSlugLabel: serverSlug,
-				codeLabel:              status.Code().String(),
+				serviceLabel:          serviceName,
+				methodLabel:           m,
+				typeLabel:             unary,
+				successLabel:          success,
+				remoteServerSlugLabel: serverSlug,
+				codeLabel:             status.Code().String(),
 			}
 			clientRPCRequestCounter.With(rpcCountLabels).Inc()
 			clientActiveRequests.With(activeRequestLabels).Dec()
@@ -177,7 +177,7 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 // monitoring for Streaming RPCs.
 //
 // This is not implemented yet.
-func PrometheusStreamClientInterceptor(serviceSlug, serverSlug string) grpc.StreamClientInterceptor {
+func PrometheusStreamClientInterceptor(serverSlug string) grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context,
 		desc *grpc.StreamDesc,

--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -138,9 +138,9 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 		serviceName, m := serviceAndMethodSlug(method)
 
 		activeRequestLabels := prometheus.Labels{
-			serviceLabel:          serviceName,
-			methodLabel:           m,
-			remoteServerSlugLabel: serverSlug,
+			serviceLabel:    serviceName,
+			methodLabel:     m,
+			serverSlugLabel: serverSlug,
 		}
 		clientActiveRequests.With(activeRequestLabels).Inc()
 
@@ -149,22 +149,22 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{
-				serviceLabel:          serviceName,
-				methodLabel:           m,
-				typeLabel:             unary,
-				successLabel:          success,
-				remoteServerSlugLabel: serverSlug,
+				serviceLabel:    serviceName,
+				methodLabel:     m,
+				typeLabel:       unary,
+				successLabel:    success,
+				serverSlugLabel: serverSlug,
 			}
 
 			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 			rpcCountLabels := prometheus.Labels{
-				serviceLabel:          serviceName,
-				methodLabel:           m,
-				typeLabel:             unary,
-				successLabel:          success,
-				remoteServerSlugLabel: serverSlug,
-				codeLabel:             status.Code().String(),
+				serviceLabel:    serviceName,
+				methodLabel:     m,
+				typeLabel:       unary,
+				successLabel:    success,
+				serverSlugLabel: serverSlug,
+				codeLabel:       status.Code().String(),
 			}
 			clientRPCRequestCounter.With(rpcCountLabels).Inc()
 			clientActiveRequests.With(activeRequestLabels).Dec()

--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -113,9 +113,9 @@ func ForwardEdgeContextStreaming(ecImpl ecinterface.Interface) grpc.StreamClient
 //
 // * grpc_client_active_requests gauge with labels:
 //
-//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_service: the fully qualified name of the gRPC service, serviceSlug arg
 //   - grpc_method: the name of the method called on the gRPC service
-//   - grpc_slug: the name of the remote server the client connects to
+//   - grpc_slug: an arbitray short string representing the backend the client is connecting to
 //
 // * grpc_client_latency_seconds histogram and grpc_client_requests_total
 //   counter with labels:
@@ -137,7 +137,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 		start := time.Now()
 		m := methodSlug(method)
 		activeRequestLabels := prometheus.Labels{
-			localServiceLabel:      serviceSlug,
+			serviceLabel:           serviceSlug,
 			methodLabel:            m,
 			remoteServiceSlugLabel: serverSlug,
 		}
@@ -148,7 +148,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{
-				localServiceLabel:      serviceSlug,
+				serviceLabel:           serviceSlug,
 				methodLabel:            m,
 				typeLabel:              unary,
 				successLabel:           success,
@@ -158,7 +158,7 @@ func PrometheusUnaryClientInterceptor(serviceSlug, serverSlug string) grpc.Unary
 			clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 			rpcCountLabels := prometheus.Labels{
-				localServiceLabel:      serviceSlug,
+				serviceLabel:           serviceSlug,
 				methodLabel:            m,
 				typeLabel:              unary,
 				successLabel:           success,

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	serviceLabel           = "grpc_service"
-	methodLabel            = "grpc_method"
-	typeLabel              = "grpc_type"
-	successLabel           = "grpc_success"
-	codeLabel              = "grpc_code"
-	remoteServiceSlugLabel = "grpc_slug"
+	serviceLabel          = "grpc_service"
+	methodLabel           = "grpc_method"
+	typeLabel             = "grpc_type"
+	successLabel          = "grpc_success"
+	codeLabel             = "grpc_code"
+	remoteServerSlugLabel = "grpc_slug"
 )
 
 const (
@@ -68,7 +68,7 @@ var (
 		methodLabel,
 		typeLabel,
 		successLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -83,7 +83,7 @@ var (
 		typeLabel,
 		successLabel,
 		codeLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -94,7 +94,7 @@ var (
 	clientActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	localServiceLabel      = "grpc_service"
+	serviceLabel           = "grpc_service"
 	methodLabel            = "grpc_method"
 	typeLabel              = "grpc_type"
 	successLabel           = "grpc_success"
@@ -24,7 +24,7 @@ const (
 
 var (
 	serverLatencyLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		typeLabel,
 		successLabel,
@@ -37,7 +37,7 @@ var (
 	}, serverLatencyLabels)
 
 	serverRequestLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		typeLabel,
 		successLabel,
@@ -50,7 +50,7 @@ var (
 	}, serverRequestLabels)
 
 	serverActiveRequestsLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 	}
 
@@ -62,7 +62,7 @@ var (
 
 var (
 	clientLatencyLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		typeLabel,
 		successLabel,
@@ -76,7 +76,7 @@ var (
 	}, clientLatencyLabels)
 
 	clientRequestLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		typeLabel,
 		successLabel,
@@ -90,7 +90,7 @@ var (
 	}, clientRequestLabels)
 
 	clientActiveRequestsLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		remoteServiceSlugLabel,
 	}

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -10,12 +10,12 @@ import (
 )
 
 const (
-	serviceLabel          = "grpc_service"
-	methodLabel           = "grpc_method"
-	typeLabel             = "grpc_type"
-	successLabel          = "grpc_success"
-	codeLabel             = "grpc_code"
-	remoteServerSlugLabel = "grpc_slug"
+	serviceLabel    = "grpc_service"
+	methodLabel     = "grpc_method"
+	typeLabel       = "grpc_type"
+	successLabel    = "grpc_success"
+	codeLabel       = "grpc_code"
+	serverSlugLabel = "grpc_slug"
 )
 
 const (
@@ -68,7 +68,7 @@ var (
 		methodLabel,
 		typeLabel,
 		successLabel,
-		remoteServerSlugLabel,
+		serverSlugLabel,
 	}
 
 	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -83,7 +83,7 @@ var (
 		typeLabel,
 		successLabel,
 		codeLabel,
-		remoteServerSlugLabel,
+		serverSlugLabel,
 	}
 
 	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -94,7 +94,7 @@ var (
 	clientActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
-		remoteServerSlugLabel,
+		serverSlugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -1,6 +1,8 @@
 package grpcbp
 
 import (
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -100,3 +102,16 @@ var (
 		Help: "The number of in-flight requests",
 	}, clientActiveRequestsLabels)
 )
+
+// serviceAndMethodSlug splits the UnaryServerInfo.FullMethod and returns
+// the package.service part separate from the method part.
+// ref: https://pkg.go.dev/google.golang.org/grpc#UnaryServerInfo
+func serviceAndMethodSlug(fullMethod string) (service string, method string) {
+	split := strings.SplitN(fullMethod, "/", 3)
+	if len(split) < 2 {
+		return "", ""
+	}
+	method = split[len(split)-1]
+	service = strings.Join(split[:len(split)-1], "")
+	return service, method
+}

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -106,12 +106,11 @@ var (
 // serviceAndMethodSlug splits the UnaryServerInfo.FullMethod and returns
 // the package.service part separate from the method part.
 // ref: https://pkg.go.dev/google.golang.org/grpc#UnaryServerInfo
-func serviceAndMethodSlug(fullMethod string) (service string, method string) {
-	split := strings.SplitN(fullMethod, "/", 3)
+func serviceAndMethodSlug(fullMethod string) (service, method string) {
+	fullMethod = strings.TrimPrefix(fullMethod, "/")
+	split := strings.SplitN(fullMethod, "/", 2)
 	if len(split) < 2 {
-		return "", ""
+		return "", fullMethod
 	}
-	method = split[len(split)-1]
-	service = strings.Join(split[:len(split)-1], "")
-	return service, method
+	return split[0], split[1]
 }

--- a/grpcbp/prometheus_test.go
+++ b/grpcbp/prometheus_test.go
@@ -1,0 +1,57 @@
+package grpcbp
+
+import (
+	"testing"
+)
+
+func TestServiceAndMethodSlug(t *testing.T) {
+	testCases := []struct {
+		name        string
+		fullMethod  string
+		wantService string
+		wantMethod  string
+	}{
+		{
+			name:        "success",
+			fullMethod:  "/package.service/method",
+			wantService: "package.service",
+			wantMethod:  "method",
+		},
+		{
+			name:        "success 2",
+			fullMethod:  "package.service/method",
+			wantService: "package.service",
+			wantMethod:  "method",
+		},
+		{
+			name:        "extra /",
+			fullMethod:  "/foo/bar/baz",
+			wantService: "foo",
+			wantMethod:  "bar/baz",
+		},
+		{
+			name:        "no /",
+			fullMethod:  "package.service.method",
+			wantService: "",
+			wantMethod:  "",
+		},
+		{
+			name:        "empty input",
+			fullMethod:  "",
+			wantService: "",
+			wantMethod:  "",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			gotService, gotMethod := serviceAndMethodSlug(tt.fullMethod)
+			if got, want := gotService, tt.wantService; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+			if got, want := gotMethod, tt.wantMethod; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/grpcbp/prometheus_test.go
+++ b/grpcbp/prometheus_test.go
@@ -33,7 +33,7 @@ func TestServiceAndMethodSlug(t *testing.T) {
 			name:        "no /",
 			fullMethod:  "package.service.method",
 			wantService: "",
-			wantMethod:  "",
+			wantMethod:  "package.service.method",
 		},
 		{
 			name:        "empty input",
@@ -47,10 +47,10 @@ func TestServiceAndMethodSlug(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotService, gotMethod := serviceAndMethodSlug(tt.fullMethod)
 			if got, want := gotService, tt.wantService; got != want {
-				t.Errorf("got %v, want %v", got, want)
+				t.Errorf("serviceAndMethodSlug(%q).service = %v, want %v", tt.fullMethod, got, want)
 			}
 			if got, want := gotMethod, tt.wantMethod; got != want {
-				t.Errorf("got %v, want %v", got, want)
+				t.Errorf("serviceAndMethodSlug(%q).method = %v, want %v", tt.fullMethod, got, want)
 			}
 		})
 	}

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -154,7 +154,7 @@ func StartSpanFromGRPCContext(ctx context.Context, name string) (context.Context
 //
 // * grpc_server_active_requests gauge with labels:
 //
-//   - grpc_service: the fully qualified name of the gRPC service, the serviceName arg
+//   - grpc_service: the fully qualified name of the gRPC service
 //   - grpc_method: the name of the method called on the gRPC service
 //
 // * grpc_server_latency_seconds histogram and grpc_server_requests_total

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -154,7 +154,7 @@ func StartSpanFromGRPCContext(ctx context.Context, name string) (context.Context
 //
 // * grpc_server_active_requests gauge with labels:
 //
-//   - grpc_service: the local service slug, serviceSlug arg
+//   - grpc_service: the fully qualified name of the gRPC service, serviceSlug arg
 //   - grpc_method: the name of the method called on the gRPC service
 //
 // * grpc_server_latency_seconds histogram and grpc_server_requests_total
@@ -170,8 +170,8 @@ func InjectPrometheusUnaryServerInterceptor(serviceSlug string) grpc.UnaryServer
 
 		method := methodSlug(info.FullMethod)
 		activeRequestLabels := prometheus.Labels{
-			localServiceLabel: serviceSlug,
-			methodLabel:       method,
+			serviceLabel: serviceSlug,
+			methodLabel:  method,
 		}
 		serverActiveRequests.With(activeRequestLabels).Inc()
 
@@ -180,19 +180,19 @@ func InjectPrometheusUnaryServerInterceptor(serviceSlug string) grpc.UnaryServer
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{
-				localServiceLabel: serviceSlug,
-				methodLabel:       method,
-				typeLabel:         unary,
-				successLabel:      success,
+				serviceLabel: serviceSlug,
+				methodLabel:  method,
+				typeLabel:    unary,
+				successLabel: success,
 			}
 			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 			rpcCountLabels := prometheus.Labels{
-				localServiceLabel: serviceSlug,
-				methodLabel:       method,
-				typeLabel:         unary,
-				successLabel:      success,
-				codeLabel:         status.Code().String(),
+				serviceLabel: serviceSlug,
+				methodLabel:  method,
+				typeLabel:    unary,
+				successLabel: success,
+				codeLabel:    status.Code().String(),
 			}
 			serverRPCRequestCounter.With(rpcCountLabels).Inc()
 			serverActiveRequests.With(activeRequestLabels).Dec()

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -207,7 +207,7 @@ func InjectPrometheusUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // Prometheus metrics.
 //
 // This is not implemented yet.
-func InjectPrometheusStreamServerInterceptor(serviceSlug string) grpc.StreamServerInterceptor {
+func InjectPrometheusStreamServerInterceptor(serverSlug string) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) (err error) {
 		return errors.New("InjectPrometheusStreamServerInterceptor: not implemented")
 	}

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -164,11 +164,12 @@ func StartSpanFromGRPCContext(ctx context.Context, name string) (context.Context
 //   - grpc_success: "true" if status is OK, "false" otherwise
 //   - grpc_type: type of request, i.e unary
 //   - grpc_code: the human-readable status code, e.g. OK, Internal, etc
-func InjectPrometheusUnaryServerInterceptor(serviceName string) grpc.UnaryServerInterceptor {
+func InjectPrometheusUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (_ interface{}, err error) {
 		start := time.Now()
 
-		method := methodSlug(info.FullMethod)
+		serviceName, method := serviceAndMethodSlug(info.FullMethod)
+
 		activeRequestLabels := prometheus.Labels{
 			serviceLabel: serviceName,
 			methodLabel:  method,

--- a/grpcbp/server_middlewares_test.go
+++ b/grpcbp/server_middlewares_test.go
@@ -187,7 +187,7 @@ func (t *mockService) PingStream(c pb.TestService_PingStreamServer) error {
 func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 	const (
 		serviceName = "mwitkow.testproto.TestService"
-		serverName  = "testServer"
+		backendSlug = "testServer"
 		method      = "Ping"
 	)
 	// create test server with InjectPrometheusUnaryServerInterceptor
@@ -197,7 +197,7 @@ func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 
 	// create test client
 	conn := setupClient(t, l, grpc.WithUnaryInterceptor(
-		PrometheusUnaryClientInterceptor(serviceName, serverName),
+		PrometheusUnaryClientInterceptor(backendSlug),
 	))
 
 	// instantiate gRPC client
@@ -254,13 +254,13 @@ func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 				unary,
 				tt.success,
 				tt.code,
-				serverName,
+				backendSlug,
 			}
 
 			clientRequestsLabelValues := []string{
 				serviceName,
 				tt.method,
-				serverName,
+				backendSlug,
 			}
 
 			defer promtest.NewPrometheusMetricTest(t, "server latency", serverLatencyDistribution).CheckExists()

--- a/grpcbp/server_middlewares_test.go
+++ b/grpcbp/server_middlewares_test.go
@@ -186,13 +186,13 @@ func (t *mockService) PingStream(c pb.TestService_PingStreamServer) error {
 
 func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 	const (
-		serviceName = "testSvc"
+		serviceName = "mwitkow.testproto.TestService"
 		serverName  = "testServer"
 		method      = "Ping"
 	)
 	// create test server with InjectPrometheusUnaryServerInterceptor
 	l, service := setupServer(t, grpc.UnaryInterceptor(
-		InjectPrometheusUnaryServerInterceptor(serviceName),
+		InjectPrometheusUnaryServerInterceptor(),
 	))
 
 	// create test client

--- a/grpcbp/tracing.go
+++ b/grpcbp/tracing.go
@@ -44,3 +44,13 @@ func methodSlug(method string) string {
 	split := strings.Split(method, "/")
 	return split[len(split)-1]
 }
+
+// serviceAndMethodSlug splits the UnaryServerInfo.FullMethod and returns
+// the package.service part separate from the method part.
+// ref: https://pkg.go.dev/google.golang.org/grpc#UnaryServerInfo
+func serviceAndMethodSlug(fullMethod string) (string, string) {
+	split := strings.Split(fullMethod, "/")
+	method := split[len(split)-1]
+	service := strings.Join(split[:len(split)-1], "")
+	return service, method
+}

--- a/grpcbp/tracing.go
+++ b/grpcbp/tracing.go
@@ -44,13 +44,3 @@ func methodSlug(method string) string {
 	split := strings.Split(method, "/")
 	return split[len(split)-1]
 }
-
-// serviceAndMethodSlug splits the UnaryServerInfo.FullMethod and returns
-// the package.service part separate from the method part.
-// ref: https://pkg.go.dev/google.golang.org/grpc#UnaryServerInfo
-func serviceAndMethodSlug(fullMethod string) (string, string) {
-	split := strings.Split(fullMethod, "/")
-	method := split[len(split)-1]
-	service := strings.Join(split[:len(split)-1], "")
-	return service, method
-}

--- a/internal/prometheusbp/spectest/spec.go
+++ b/internal/prometheusbp/spectest/spec.go
@@ -136,31 +136,29 @@ func validateName(name, prefix, clientOrServer string) error {
 }
 
 func validateLabels(name, prefix, clientOrServer string, gotLabels map[string]struct{}) error {
-	wantLabels := buildLables(name, prefix, clientOrServer)
+	wantLabels := buildLabels(name, prefix, clientOrServer)
 	if diff := cmp.Diff(gotLabels, wantLabels); diff != "" {
 		return fmt.Errorf("%w: (-got +want)\n%s", errDiffLabels, diff)
 	}
 	return nil
 }
 
-// buildLables returns a set of expected labels for the metric name provided.
+// buildLabels returns a set of expected labels for the metric name provided.
 // prefix is either thrift, http, or grpc.
-func buildLables(name, prefix, clientOrServer string) map[string]struct{} {
-	var labelSuffixes = []string{}
+func buildLabels(name, prefix, clientOrServer string) map[string]struct{} {
+	var labelSuffixes []string
 	switch prefix {
 	case thriftPrefix:
 		labelSuffixes = thriftSpecificLabels(name)
 	case grpcPrefix:
 		labelSuffixes = grpcSpecificLabels(name)
-	default:
-		labelSuffixes = []string{}
 	}
 
 	if clientOrServer == client {
 		labelSuffixes = append(labelSuffixes, "slug")
 	}
 
-	var wantLabels = map[string]struct{}{}
+	wantLabels := make(map[string]struct{}, len(labelSuffixes))
 	for _, label := range labelSuffixes {
 		wantLabels[prefix+"_"+label] = struct{}{}
 	}
@@ -189,7 +187,7 @@ func thriftSpecificLabels(name string) []string {
 	case strings.HasSuffix(name, "_active_requests"):
 		// no op
 	default:
-		labelSuffixes = []string{}
+		return nil
 	}
 	return labelSuffixes
 }
@@ -219,7 +217,7 @@ func grpcSpecificLabels(name string) []string {
 	case strings.HasSuffix(name, "_active_requests"):
 		// no op
 	default:
-		labelSuffixes = []string{}
+		return nil
 	}
 	return labelSuffixes
 }

--- a/internal/prometheusbp/spectest/spec.go
+++ b/internal/prometheusbp/spectest/spec.go
@@ -143,21 +143,18 @@ func validateLabels(name, prefix, clientOrServer string, gotLabels map[string]st
 // buildLables returns a set of expected labels for the metric name provided.
 // prefix is either thrift, http, or grpc.
 // latency_seconds metrics expect the following labels:
-//   - "<prefix>_service"
 //   - "<prefix>_method"
 //   - "<prefix>_success"
 // requests_total metrics expect the following labels:
-//   - "<prefix>_service"
 //   - "<prefix>_method"
 //   - "<prefix>_success"
 //   - "<prefix>_exception_type"
 //   - "<prefix>_baseplate_status"
 //   - "<prefix>_baseplate_status_code"
 // active_requests metrics expect the following labels:
-//   - "<prefix>_service"
 //   - "<prefix>_method"
 func buildLables(name, prefix, clientOrServer string) map[string]struct{} {
-	labelSuffixes := []string{"service", "method"}
+	labelSuffixes := []string{"method"}
 	switch {
 	case strings.HasSuffix(name, "_latency_seconds"):
 		labelSuffixes = append(labelSuffixes, "success")

--- a/internal/prometheusbp/spectest/spec_test.go
+++ b/internal/prometheusbp/spectest/spec_test.go
@@ -151,56 +151,56 @@ func TestValidateLabels(t *testing.T) {
 		},
 		{
 			name:           "latency success",
-			metricName:     "test_latency_seconds",
-			prefix:         "test",
+			metricName:     "thrift_latency_seconds",
+			prefix:         thriftPrefix,
 			clientOrServer: client,
-			gotLabels:      map[string]struct{}{"test_method": {}, "test_success": {}, "test_slug": {}},
+			gotLabels:      map[string]struct{}{"thrift_method": {}, "thrift_success": {}, "thrift_slug": {}},
 			wantErrs:       []error{},
 		},
 		{
 			name:           "latency wrong labels",
-			metricName:     "test_latency_seconds",
-			prefix:         "test",
+			metricName:     "thrift_latency_seconds",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}},
+			gotLabels:      map[string]struct{}{"thrift_method": {}},
 			wantErrs:       []error{errDiffLabels},
 		},
 		{
 			name:           "request total success",
-			metricName:     "test_requests_total",
-			prefix:         "test",
+			metricName:     "thrift_requests_total",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
 			gotLabels: map[string]struct{}{
-				"test_method":                {},
-				"test_success":               {},
-				"test_baseplate_status":      {},
-				"test_baseplate_status_code": {},
-				"test_exception_type":        {},
+				"thrift_method":                {},
+				"thrift_success":               {},
+				"thrift_baseplate_status":      {},
+				"thrift_baseplate_status_code": {},
+				"thrift_exception_type":        {},
 			},
 			wantErrs: []error{},
 		},
 		{
 			name:           "request total labels",
-			metricName:     "test_requests_total",
-			prefix:         "test",
+			metricName:     "thrift_requests_total",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}},
+			gotLabels:      map[string]struct{}{"thrift_method": {}},
 			wantErrs:       []error{errDiffLabels},
 		},
 		{
 			name:           "active_requests success",
-			metricName:     "test_active_requests",
-			prefix:         "test",
+			metricName:     "thrift_active_requests",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}},
+			gotLabels:      map[string]struct{}{"thrift_method": {}},
 			wantErrs:       []error{},
 		},
 		{
 			name:           "active_requests wrong labels",
-			metricName:     "test_active_requests",
-			prefix:         "test",
+			metricName:     "thrift_active_requests",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}, "foo": {}},
+			gotLabels:      map[string]struct{}{"thrift_method": {}, "foo": {}},
 			wantErrs:       []error{errDiffLabels},
 		},
 	}
@@ -213,7 +213,7 @@ func TestValidateLabels(t *testing.T) {
 	}
 }
 
-func TestBuildLabels(t *testing.T) {
+func TestBuildLabelsThrift(t *testing.T) {
 	testCases := []struct {
 		name           string
 		metricName     string
@@ -223,35 +223,92 @@ func TestBuildLabels(t *testing.T) {
 	}{
 		{
 			name:           "latency_seconds labels",
-			metricName:     "test_latency_seconds",
-			prefix:         "test",
+			metricName:     "thrift_latency_seconds",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			want:           map[string]struct{}{"test_method": {}, "test_success": {}},
+			want:           map[string]struct{}{"thrift_method": {}, "thrift_success": {}},
 		},
 		{
 			name:           "requests_total labels",
-			metricName:     "test_requests_total",
-			prefix:         "test",
+			metricName:     "thrift_requests_total",
+			prefix:         thriftPrefix,
 			clientOrServer: client,
 			want: map[string]struct{}{
-				"test_method":                {},
-				"test_success":               {},
-				"test_baseplate_status":      {},
-				"test_baseplate_status_code": {},
-				"test_exception_type":        {},
-				"test_slug":                  {},
+				"thrift_method":                {},
+				"thrift_success":               {},
+				"thrift_baseplate_status":      {},
+				"thrift_baseplate_status_code": {},
+				"thrift_exception_type":        {},
+				"thrift_slug":                  {},
 			},
 		},
 		{
 			name:           "active_requests labels",
-			metricName:     "test_active_requests",
-			prefix:         "test",
+			metricName:     "thrift_active_requests",
+			prefix:         thriftPrefix,
 			clientOrServer: server,
-			want:           map[string]struct{}{"test_method": {}},
+			want:           map[string]struct{}{"thrift_method": {}},
 		},
 		{
 			name:           "none",
-			prefix:         "test",
+			prefix:         thriftPrefix,
+			clientOrServer: server,
+			want:           map[string]struct{}{},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := buildLables(tt.metricName, tt.prefix, tt.clientOrServer), tt.want; !reflect.DeepEqual(got, want) {
+				t.Fatalf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestBuildLabelsGPRC(t *testing.T) {
+	testCases := []struct {
+		name           string
+		metricName     string
+		prefix         string
+		clientOrServer string
+		want           map[string]struct{}
+	}{
+		{
+			name:           "latency_seconds labels",
+			metricName:     "grpc_latency_seconds",
+			prefix:         grpcPrefix,
+			clientOrServer: server,
+			want: map[string]struct{}{
+				"grpc_service": {},
+				"grpc_method":  {},
+				"grpc_type":    {},
+				"grpc_success": {},
+			},
+		},
+		{
+			name:           "requests_total labels",
+			metricName:     "grpc_requests_total",
+			prefix:         grpcPrefix,
+			clientOrServer: client,
+			want: map[string]struct{}{
+				"grpc_service": {},
+				"grpc_method":  {},
+				"grpc_type":    {},
+				"grpc_success": {},
+				"grpc_code":    {},
+				"grpc_slug":    {},
+			},
+		},
+		{
+			name:           "active_requests labels",
+			metricName:     "grpc_active_requests",
+			prefix:         grpcPrefix,
+			clientOrServer: server,
+			want:           map[string]struct{}{"grpc_method": {}, "grpc_service": {}},
+		},
+		{
+			name:           "none",
+			prefix:         grpcPrefix,
 			clientOrServer: server,
 			want:           map[string]struct{}{},
 		},
@@ -297,14 +354,14 @@ func TestValidateSpec(t *testing.T) {
 		{
 			name:           "not found server",
 			metric:         testMetric,
-			prefix:         "thrift",
+			prefix:         thriftPrefix,
 			clientOrServer: "server",
 			wantErrs:       []error{errNotFound},
 		},
 		{
 			name:           "multi errs client",
 			metric:         testMetric,
-			prefix:         "thrift",
+			prefix:         thriftPrefix,
 			clientOrServer: "client",
 			wantErrs:       []error{errPrometheusLint, errDiffLabels, errNotFound},
 		},

--- a/internal/prometheusbp/spectest/spec_test.go
+++ b/internal/prometheusbp/spectest/spec_test.go
@@ -154,7 +154,7 @@ func TestValidateLabels(t *testing.T) {
 			metricName:     "test_latency_seconds",
 			prefix:         "test",
 			clientOrServer: client,
-			gotLabels:      map[string]struct{}{"test_method": {}, "test_service": {}, "test_success": {}, "test_slug": {}},
+			gotLabels:      map[string]struct{}{"test_method": {}, "test_success": {}, "test_slug": {}},
 			wantErrs:       []error{},
 		},
 		{
@@ -172,7 +172,6 @@ func TestValidateLabels(t *testing.T) {
 			clientOrServer: server,
 			gotLabels: map[string]struct{}{
 				"test_method":                {},
-				"test_service":               {},
 				"test_success":               {},
 				"test_baseplate_status":      {},
 				"test_baseplate_status_code": {},
@@ -193,7 +192,7 @@ func TestValidateLabels(t *testing.T) {
 			metricName:     "test_active_requests",
 			prefix:         "test",
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}, "test_service": {}},
+			gotLabels:      map[string]struct{}{"test_method": {}},
 			wantErrs:       []error{},
 		},
 		{
@@ -201,7 +200,7 @@ func TestValidateLabels(t *testing.T) {
 			metricName:     "test_active_requests",
 			prefix:         "test",
 			clientOrServer: server,
-			gotLabels:      map[string]struct{}{"test_method": {}},
+			gotLabels:      map[string]struct{}{"test_method": {}, "foo": {}},
 			wantErrs:       []error{errDiffLabels},
 		},
 	}
@@ -227,7 +226,7 @@ func TestBuildLabels(t *testing.T) {
 			metricName:     "test_latency_seconds",
 			prefix:         "test",
 			clientOrServer: server,
-			want:           map[string]struct{}{"test_method": {}, "test_service": {}, "test_success": {}},
+			want:           map[string]struct{}{"test_method": {}, "test_success": {}},
 		},
 		{
 			name:           "requests_total labels",
@@ -236,7 +235,6 @@ func TestBuildLabels(t *testing.T) {
 			clientOrServer: client,
 			want: map[string]struct{}{
 				"test_method":                {},
-				"test_service":               {},
 				"test_success":               {},
 				"test_baseplate_status":      {},
 				"test_baseplate_status_code": {},
@@ -249,7 +247,7 @@ func TestBuildLabels(t *testing.T) {
 			metricName:     "test_active_requests",
 			prefix:         "test",
 			clientOrServer: server,
-			want:           map[string]struct{}{"test_method": {}, "test_service": {}},
+			want:           map[string]struct{}{"test_method": {}},
 		},
 		{
 			name:           "none",
@@ -271,7 +269,6 @@ func TestValidateSpec(t *testing.T) {
 	var (
 		testLabels = []string{
 			"thrift_method",
-			"thrift_service",
 			"thrift_success",
 			"thrift_baseplate_status",
 		}
@@ -284,7 +281,6 @@ func TestValidateSpec(t *testing.T) {
 
 	labels := prometheus.Labels{
 		"thrift_method":           "foo",
-		"thrift_service":          "foo",
 		"thrift_success":          "foo",
 		"thrift_baseplate_status": "foo",
 	}

--- a/internal/prometheusbp/spectest/spec_test.go
+++ b/internal/prometheusbp/spectest/spec_test.go
@@ -258,7 +258,7 @@ func TestBuildLabelsThrift(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, want := buildLables(tt.metricName, tt.prefix, tt.clientOrServer), tt.want; !reflect.DeepEqual(got, want) {
+			if got, want := buildLabels(tt.metricName, tt.prefix, tt.clientOrServer), tt.want; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got %v, want %v", got, want)
 			}
 		})
@@ -315,7 +315,7 @@ func TestBuildLabelsGPRC(t *testing.T) {
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, want := buildLables(tt.metricName, tt.prefix, tt.clientOrServer), tt.want; !reflect.DeepEqual(got, want) {
+			if got, want := buildLabels(tt.metricName, tt.prefix, tt.clientOrServer), tt.want; !reflect.DeepEqual(got, want) {
 				t.Fatalf("got %v, want %v", got, want)
 			}
 		})

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -326,7 +326,6 @@ var (
 //
 // * thrift_client_active_requests gauge with labels:
 //
-//   - thrift_service: the name of the thrift service, the serviceName arg
 //   - thrift_method: the method of the endpoint called
 //   - thrift_slug: an arbitray short string representing the backend the client is connecting to, the remoteServiceSlug arg
 //
@@ -342,13 +341,12 @@ var (
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusClientMiddleware(serviceName, remoteServiceSlug string) thrift.ClientMiddleware {
+func PrometheusClientMiddleware(remoteServiceSlug string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (_ thrift.ResponseMeta, err error) {
 				start := time.Now()
 				activeRequestLabels := prometheus.Labels{
-					serviceLabel:           serviceName,
 					methodLabel:            method,
 					remoteServiceSlugLabel: remoteServiceSlug,
 				}
@@ -371,7 +369,6 @@ func PrometheusClientMiddleware(serviceName, remoteServiceSlug string) thrift.Cl
 					}
 
 					latencyLabels := prometheus.Labels{
-						serviceLabel:           serviceName,
 						methodLabel:            method,
 						successLabel:           success,
 						remoteServiceSlugLabel: remoteServiceSlug,
@@ -379,7 +376,6 @@ func PrometheusClientMiddleware(serviceName, remoteServiceSlug string) thrift.Cl
 					clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 					rpcCountLabels := prometheus.Labels{
-						serviceLabel:             serviceName,
 						methodLabel:              method,
 						successLabel:             success,
 						exceptionLabel:           exceptionTypeLabel,

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -327,7 +327,7 @@ var (
 // * thrift_client_active_requests gauge with labels:
 //
 //   - thrift_method: the method of the endpoint called
-//   - thrift_slug: an arbitray short string representing the backend the client is connecting to, the remoteServiceSlug arg
+//   - thrift_slug: an arbitray short string representing the backend the client is connecting to, the remoteServerSlug arg
 //
 // * thrift_client_latency_seconds histogram with labels above plus:
 //
@@ -341,14 +341,14 @@ var (
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusClientMiddleware(remoteServiceSlug string) thrift.ClientMiddleware {
+func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (_ thrift.ResponseMeta, err error) {
 				start := time.Now()
 				activeRequestLabels := prometheus.Labels{
-					methodLabel:            method,
-					remoteServiceSlugLabel: remoteServiceSlug,
+					methodLabel:           method,
+					remoteServerSlugLabel: remoteServerSlug,
 				}
 				clientActiveRequests.With(activeRequestLabels).Inc()
 
@@ -369,9 +369,9 @@ func PrometheusClientMiddleware(remoteServiceSlug string) thrift.ClientMiddlewar
 					}
 
 					latencyLabels := prometheus.Labels{
-						methodLabel:            method,
-						successLabel:           success,
-						remoteServiceSlugLabel: remoteServiceSlug,
+						methodLabel:           method,
+						successLabel:          success,
+						remoteServerSlugLabel: remoteServerSlug,
 					}
 					clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
@@ -381,7 +381,7 @@ func PrometheusClientMiddleware(remoteServiceSlug string) thrift.ClientMiddlewar
 						exceptionLabel:           exceptionTypeLabel,
 						baseplateStatusCodeLabel: baseplateStatusCode,
 						baseplateStatusLabel:     baseplateStatus,
-						remoteServiceSlugLabel:   remoteServiceSlug,
+						remoteServerSlugLabel:    remoteServerSlug,
 					}
 					clientRPCRequestCounter.With(rpcCountLabels).Inc()
 					clientActiveRequests.With(activeRequestLabels).Dec()

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -326,7 +326,7 @@ var (
 //
 // * thrift_client_active_requests gauge with labels:
 //
-//   - thrift_service: the fully qualified name of the thrift service, the serviceSlug arg
+//   - thrift_service: the name of the thrift service, the serviceName arg
 //   - thrift_method: the method of the endpoint called
 //   - thrift_slug: an arbitray short string representing the backend the client is connecting to, the remoteServiceSlug arg
 //
@@ -342,13 +342,13 @@ var (
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusClientMiddleware(serviceSlug, remoteServiceSlug string) thrift.ClientMiddleware {
+func PrometheusClientMiddleware(serviceName, remoteServiceSlug string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (_ thrift.ResponseMeta, err error) {
 				start := time.Now()
 				activeRequestLabels := prometheus.Labels{
-					serviceLabel:           serviceSlug,
+					serviceLabel:           serviceName,
 					methodLabel:            method,
 					remoteServiceSlugLabel: remoteServiceSlug,
 				}
@@ -371,7 +371,7 @@ func PrometheusClientMiddleware(serviceSlug, remoteServiceSlug string) thrift.Cl
 					}
 
 					latencyLabels := prometheus.Labels{
-						serviceLabel:           serviceSlug,
+						serviceLabel:           serviceName,
 						methodLabel:            method,
 						successLabel:           success,
 						remoteServiceSlugLabel: remoteServiceSlug,
@@ -379,7 +379,7 @@ func PrometheusClientMiddleware(serviceSlug, remoteServiceSlug string) thrift.Cl
 					clientLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 					rpcCountLabels := prometheus.Labels{
-						serviceLabel:             serviceSlug,
+						serviceLabel:             serviceName,
 						methodLabel:              method,
 						successLabel:             success,
 						exceptionLabel:           exceptionTypeLabel,

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -462,7 +462,7 @@ func TestSetClientName(t *testing.T) {
 }
 
 const (
-	remoteSvr       = "remotesvr"
+	remoteServer    = "remoteServer"
 	methodIsHealthy = "is_healthy"
 )
 
@@ -495,12 +495,12 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 				tt.exceptionType,
 				"",
 				"",
-				remoteSvr,
+				remoteServer,
 			}
 
 			requestLabelValues := []string{
 				methodIsHealthy,
-				remoteSvr,
+				remoteServer,
 			}
 
 			defer thriftbp.PrometheusClientMetricsTest(t, labelValues, requestLabelValues).CheckMetrics()
@@ -541,7 +541,7 @@ func (srv mockBaseplateService) IsHealthy(ctx context.Context, req *baseplatethr
 func setupFake(ctx context.Context, t *testing.T, handler baseplatethrift.BaseplateServiceV2) thriftbp.ClientPool {
 	srv, err := thrifttest.NewBaseplateServer(thrifttest.ServerConfig{
 		Processor:         baseplatethrift.NewBaseplateServiceV2Processor(handler),
-		ClientMiddlewares: []thrift.ClientMiddleware{thriftbp.PrometheusClientMiddleware(remoteSvr)},
+		ClientMiddlewares: []thrift.ClientMiddleware{thriftbp.PrometheusClientMiddleware(remoteServer)},
 	})
 	if err != nil {
 		t.Fatalf("SETUP: Setting up baseplate server: %s", err)

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -462,7 +462,6 @@ func TestSetClientName(t *testing.T) {
 }
 
 const (
-	localSvr        = "localsvr"
 	remoteSvr       = "remotesvr"
 	methodIsHealthy = "is_healthy"
 )
@@ -491,7 +490,6 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			labelValues := []string{
-				localSvr,
 				methodIsHealthy,
 				strconv.FormatBool(!tt.wantFail),
 				tt.exceptionType,
@@ -501,7 +499,6 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 			}
 
 			requestLabelValues := []string{
-				localSvr,
 				methodIsHealthy,
 				remoteSvr,
 			}
@@ -544,7 +541,7 @@ func (srv mockBaseplateService) IsHealthy(ctx context.Context, req *baseplatethr
 func setupFake(ctx context.Context, t *testing.T, handler baseplatethrift.BaseplateServiceV2) thriftbp.ClientPool {
 	srv, err := thrifttest.NewBaseplateServer(thrifttest.ServerConfig{
 		Processor:         baseplatethrift.NewBaseplateServiceV2Processor(handler),
-		ClientMiddlewares: []thrift.ClientMiddleware{thriftbp.PrometheusClientMiddleware(localSvr, remoteSvr)},
+		ClientMiddlewares: []thrift.ClientMiddleware{thriftbp.PrometheusClientMiddleware(remoteSvr)},
 	})
 	if err != nil {
 		t.Fatalf("SETUP: Setting up baseplate server: %s", err)

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	localServiceLabel        = "thrift_service"
+	serviceLabel             = "thrift_service"
 	methodLabel              = "thrift_method"
 	successLabel             = "thrift_success"
 	exceptionLabel           = "thrift_exception_type"
@@ -19,7 +19,7 @@ const (
 
 var (
 	serverLatencyLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		successLabel,
 	}
@@ -31,7 +31,7 @@ var (
 	}, serverLatencyLabels)
 
 	serverRequestLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -45,7 +45,7 @@ var (
 	}, serverRequestLabels)
 
 	serverActiveRequestsLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 	}
 
@@ -57,7 +57,7 @@ var (
 
 var (
 	clientLatencyLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		successLabel,
 		remoteServiceSlugLabel,
@@ -70,7 +70,7 @@ var (
 	}, clientLatencyLabels)
 
 	clientRequestLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -85,7 +85,7 @@ var (
 	}, clientRequestLabels)
 
 	clientActiveRequestsLabels = []string{
-		localServiceLabel,
+		serviceLabel,
 		methodLabel,
 		remoteServiceSlugLabel,
 	}

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	serviceLabel             = "thrift_service"
 	methodLabel              = "thrift_method"
 	successLabel             = "thrift_success"
 	exceptionLabel           = "thrift_exception_type"
@@ -19,7 +18,6 @@ const (
 
 var (
 	serverLatencyLabels = []string{
-		serviceLabel,
 		methodLabel,
 		successLabel,
 	}
@@ -31,7 +29,6 @@ var (
 	}, serverLatencyLabels)
 
 	serverRequestLabels = []string{
-		serviceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -45,7 +42,6 @@ var (
 	}, serverRequestLabels)
 
 	serverActiveRequestsLabels = []string{
-		serviceLabel,
 		methodLabel,
 	}
 
@@ -57,7 +53,6 @@ var (
 
 var (
 	clientLatencyLabels = []string{
-		serviceLabel,
 		methodLabel,
 		successLabel,
 		remoteServiceSlugLabel,
@@ -70,7 +65,6 @@ var (
 	}, clientLatencyLabels)
 
 	clientRequestLabels = []string{
-		serviceLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -85,7 +79,6 @@ var (
 	}, clientRequestLabels)
 
 	clientActiveRequestsLabels = []string{
-		serviceLabel,
 		methodLabel,
 		remoteServiceSlugLabel,
 	}

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -13,7 +13,7 @@ const (
 	exceptionLabel           = "thrift_exception_type"
 	baseplateStatusLabel     = "thrift_baseplate_status"
 	baseplateStatusCodeLabel = "thrift_baseplate_status_code"
-	remoteServiceSlugLabel   = "thrift_slug"
+	remoteServerSlugLabel    = "thrift_slug"
 )
 
 var (
@@ -55,7 +55,7 @@ var (
 	clientLatencyLabels = []string{
 		methodLabel,
 		successLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientLatencyDistribution = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -70,7 +70,7 @@ var (
 		exceptionLabel,
 		baseplateStatusLabel,
 		baseplateStatusCodeLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientRPCRequestCounter = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -80,7 +80,7 @@ var (
 
 	clientActiveRequestsLabels = []string{
 		methodLabel,
-		remoteServiceSlugLabel,
+		remoteServerSlugLabel,
 	}
 
 	clientActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -49,7 +49,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 	}
 
 	const (
-		serviceName = "testservice"
+		serviceName = "test.testService"
 		method      = "testmethod"
 	)
 

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -48,10 +48,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 		},
 	}
 
-	const (
-		serviceName = "test.testService"
-		method      = "testmethod"
-	)
+	const method = "testmethod"
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,7 +64,6 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 
 			success := strconv.FormatBool(tt.wantErr == nil)
 			labelValues := []string{
-				serviceName,
 				method,
 				success,
 				exceptionType,
@@ -76,7 +72,6 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 			}
 
 			requestLabelValues := []string{
-				serviceName,
 				method,
 			}
 
@@ -90,7 +85,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 					return tt.wantOK, tt.wantErr
 				},
 			}
-			promMiddleware := PrometheusServerMiddleware(serviceName)
+			promMiddleware := PrometheusServerMiddleware()
 			wrapped := promMiddleware(method, next)
 			gotOK, gotErr := wrapped.Process(context.Background(), 1, nil, nil)
 

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -85,9 +85,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 					return tt.wantOK, tt.wantErr
 				},
 			}
-			promMiddleware := PrometheusServerMiddleware()
-			wrapped := promMiddleware(method, next)
-			gotOK, gotErr := wrapped.Process(context.Background(), 1, nil, nil)
+			gotOK, gotErr := PrometheusServerMiddleware(method, next).Process(context.Background(), 1, nil, nil)
 
 			if gotOK != tt.wantOK {
 				t.Errorf("wanted %v, got %v", tt.wantOK, gotOK)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -391,7 +391,7 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //
 // * thrift_server_active_requests gauge with labels:
 //
-//   - thrift_service: the serviceSlug arg
+//   - thrift_service: the fully qualified name of the thrift service, the serviceSlug arg
 //   - thrift_method: the method of the endpoint called
 //
 // * thrift_server_latency_seconds histogram with labels above plus:
@@ -411,8 +411,8 @@ func PrometheusServerMiddleware(serviceSlug string) thrift.ProcessorMiddleware {
 		process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
 			start := time.Now()
 			activeRequestLabels := prometheus.Labels{
-				localServiceLabel: serviceSlug,
-				methodLabel:       method,
+				serviceLabel: serviceSlug,
+				methodLabel:  method,
 			}
 			serverActiveRequests.With(activeRequestLabels).Inc()
 
@@ -433,14 +433,14 @@ func PrometheusServerMiddleware(serviceSlug string) thrift.ProcessorMiddleware {
 				}
 
 				latencyLabels := prometheus.Labels{
-					localServiceLabel: serviceSlug,
-					methodLabel:       method,
-					successLabel:      success,
+					serviceLabel: serviceSlug,
+					methodLabel:  method,
+					successLabel: success,
 				}
 				serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 				rpcCountLabels := prometheus.Labels{
-					localServiceLabel:        serviceSlug,
+					serviceLabel:             serviceSlug,
 					methodLabel:              method,
 					successLabel:             success,
 					exceptionLabel:           exceptionTypeLabel,

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -391,7 +391,7 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //
 // * thrift_server_active_requests gauge with labels:
 //
-//   - thrift_service: the fully qualified name of the thrift service, the serviceSlug arg
+//   - thrift_service: the name of the thrift service, the serviceName arg
 //   - thrift_method: the method of the endpoint called
 //
 // * thrift_server_latency_seconds histogram with labels above plus:
@@ -406,12 +406,12 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusServerMiddleware(serviceSlug string) thrift.ProcessorMiddleware {
+func PrometheusServerMiddleware(serviceName string) thrift.ProcessorMiddleware {
 	return func(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 		process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
 			start := time.Now()
 			activeRequestLabels := prometheus.Labels{
-				serviceLabel: serviceSlug,
+				serviceLabel: serviceName,
 				methodLabel:  method,
 			}
 			serverActiveRequests.With(activeRequestLabels).Inc()
@@ -433,14 +433,14 @@ func PrometheusServerMiddleware(serviceSlug string) thrift.ProcessorMiddleware {
 				}
 
 				latencyLabels := prometheus.Labels{
-					serviceLabel: serviceSlug,
+					serviceLabel: serviceName,
 					methodLabel:  method,
 					successLabel: success,
 				}
 				serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 				rpcCountLabels := prometheus.Labels{
-					serviceLabel:             serviceSlug,
+					serviceLabel:             serviceName,
 					methodLabel:              method,
 					successLabel:             success,
 					exceptionLabel:           exceptionTypeLabel,

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -391,7 +391,6 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //
 // * thrift_server_active_requests gauge with labels:
 //
-//   - thrift_service: the name of the thrift service, the serviceName arg
 //   - thrift_method: the method of the endpoint called
 //
 // * thrift_server_latency_seconds histogram with labels above plus:
@@ -406,13 +405,12 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusServerMiddleware(serviceName string) thrift.ProcessorMiddleware {
+func PrometheusServerMiddleware() thrift.ProcessorMiddleware {
 	return func(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 		process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
 			start := time.Now()
 			activeRequestLabels := prometheus.Labels{
-				serviceLabel: serviceName,
-				methodLabel:  method,
+				methodLabel: method,
 			}
 			serverActiveRequests.With(activeRequestLabels).Inc()
 
@@ -433,14 +431,12 @@ func PrometheusServerMiddleware(serviceName string) thrift.ProcessorMiddleware {
 				}
 
 				latencyLabels := prometheus.Labels{
-					serviceLabel: serviceName,
 					methodLabel:  method,
 					successLabel: success,
 				}
 				serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
 				rpcCountLabels := prometheus.Labels{
-					serviceLabel:             serviceName,
 					methodLabel:              method,
 					successLabel:             success,
 					exceptionLabel:           exceptionTypeLabel,

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -405,50 +405,48 @@ func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusServerMiddleware() thrift.ProcessorMiddleware {
-	return func(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
-		process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
-			start := time.Now()
-			activeRequestLabels := prometheus.Labels{
-				methodLabel: method,
-			}
-			serverActiveRequests.With(activeRequestLabels).Inc()
+func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+	process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
+		start := time.Now()
+		activeRequestLabels := prometheus.Labels{
+			methodLabel: method,
+		}
+		serverActiveRequests.With(activeRequestLabels).Inc()
 
-			defer func() {
-				var exceptionTypeLabel, baseplateStatusCode, baseplateStatus string
-				success := strconv.FormatBool(err == nil)
-				if err != nil {
-					exceptionTypeLabel = strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
+		defer func() {
+			var exceptionTypeLabel, baseplateStatusCode, baseplateStatus string
+			success := strconv.FormatBool(err == nil)
+			if err != nil {
+				exceptionTypeLabel = strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
 
-					var bpErr baseplateError
-					if errors.As(err, &bpErr) {
-						code := bpErr.GetCode()
-						baseplateStatusCode = strconv.FormatInt(int64(code), 10)
-						if status := baseplate.ErrorCode(code).String(); status != "<UNSET>" {
-							baseplateStatus = status
-						}
+				var bpErr baseplateError
+				if errors.As(err, &bpErr) {
+					code := bpErr.GetCode()
+					baseplateStatusCode = strconv.FormatInt(int64(code), 10)
+					if status := baseplate.ErrorCode(code).String(); status != "<UNSET>" {
+						baseplateStatus = status
 					}
 				}
+			}
 
-				latencyLabels := prometheus.Labels{
-					methodLabel:  method,
-					successLabel: success,
-				}
-				serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+			latencyLabels := prometheus.Labels{
+				methodLabel:  method,
+				successLabel: success,
+			}
+			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
-				rpcCountLabels := prometheus.Labels{
-					methodLabel:              method,
-					successLabel:             success,
-					exceptionLabel:           exceptionTypeLabel,
-					baseplateStatusLabel:     baseplateStatus,
-					baseplateStatusCodeLabel: baseplateStatusCode,
-				}
-				serverRPCRequestCounter.With(rpcCountLabels).Inc()
-				serverActiveRequests.With(activeRequestLabels).Dec()
-			}()
+			rpcCountLabels := prometheus.Labels{
+				methodLabel:              method,
+				successLabel:             success,
+				exceptionLabel:           exceptionTypeLabel,
+				baseplateStatusLabel:     baseplateStatus,
+				baseplateStatusCodeLabel: baseplateStatusCode,
+			}
+			serverRPCRequestCounter.With(rpcCountLabels).Inc()
+			serverActiveRequests.With(activeRequestLabels).Dec()
+		}()
 
-			return next.Process(ctx, seqID, in, out)
-		}
-		return thrift.WrappedTProcessorFunction{Wrapped: process}
+		return next.Process(ctx, seqID, in, out)
 	}
+	return thrift.WrappedTProcessorFunction{Wrapped: process}
 }


### PR DESCRIPTION
There is some confusion around the `*_service` label representing the name of the rpc server when really it should be the fully qualified name of the rpc service. This PR attempts to fix that confusion.  

This PR also removes the thrift service label, re: https://github.snooguts.net/reddit/baseplate.spec/pull/40.

This PR also adds a prometheus metrics spec test for grpc.