### PR TITLE
metricsbp: Default to use blackhole sink without Endpoint

### DIFF
--- a/metricsbp/baseplate_hooks_internal_test.go
+++ b/metricsbp/baseplate_hooks_internal_test.go
@@ -19,7 +19,9 @@ func (h createServerSpanHook) OnCreateServerSpan(span *tracing.Span) error {
 func TestCountActiveRequestsHook(t *testing.T) {
 	st := NewStatsd(
 		context.Background(),
-		Config{},
+		Config{
+			BufferInMemoryForTesting: true,
+		},
 	)
 
 	createServerHook := createServerSpanHook{

--- a/metricsbp/baseplate_hooks_test.go
+++ b/metricsbp/baseplate_hooks_test.go
@@ -60,7 +60,9 @@ func foundHistogram(histograms []string, pattern *regexp.Regexp) bool {
 func TestOnCreateServerSpan(t *testing.T) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.Config{},
+		metricsbp.Config{
+			BufferInMemoryForTesting: true,
+		},
 	)
 
 	hook := metricsbp.CreateServerSpanHook{Metrics: st}
@@ -292,7 +294,9 @@ func TestWithStartAndFinishTimes(t *testing.T) {
 
 	st := metricsbp.NewStatsd(
 		context.Background(),
-		metricsbp.Config{},
+		metricsbp.Config{
+			BufferInMemoryForTesting: true,
+		},
 	)
 
 	hook := metricsbp.CreateServerSpanHook{Metrics: st}

--- a/metricsbp/config.go
+++ b/metricsbp/config.go
@@ -51,8 +51,21 @@ type Config struct {
 
 	// RunSysStats indicates that you want to publish system stats.
 	//
-	// Optional, defaults to false.
+	// Optional, default to false.
 	RunSysStats bool `yaml:"runSysStats"`
+
+	// By default, when Endpoint is empty,
+	// the Statsd uses a blackhole sink to send statsd metrics to.
+	// Set this to true to buffer all statsd metrics in memory until they are read
+	// explicitly (via Statsd.WriteTo).
+	//
+	// This is provided only for tests to verify the statsd metrics.
+	// Using it in production code with empty Endpoint will cause the memory used
+	// by Statsd to grow unbounded over the time.
+	// It also has no effects when Endpoint is non-empty.
+	//
+	// Optional, default to false.
+	BufferInMemoryForTesting bool `yaml:"-"`
 }
 
 // InitFromConfig initializes the global metricsbp.M with the given context and

--- a/metricsbp/log_test.go
+++ b/metricsbp/log_test.go
@@ -31,7 +31,9 @@ func TestLogWrapper(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	statsd := metricsbp.NewStatsd(ctx, metricsbp.Config{})
+	statsd := metricsbp.NewStatsd(ctx, metricsbp.Config{
+		BufferInMemoryForTesting: true,
+	})
 	wrapped := metricsbp.LogWrapper(metricsbp.LogWrapperArgs{
 		Counter: path,
 		Statsd:  statsd,

--- a/metricsbp/sampled_test.go
+++ b/metricsbp/sampled_test.go
@@ -18,12 +18,15 @@ func TestSampledHistogram(t *testing.T) {
 
 	statsd := NewStatsd(
 		context.Background(),
-		Config{},
+		Config{
+			BufferInMemoryForTesting: true,
+		},
 	)
 	statsdSampled := NewStatsd(
 		context.Background(),
 		Config{
-			HistogramSampleRate: Float64Ptr(rate),
+			HistogramSampleRate:      Float64Ptr(rate),
+			BufferInMemoryForTesting: true,
 		},
 	)
 	statsdWithTags := NewStatsd(
@@ -32,6 +35,7 @@ func TestSampledHistogram(t *testing.T) {
 			Tags: map[string]string{
 				"foo": "bar",
 			},
+			BufferInMemoryForTesting: true,
 		},
 	)
 	statsdWithTagsSampled := NewStatsd(
@@ -41,6 +45,7 @@ func TestSampledHistogram(t *testing.T) {
 			Tags: map[string]string{
 				"foo": "bar",
 			},
+			BufferInMemoryForTesting: true,
 		},
 	)
 
@@ -203,7 +208,9 @@ func TestSampledCounter(t *testing.T) {
 
 	statsd := NewStatsd(
 		context.Background(),
-		Config{},
+		Config{
+			BufferInMemoryForTesting: true,
+		},
 	)
 	statsdWithTags := NewStatsd(
 		context.Background(),
@@ -211,6 +218,7 @@ func TestSampledCounter(t *testing.T) {
 			Tags: map[string]string{
 				"foo": "bar",
 			},
+			BufferInMemoryForTesting: true,
 		},
 	)
 

--- a/metricsbp/statsd_test.go
+++ b/metricsbp/statsd_test.go
@@ -49,7 +49,8 @@ func TestNoFallback(t *testing.T) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.Config{
-			Namespace: prefix,
+			Namespace:                prefix,
+			BufferInMemoryForTesting: true,
 		},
 	)
 	st.Counter("foo").Add(1)
@@ -64,7 +65,8 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.Config{
-			Namespace: prefix,
+			Namespace:                prefix,
+			BufferInMemoryForTesting: true,
 		},
 	)
 	st.Histogram("foo").Observe(1)
@@ -79,7 +81,8 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.Config{
-			Namespace: prefix,
+			Namespace:                prefix,
+			BufferInMemoryForTesting: true,
 		},
 	)
 	st.Timing("foo").Observe(1)
@@ -94,7 +97,8 @@ func TestNoFallback(t *testing.T) {
 	st = metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.Config{
-			Namespace: prefix,
+			Namespace:                prefix,
+			BufferInMemoryForTesting: true,
 		},
 	)
 	st.Gauge("foo").Set(1)
@@ -124,7 +128,8 @@ func BenchmarkStatsd(b *testing.B) {
 	st := metricsbp.NewStatsd(
 		context.Background(),
 		metricsbp.Config{
-			Tags: initialTags,
+			Tags:                     initialTags,
+			BufferInMemoryForTesting: true,
 		},
 	)
 


### PR DESCRIPTION
Add BufferInMemoryForTesting to metricsbp.Config, with yaml tag
disabled, to be used by test code that reads from the metricsbp.Statsd
buffer explicitly.