### PR TITLE
Adjust default client middleware order to handle retries

### DIFF
--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/retrybp"
 	"github.com/reddit/baseplate.go/tracing"
+	"github.com/reddit/baseplate.go/transport"
 )
 
 const (
@@ -38,7 +39,18 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NewClient returns a standard HTTP client wrapped with the default middleware
 // plus any additional client middleware passed into this function. Default
-// middlewares are: MonitorClient, Retries, and PrometheusClientMetrics.
+// middlewares are:
+//
+// * MonitorClient with transport.WithRetrySlugSuffix
+//
+// * PrometheusClientMetrics with transport.WithRetrySlugSuffix
+//
+// * Retries
+//
+// * MonitorClient
+//
+// * PrometheusClientMetrics
+//
 // ClientErrorWrapper is included as transitive middleware through Retries.
 func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Client, error) {
 	if err := config.Validate(); err != nil {
@@ -46,9 +58,9 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 	}
 
 	// set max connections per host if set
-	var transport http.Transport
+	var httpTransport http.Transport
 	if config.MaxConnections > 0 {
-		transport.MaxConnsPerHost = config.MaxConnections
+		httpTransport.MaxConnsPerHost = config.MaxConnections
 	}
 
 	// apply default if not set
@@ -62,8 +74,10 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 	}
 
 	defaults := []ClientMiddleware{
-		MonitorClient(config.Slug),
+		MonitorClient(config.Slug + transport.WithRetrySlugSuffix),
+		PrometheusClientMetrics(config.Slug + transport.WithRetrySlugSuffix),
 		Retries(config.MaxErrorReadAhead, config.RetryOptions...),
+		MonitorClient(config.Slug),
 		PrometheusClientMetrics(config.Slug),
 	}
 
@@ -75,7 +89,7 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 	middleware = append(middleware, defaults...)
 
 	return &http.Client{
-		Transport: WrapTransport(&transport, middleware...),
+		Transport: WrapTransport(&httpTransport, middleware...),
 	}, nil
 }
 
