### PR TITLE
Add prometheus middleware to default middleware

### DIFF
--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -38,8 +38,8 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NewClient returns a standard HTTP client wrapped with the default middleware
 // plus any additional client middleware passed into this function. Default
-// middlewares are: MonitorClient and Retries. ClientErrorWrapper is included
-// as transitive middleware through Retries.
+// middlewares are: MonitorClient, Retries, and PrometheusClientMetrics.
+// ClientErrorWrapper is included as transitive middleware through Retries.
 func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Client, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -64,6 +64,7 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 	defaults := []ClientMiddleware{
 		MonitorClient(config.Slug),
 		Retries(config.MaxErrorReadAhead, config.RetryOptions...),
+		PrometheusClientMetrics(config.Slug),
 	}
 
 	// prepend middleware to ensure Retires with ClientErrorWrapper is still

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -78,6 +78,7 @@ func DefaultMiddleware(args DefaultMiddlewareArgs) []Middleware {
 		InjectServerSpan(args.TrustHandler),
 		InjectEdgeRequestContext(InjectEdgeRequestContextArgs(args)),
 		RecordStatusCode(),
+		PrometheusServerMetrics(),
 	}
 }
 
@@ -433,7 +434,7 @@ func RecordStatusCode() Middleware {
 // * http_server_requests_total counter with all labels above plus:
 //
 //   - http_response_code: numeric status code as a string, e.g. 200
-func PrometheusServerMetrics(serverSlug string) Middleware {
+func PrometheusServerMetrics() Middleware {
 	return func(name string, next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
 			start := time.Now()

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -435,8 +435,8 @@ func RecordStatusCode() Middleware {
 // * http_server_requests_total counter with all labels above plus:
 //
 //   - http_response_code: numeric status code as a string, e.g. 200
-// TODO: we accidentally added this arg and it is not needed, therefore we need to
-// remove the arg from this function, but we cannot remove now since its a breaking change.
+//
+// TODO: the arg of this function is unused and will be removed in a future version.
 func PrometheusServerMetrics(_ string) Middleware {
 	return func(name string, next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -70,6 +70,7 @@ type DefaultMiddlewareArgs struct {
 //	1. InjectServerSpan
 //	2. InjectEdgeRequestContext
 //	3. RecordStatusCode
+//  4. PrometheusServerMetrics
 func DefaultMiddleware(args DefaultMiddlewareArgs) []Middleware {
 	if args.TrustHandler == nil {
 		args.TrustHandler = NeverTrustHeaders{}
@@ -78,7 +79,7 @@ func DefaultMiddleware(args DefaultMiddlewareArgs) []Middleware {
 		InjectServerSpan(args.TrustHandler),
 		InjectEdgeRequestContext(InjectEdgeRequestContextArgs(args)),
 		RecordStatusCode(),
-		PrometheusServerMetrics(),
+		PrometheusServerMetrics(""),
 	}
 }
 
@@ -434,7 +435,9 @@ func RecordStatusCode() Middleware {
 // * http_server_requests_total counter with all labels above plus:
 //
 //   - http_response_code: numeric status code as a string, e.g. 200
-func PrometheusServerMetrics() Middleware {
+// TODO: we accidentally added this arg and it is not needed, therefore we need to
+// remove the arg from this function, but we cannot remove now since its a breaking change.
+func PrometheusServerMetrics(_ string) Middleware {
 	return func(name string, next HandlerFunc) HandlerFunc {
 		return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
 			start := time.Now()

--- a/httpbp/prometheus_test.go
+++ b/httpbp/prometheus_test.go
@@ -96,7 +96,6 @@ func TestPrometheusClientServerMetrics(t *testing.T) {
 				},
 			},
 		},
-		Middlewares: []Middleware{PrometheusServerMetrics(serverSlug)},
 	}
 
 	server, ts, err := NewTestBaseplateServer(args)

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -149,6 +149,7 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 		SetClientName(args.ClientName),
 		BaseplateErrorWrapper,
 		SetDeadlineBudget,
+		PrometheusClientMiddleware(args.ServiceSlug),
 	)
 	return middlewares
 }

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -122,6 +122,8 @@ type DefaultClientMiddlewareArgs struct {
 // 7. BaseplateErrorWrapper
 //
 // 8. SetDeadlineBudget
+//
+// 9. PrometheusClientMiddleware
 func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrift.ClientMiddleware {
 	if len(args.RetryOptions) == 0 {
 		args.RetryOptions = []retry.Option{retry.Attempts(1)}

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -463,7 +463,6 @@ func TestSetClientName(t *testing.T) {
 }
 
 const (
-	serverSlug      = "serverSlug"
 	methodIsHealthy = "is_healthy"
 )
 
@@ -503,7 +502,7 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 			latencyLabels := prometheus.Labels{
 				methodLabel:            methodIsHealthy,
 				successLabel:           strconv.FormatBool(!tt.wantFail),
-				remoteServiceSlugLabel: serverSlug,
+				remoteServiceSlugLabel: thrifttest.DefaultServiceSlug,
 			}
 
 			totalRequestLabels := prometheus.Labels{
@@ -512,12 +511,12 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 				exceptionLabel:           tt.exceptionType,
 				baseplateStatusCodeLabel: "",
 				baseplateStatusLabel:     "",
-				remoteServiceSlugLabel:   serverSlug,
+				remoteServiceSlugLabel:   thrifttest.DefaultServiceSlug,
 			}
 
 			activeRequestLabels := prometheus.Labels{
 				methodLabel:            methodIsHealthy,
-				remoteServiceSlugLabel: serverSlug,
+				remoteServiceSlugLabel: thrifttest.DefaultServiceSlug,
 			}
 
 			defer thriftbp.PrometheusClientMetricsTest(t, latencyLabels, totalRequestLabels, activeRequestLabels).CheckMetrics()
@@ -557,8 +556,7 @@ func (srv mockBaseplateService) IsHealthy(ctx context.Context, req *baseplatethr
 
 func setupFake(ctx context.Context, t *testing.T, handler baseplatethrift.BaseplateServiceV2) thriftbp.ClientPool {
 	srv, err := thrifttest.NewBaseplateServer(thrifttest.ServerConfig{
-		Processor:         baseplatethrift.NewBaseplateServiceV2Processor(handler),
-		ClientMiddlewares: []thrift.ClientMiddleware{thriftbp.PrometheusClientMiddleware(serverSlug)},
+		Processor: baseplatethrift.NewBaseplateServiceV2Processor(handler),
 	})
 	if err != nil {
 		t.Fatalf("SETUP: Setting up baseplate server: %s", err)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -79,6 +79,7 @@ func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) 
 		AbandonCanceledRequests,
 		ReportPayloadSizeMetrics(args.ReportPayloadSizeMetricsSampleRate),
 		RecoverPanic,
+		PrometheusServerMiddleware,
 	}
 }
 

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -71,6 +71,8 @@ type DefaultProcessorMiddlewaresArgs struct {
 // 5. ReportPayloadSizeMetrics
 //
 // 6. RecoverPanic
+//
+// 7. PrometheusServerMiddleware
 func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) []thrift.ProcessorMiddleware {
 	return []thrift.ProcessorMiddleware{
 		ExtractDeadlineBudget,


### PR DESCRIPTION
While @kylelemons and I were working on making a new [upgrader](https://github.snooguts.net/reddit-go/baseplate-go-updater) for baseplate.go v0.9.2, we realized it would be better to add the Prometheus metric middleware by default so we don't have to add it for each repo. That means we would like to cut another tag v0.9.3 after this change is merged.


