### PR TITLE
Add http_endpoint label for Prometheus metrics

### DIFF
--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -443,7 +443,8 @@ func PrometheusServerMetrics(_ string) Middleware {
 			start := time.Now()
 			method := r.Method
 			activeRequestLabels := prometheus.Labels{
-				methodLabel: method,
+				methodLabel:   method,
+				endpointLabel: name,
 			}
 			serverActiveRequests.With(activeRequestLabels).Inc()
 
@@ -453,17 +454,19 @@ func PrometheusServerMetrics(_ string) Middleware {
 				success := isRequestSuccessful(code, err)
 
 				labels := prometheus.Labels{
-					methodLabel:  method,
-					successLabel: success,
+					methodLabel:   method,
+					successLabel:  success,
+					endpointLabel: name,
 				}
 				serverLatency.With(labels).Observe(time.Since(start).Seconds())
 				serverRequestSize.With(labels).Observe(float64(r.ContentLength))
 				serverResponseSize.With(labels).Observe(float64(wrapped.bytesWritten))
 
 				totalRequestLabels := prometheus.Labels{
-					methodLabel:  method,
-					successLabel: success,
-					codeLabel:    strconv.Itoa(code),
+					methodLabel:   method,
+					successLabel:  success,
+					codeLabel:     strconv.Itoa(code),
+					endpointLabel: name,
 				}
 				serverTotalRequests.With(totalRequestLabels).Inc()
 				serverActiveRequests.With(activeRequestLabels).Dec()

--- a/httpbp/prometheus.go
+++ b/httpbp/prometheus.go
@@ -12,12 +12,14 @@ const (
 	successLabel    = "http_success"
 	codeLabel       = "http_response_code"
 	serverSlugLabel = "http_slug"
+	endpointLabel   = "http_endpoint"
 )
 
 var (
 	serverLabels = []string{
 		methodLabel,
 		successLabel,
+		endpointLabel,
 	}
 
 	serverLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -54,6 +56,7 @@ var (
 		methodLabel,
 		successLabel,
 		codeLabel,
+		endpointLabel,
 	}
 
 	serverTotalRequests = promauto.NewCounterVec(prometheus.CounterOpts{
@@ -63,6 +66,7 @@ var (
 
 	serverActiveRequestsLabels = []string{
 		methodLabel,
+		endpointLabel,
 	}
 
 	serverActiveRequests = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/httpbp/prometheus_test.go
+++ b/httpbp/prometheus_test.go
@@ -37,27 +37,30 @@ func TestPrometheusClientServerMetrics(t *testing.T) {
 		respSize int
 	}{
 		{
-			name:    "success get",
-			code:    "200",
-			success: "true",
-			method:  http.MethodGet,
-			route:   "/test",
+			name:     "success get",
+			code:     "200",
+			success:  "true",
+			method:   http.MethodGet,
+			endpoint: "test",
+			route:    "/test",
 		},
 		{
 			name:     "err post",
 			code:     "401",
 			success:  "false",
 			method:   http.MethodPost,
+			endpoint: "error2",
 			route:    "/error2",
 			reqSize:  16,
 			respSize: 29,
 		},
 		{
-			name:    "internal err get",
-			code:    "500",
-			success: "false",
-			method:  http.MethodGet,
-			route:   "/error",
+			name:     "internal err get",
+			code:     "500",
+			success:  "false",
+			method:   http.MethodGet,
+			endpoint: "error",
+			route:    "/error",
 		},
 	}
 
@@ -75,7 +78,7 @@ func TestPrometheusClientServerMetrics(t *testing.T) {
 				Handle:  func(ctx context.Context, w http.ResponseWriter, r *http.Request) error { return nil },
 			},
 			"/error2": {
-				Name:    "error",
+				Name:    "error2",
 				Methods: []string{http.MethodPost},
 				Handle: func(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 					var req exampleRequest
@@ -119,18 +122,21 @@ func TestPrometheusClientServerMetrics(t *testing.T) {
 			clientActiveRequests.Reset()
 
 			serverSizeLabels := prometheus.Labels{
-				methodLabel:  tt.method,
-				successLabel: tt.success,
+				methodLabel:   tt.method,
+				successLabel:  tt.success,
+				endpointLabel: tt.endpoint,
 			}
 
 			serverTotalRequestLabels := prometheus.Labels{
-				methodLabel:  tt.method,
-				successLabel: tt.success,
-				codeLabel:    tt.code,
+				methodLabel:   tt.method,
+				successLabel:  tt.success,
+				codeLabel:     tt.code,
+				endpointLabel: tt.endpoint,
 			}
 
 			serverActiveRequestLabels := prometheus.Labels{
-				methodLabel: tt.method,
+				methodLabel:   tt.method,
+				endpointLabel: tt.endpoint,
 			}
 
 			clientLatencyLabels := prometheus.Labels{

--- a/internal/prometheusbp/spectest/spec.go
+++ b/internal/prometheusbp/spectest/spec.go
@@ -41,7 +41,7 @@ func ValidateSpec(tb testing.TB, metricPrefix, clientOrServer string) {
 	tb.Helper()
 
 	var batch errorsbp.Batch
-	batch.AddPrefix("validate spec", validateSpec(metricPrefix, clientOrServer))
+	batch.AddPrefix("validate spec "+clientOrServer, validateSpec(metricPrefix, clientOrServer))
 
 	if err := batch.Compile(); err != nil {
 		tb.Error(err)
@@ -154,7 +154,7 @@ func buildLabels(name, prefix, clientOrServer string) map[string]struct{} {
 	case grpcPrefix:
 		labelSuffixes = grpcSpecificLabels(name)
 	case httpPrefix:
-		labelSuffixes = httpSpecificLabels(name)
+		labelSuffixes = httpSpecificLabels(name, clientOrServer)
 	}
 
 	if clientOrServer == client {
@@ -236,8 +236,12 @@ func grpcSpecificLabels(name string) []string {
 // active_requests metrics expect the following labels:
 //   - "service"
 //   - "method"
-func httpSpecificLabels(name string) []string {
+func httpSpecificLabels(name, clientOrServer string) []string {
 	labelSuffixes := []string{"method"}
+	if clientOrServer == server {
+		labelSuffixes = append(labelSuffixes, "endpoint")
+	}
+
 	switch {
 	case strings.HasSuffix(name, "_latency_seconds"):
 		labelSuffixes = append(labelSuffixes, "success")

--- a/internal/prometheusbp/spectest/spec_test.go
+++ b/internal/prometheusbp/spectest/spec_test.go
@@ -279,8 +279,9 @@ func TestBuildLabelsHTTP(t *testing.T) {
 			prefix:         httpPrefix,
 			clientOrServer: server,
 			want: map[string]struct{}{
-				"http_method":  {},
-				"http_success": {},
+				"http_method":   {},
+				"http_success":  {},
+				"http_endpoint": {},
 			},
 		},
 		{
@@ -289,8 +290,9 @@ func TestBuildLabelsHTTP(t *testing.T) {
 			prefix:         httpPrefix,
 			clientOrServer: server,
 			want: map[string]struct{}{
-				"http_method":  {},
-				"http_success": {},
+				"http_method":   {},
+				"http_success":  {},
+				"http_endpoint": {},
 			},
 		},
 		{
@@ -299,8 +301,9 @@ func TestBuildLabelsHTTP(t *testing.T) {
 			prefix:         httpPrefix,
 			clientOrServer: server,
 			want: map[string]struct{}{
-				"http_method":  {},
-				"http_success": {},
+				"http_method":   {},
+				"http_success":  {},
+				"http_endpoint": {},
 			},
 		},
 		{
@@ -329,7 +332,10 @@ func TestBuildLabelsHTTP(t *testing.T) {
 			metricName:     "http_active_requests",
 			prefix:         httpPrefix,
 			clientOrServer: server,
-			want:           map[string]struct{}{"http_method": {}},
+			want: map[string]struct{}{
+				"http_method":   {},
+				"http_endpoint": {},
+			},
 		},
 		{
 			name:           "none",


### PR DESCRIPTION
This adds a separate label for HTTP Prometheus server metrics to differentiate individual endpoints. For HTTP servers we have the notion of endpoint names, depending on whether we want to move away from defining them as part of a HTTP server router we could also use a different naming schema.