@@ -278,7 +292,18 @@ func PrometheusClientMetrics(serverSlug string) ClientMiddleware {
 			clientActiveRequests.With(activeRequestLabels).Inc()
 
 			defer func() {
-				success := isRequestSuccessful(resp.StatusCode, err)
+				// the Retries middleware might return nil resp with an error,
+				// in such case, try to get it from ClientError instead,
+				// but fallback to a 5xx error code if nothing is available.
+				code := 599
+				var ce *ClientError
+				if errors.As(err, &ce) {
+					code = ce.StatusCode
+				}
+				if resp != nil {
+					code = resp.StatusCode
+				}
+				success := isRequestSuccessful(code, err)
 
 				latencyLabels := prometheus.Labels{
 					methodLabel:     method,
@@ -291,7 +316,7 @@ func PrometheusClientMetrics(serverSlug string) ClientMiddleware {
 				totalRequestLabels := prometheus.Labels{
 					methodLabel:     method,
 					successLabel:    success,
-					codeLabel:       strconv.Itoa(resp.StatusCode),
+					codeLabel:       strconv.Itoa(code),
 					serverSlugLabel: serverSlug,
 				}
 

--- a/httpbp/errors.go
+++ b/httpbp/errors.go
@@ -724,7 +724,7 @@ func (ce ClientError) Retryable() int {
 
 // ClientErrorFromResponse creates ClientError from http response.
 //
-// It returns nil error when the response code are in range of [200, 400),
+// It returns nil error when the response code are in range of [100, 400),
 // or non-nil error otherwise (including response being nil).
 // When the returned error is non-nil,
 // it's guaranteed to be of type *ClientError.
@@ -741,7 +741,7 @@ func ClientErrorFromResponse(resp *http.Response) error {
 	if resp == nil {
 		return &ClientError{}
 	}
-	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+	if isSuccessStatusCode(resp.StatusCode) {
 		return nil
 	}
 	ce := &ClientError{

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -477,7 +477,7 @@ func PrometheusServerMetrics(_ string) Middleware {
 // isRequestSuccessful returns the success of an HTTP request as a string, i.e. "true" or "false".
 // A HTTP request is successful when:
 //   1) no error is returned from the request and
-//   2) the HTTP status code is in the form 2xx.
+//   2) the HTTP status code is in the range [100, 400).
 func isRequestSuccessful(httpStatusCode int, requestErr error) string {
 	return strconv.FormatBool(requestErr == nil && isSuccessStatusCode(httpStatusCode))
 }

--- a/prometheusbp/promtest/testutil.go
+++ b/prometheusbp/promtest/testutil.go
@@ -19,6 +19,8 @@ type PrometheusMetricTest struct {
 
 // CheckDelta checks that the metric value changes exactly delta from when Helper was called.
 func (p *PrometheusMetricTest) CheckDelta(delta float64) {
+	p.tb.Helper()
+
 	got := p.getValue()
 	got -= float64(p.initValue)
 	if got != delta {
@@ -26,11 +28,26 @@ func (p *PrometheusMetricTest) CheckDelta(delta float64) {
 	}
 }
 
-// CheckExists confirms that the metric exists and returns the count of metrics.
+// CheckExists confirms that the metric exists and returns exactly 1 metrics.
+//
+// It's a shorthand for CheckExistsN(1)
 func (p *PrometheusMetricTest) CheckExists() {
+	p.tb.Helper()
+	p.CheckExistsN(1)
+}
+
+// CheckExistsN confirms that the metric exists and returns the count of metrics.
+//
+// Please note that due to the limitation of upstream API,
+// neither CheckExistsN nor CheckExists will limit the counts to the specified
+// labels, so they will check against the number of metrics reported with all
+// label values.
+func (p *PrometheusMetricTest) CheckExistsN(count int) {
+	p.tb.Helper()
+
 	got := testutil.CollectAndCount(p.metric)
-	if got != 1 {
-		p.tb.Errorf("%s metric count: wanted %v, got %v", p.name, 1, got)
+	if got != count {
+		p.tb.Errorf("%s metric count: wanted %v, got %v", p.name, count, got)
 	}
 }
 

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -35,7 +35,7 @@ import (
 // like:
 //
 //     service.endpointName
-const MonitorClientWrappedSlugSuffix = "-with-retry"
+const MonitorClientWrappedSlugSuffix = transport.WithRetrySlugSuffix
 
 // WithDefaultRetryFilters returns a list of retrybp.Filters by appending the
 // given filters to the "default" retry filters:
@@ -105,35 +105,41 @@ type DefaultClientMiddlewareArgs struct {
 //
 // 1. ForwardEdgeRequestContext.
 //
-// 2. MonitorClient with MonitorClientWrappedSlugSuffix - This creates the spans
+// 2. SetClientName(clientName)
+//
+// 3. MonitorClient with MonitorClientWrappedSlugSuffix - This creates the spans
 // from the view of the client that group all retries into a single,
 // wrapped span.
 //
-// 3. Retry(retryOptions) - If retryOptions is empty/nil, default to only
+// 4. PrometheusClientMiddleware with MonitorClientWrappedSlugSuffix - This
+// creates the prometheus client metrics from the view of the client that group
+// all retries into a single operation.
+//
+// 5. Retry(retryOptions) - If retryOptions is empty/nil, default to only
 // retry.Attempts(1), this will not actually retry any calls but your client is
 // configured to set retry logic per-call using retrybp.WithOptions.
 //
-// 4. FailureRatioBreaker - Only if BreakerConfig is non-nil.
+// 6. FailureRatioBreaker - Only if BreakerConfig is non-nil.
 //
-// 5. MonitorClient - This creates the spans of the raw client calls.
+// 7. MonitorClient - This creates the spans of the raw client calls.
 //
-// 6. SetClientName(clientName)
+// 8. PrometheusClientMiddleware
 //
-// 7. BaseplateErrorWrapper
+// 9. BaseplateErrorWrapper
 //
-// 8. SetDeadlineBudget
-//
-// 9. PrometheusClientMiddleware
+// 10. SetDeadlineBudget
 func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrift.ClientMiddleware {
 	if len(args.RetryOptions) == 0 {
 		args.RetryOptions = []retry.Option{retry.Attempts(1)}
 	}
 	middlewares := []thrift.ClientMiddleware{
 		ForwardEdgeRequestContext(args.EdgeContextImpl),
+		SetClientName(args.ClientName),
 		MonitorClient(MonitorClientArgs{
 			ServiceSlug:         args.ServiceSlug + MonitorClientWrappedSlugSuffix,
 			ErrorSpanSuppressor: args.ErrorSpanSuppressor,
 		}),
+		PrometheusClientMiddleware(args.ServiceSlug + MonitorClientWrappedSlugSuffix),
 		Retry(args.RetryOptions...),
 	}
 	if args.BreakerConfig != nil {
@@ -148,10 +154,9 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 			ServiceSlug:         args.ServiceSlug,
 			ErrorSpanSuppressor: args.ErrorSpanSuppressor,
 		}),
-		SetClientName(args.ClientName),
+		PrometheusClientMiddleware(args.ServiceSlug),
 		BaseplateErrorWrapper,
 		SetDeadlineBudget,
-		PrometheusClientMiddleware(args.ServiceSlug),
 	)
 	return middlewares
 }

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -519,7 +519,7 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 				remoteServiceSlugLabel: thrifttest.DefaultServiceSlug,
 			}
 
-			defer thriftbp.PrometheusClientMetricsTest(t, latencyLabels, totalRequestLabels, activeRequestLabels).CheckMetrics()
+			defer thriftbp.PrometheusClientMetricsTest(t, latencyLabels, totalRequestLabels, activeRequestLabels).CheckMetrics(2)
 			defer spectest.ValidateSpec(t, "thrift", "client")
 
 			ctx := context.Background()

--- a/transport/constants.go
+++ b/transport/constants.go
@@ -1,0 +1,5 @@
+package transport
+
+// WithRetrySlugSuffix is the suffix we add to service slug for after retry
+// metrics, to distinguish from raw client metrics.
+const WithRetrySlugSuffix = "-with-retry"


### PR DESCRIPTION
For thriftbp, we used to use two MonitorClient middlewares, one before
and one after Retry, to record both raw and -with-retry metrics, so do
the same thing for PrometheusClientMiddleware.

For httpbp, move PrometheusClientMetrics to before Retries so it records
the metrics with retries, same as how MonitorClient middleware is doing
today.