### PR TITLE
Add support for *string in redisx

### DIFF
--- a/redis/cache/redisx/request.go
+++ b/redis/cache/redisx/request.go
@@ -250,7 +250,8 @@ func (r Request) setStructValue(dst reflect.Value, src reflect.Value) error {
 func (r Request) convertAndSetByteSlice(dst reflect.Value, src reflect.Value) error {
 	asBytes, _ := src.Interface().([]byte)
 	asStr := string(asBytes)
-	if dst.Kind() == reflect.Int64 {
+	switch dst.Kind() {
+	case reflect.Int64:
 		asInt, err := strconv.ParseInt(asStr, 10, 64)
 		if err != nil {
 			return &InvalidInputError{
@@ -258,14 +259,16 @@ func (r Request) convertAndSetByteSlice(dst reflect.Value, src reflect.Value) er
 			}
 		}
 		dst.Set(reflect.ValueOf(asInt))
-	} else if dst.Kind() == reflect.String {
+	case reflect.String:
 		dst.Set(reflect.ValueOf(asStr))
-	} else if dst.Type() == stringPtrT {
-		dst.Set(reflect.ValueOf(&asStr))
-	} else {
-		return &ResponseInputTypeError{
-			Cmd:               r.Cmd,
-			ResponseInputType: dst.Type(),
+	default:
+		if dst.Type() == stringPtrT {
+			dst.Set(reflect.ValueOf(&asStr))
+		} else {
+			return &ResponseInputTypeError{
+				Cmd:               r.Cmd,
+				ResponseInputType: dst.Type(),
+			}
 		}
 	}
 	return nil

--- a/redis/cache/redisx/request_benchmark_test.go
+++ b/redis/cache/redisx/request_benchmark_test.go
@@ -11,6 +11,8 @@ import (
 // BenchmarkSetValue
 // BenchmarkSetValue/string
 // BenchmarkSetValue/string-12         	14946445	        67.1 ns/op
+// BenchmarkSetValue/*string
+// BenchmarkSetValue/*string-12	         6187052	        169 ns/op
 // BenchmarkSetValue/int64
 // BenchmarkSetValue/int64-12          	31571834	        34.5 ns/op
 // BenchmarkSetValue/[]byte
@@ -22,6 +24,19 @@ func BenchmarkSetValue(b *testing.B) {
 		var v string
 		r := Req(&v, "PING")
 		res := "foo"
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := r.setValue(res); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("*string", func(b *testing.B) {
+		var v *string
+		r := Req(&v, "GET", "foo")
+		res := []byte("foo")
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/redis/cache/redisx/request_benchmark_test.go
+++ b/redis/cache/redisx/request_benchmark_test.go
@@ -5,22 +5,20 @@ import (
 	"testing"
 )
 
-// goos: darwin
+// goos: linux
 // goarch: amd64
 // pkg: github.com/reddit/baseplate.go/redis/cache/redisx
-// BenchmarkSetValue
-// BenchmarkSetValue/string
-// BenchmarkSetValue/string-12         	14946445	        67.1 ns/op
-// BenchmarkSetValue/*string
-// BenchmarkSetValue/*string-12	         6187052	        169 ns/op
-// BenchmarkSetValue/int64
-// BenchmarkSetValue/int64-12          	31571834	        34.5 ns/op
-// BenchmarkSetValue/[]byte
-// BenchmarkSetValue/[]byte-12         	13296234	        82.4 ns/op
-// BenchmarkSetValue/[]interface{}
-// BenchmarkSetValue/[]interface{}-12  	10814821	       105 ns/op
+// cpu: AMD EPYC-Rome Processor
+// BenchmarkSetValue/string_string-8               14308600                82.94 ns/op
+// BenchmarkSetValue/int64_int64-8                 27027405                42.59 ns/op
+// BenchmarkSetValue/[]byte_[]byte-8               10459291               106.0 ns/op
+// BenchmarkSetValue/[]byte_string-8                5159313               233.9 ns/op
+// BenchmarkSetValue/[]byte_*string-8               5864259               207.7 ns/op
+// BenchmarkSetValue/[]byte_int64-8                 6185367               210.9 ns/op
+// BenchmarkSetValue/[]byte_*int64-8                4815808               267.4 ns/op
+// BenchmarkSetValue/[]interface{}-8                9794007               118.6 ns/op
 func BenchmarkSetValue(b *testing.B) {
-	b.Run("string", func(b *testing.B) {
+	b.Run("string_string", func(b *testing.B) {
 		var v string
 		r := Req(&v, "PING")
 		res := "foo"
@@ -33,20 +31,7 @@ func BenchmarkSetValue(b *testing.B) {
 		}
 	})
 
-	b.Run("*string", func(b *testing.B) {
-		var v *string
-		r := Req(&v, "GET", "foo")
-		res := []byte("foo")
-
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			if err := r.setValue(res); err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
-
-	b.Run("int64", func(b *testing.B) {
+	b.Run("int64_int64", func(b *testing.B) {
 		var v int64
 		r := Req(&v, "INCR", "foo")
 		var res int64 = 123
@@ -59,10 +44,58 @@ func BenchmarkSetValue(b *testing.B) {
 		}
 	})
 
-	b.Run("[]byte", func(b *testing.B) {
+	b.Run("[]byte_[]byte", func(b *testing.B) {
 		var v []byte
 		r := Req(&v, "GET", "foo")
 		res := []byte("foo")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := r.setValue(res); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("[]byte_string", func(b *testing.B) {
+		var v string
+		r := Req(&v, "GET", "foo")
+		res := []byte("foo")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := r.setValue(res); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("[]byte_*string", func(b *testing.B) {
+		var v *string
+		r := Req(&v, "GET", "foo")
+		res := []byte("foo")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := r.setValue(res); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("[]byte_int64", func(b *testing.B) {
+		var v int64
+		r := Req(&v, "GET", "foo")
+		res := []byte("123")
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := r.setValue(res); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("[]byte_*int64", func(b *testing.B) {
+		var v *int64
+		r := Req(&v, "GET", "foo")
+		res := []byte("123")
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {

--- a/redis/cache/redisx/syncx.go
+++ b/redis/cache/redisx/syncx.go
@@ -28,7 +28,8 @@ import (
 //    is supported as a response input.  In additon, you may use a "string" or
 //    "int64" and we will attempt to convert the "[]byte" response to that value.
 //    Note that this is done by converting it to a "string" first and, in the
-//    case of "int64", parsing it into an integer.
+//    case of "int64", parsing it into an integer. You can also use "*string"
+//    or "*int64", to be able to represent null value.
 // 4. Arrays: Arrays are the most flexible type returned by Redis as an array
 //    can contain elements of any of the types above. "[]interface{}" is the
 //    type that redispipe returns on these commands and is supported as a

--- a/redis/cache/redisx/syncx_test.go
+++ b/redis/cache/redisx/syncx_test.go
@@ -251,6 +251,31 @@ func TestResponseTypes(t *testing.T) {
 		}
 	})
 
+	t.Run("*string", func(t *testing.T) {
+		key := "star"
+
+		var v *string
+		if err := client.Do(ctx, &v, "GET", key); err != nil {
+			t.Fatal(err)
+		}
+		if v != nil {
+			t.Errorf("expected value to not be set, got %v", v)
+		}
+
+		value := "buzz"
+		if err := client.Do(ctx, nil, "SET", key, value); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := client.Do(ctx, &v, "GET", key); err != nil {
+			t.Fatal(err)
+		}
+		if *v != value {
+			t.Errorf("*string value mismatch, expected %q, got %v", value, v)
+		}
+
+	})
+
 	t.Run("[]byte", func(t *testing.T) {
 		key := "fizz"
 

--- a/redis/cache/redisx/syncx_test.go
+++ b/redis/cache/redisx/syncx_test.go
@@ -251,49 +251,29 @@ func TestResponseTypes(t *testing.T) {
 		}
 	})
 
-	t.Run("*string", func(t *testing.T) {
-		key := "star"
-
-		var v *string
-		if err := client.Do(ctx, &v, "GET", key); err != nil {
-			t.Fatal(err)
-		}
-		if v != nil {
-			t.Errorf("expected value to not be set, got %v", v)
-		}
-
-		value := "buzz"
-		if err := client.Do(ctx, nil, "SET", key, value); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := client.Do(ctx, &v, "GET", key); err != nil {
-			t.Fatal(err)
-		}
-		if *v != value {
-			t.Errorf("*string value mismatch, expected %q, got %v", value, v)
-		}
-
-	})
-
 	t.Run("[]byte", func(t *testing.T) {
 		key := "fizz"
-
-		var v []byte
-		if err := client.Do(ctx, &v, "GET", key); err != nil {
-			t.Fatal(err)
-		}
-		if v != nil {
-			t.Errorf("expected value to not be set, got %q", string(v))
-		}
+		nilKey := "empty"
+		intKey := "number"
 
 		value := "buzz"
 		if err := client.Do(ctx, nil, "SET", key, value); err != nil {
+			t.Fatal(err)
+		}
+		var intValue int64 = 3
+		if err := client.Do(ctx, nil, "SET", intKey, strconv.FormatInt(intValue, 10)); err != nil {
 			t.Fatal(err)
 		}
 
 		t.Run("input/[]byte", func(t *testing.T) {
 			var v []byte
+			if err := client.Do(ctx, &v, "GET", nilKey); err != nil {
+				t.Fatal(err)
+			}
+			if v != nil {
+				t.Errorf("expected value to not be set, got %q", string(v))
+			}
+
 			if err := client.Do(ctx, &v, "GET", key); err != nil {
 				t.Fatal(err)
 			}
@@ -312,18 +292,48 @@ func TestResponseTypes(t *testing.T) {
 			}
 		})
 
-		t.Run("input/int64", func(t *testing.T) {
-			var value int64 = 3
-			if err := client.Do(ctx, nil, "SET", key, strconv.FormatInt(value, 10)); err != nil {
+		t.Run("input/*string", func(t *testing.T) {
+			var v *string
+			if err := client.Do(ctx, &v, "GET", nilKey); err != nil {
 				t.Fatal(err)
 			}
+			if v != nil {
+				t.Errorf("expected value to not be set, got %v", v)
+			}
 
-			var v int64
 			if err := client.Do(ctx, &v, "GET", key); err != nil {
 				t.Fatal(err)
 			}
-			if v != value {
-				t.Errorf("bulk string value mismatch, expected %d, got %d", value, v)
+			if *v != value {
+				t.Errorf("*string value mismatch, expected %q, got %v", value, v)
+			}
+
+		})
+
+		t.Run("input/int64", func(t *testing.T) {
+			var v int64
+			if err := client.Do(ctx, &v, "GET", intKey); err != nil {
+				t.Fatal(err)
+			}
+			if v != intValue {
+				t.Errorf("bulk string value mismatch, expected %d, got %d", intValue, v)
+			}
+		})
+
+		t.Run("input/*int64", func(t *testing.T) {
+			var v *int64
+			if err := client.Do(ctx, &v, "GET", nilKey); err != nil {
+				t.Fatal(err)
+			}
+			if v != nil {
+				t.Errorf("expected value to not be set, got %v", v)
+			}
+
+			if err := client.Do(ctx, &v, "GET", intKey); err != nil {
+				t.Fatal(err)
+			}
+			if *v != intValue {
+				t.Errorf("bulk string value mismatch, expected %d, got %d", intValue, v)
 			}
 		})
 	})


### PR DESCRIPTION
Add support for *string data receiver in redisx
Using `*string` receiver for data from redis enables distinguishing between empty string values and `nil` (e.g. stored empty string vs. cache miss).