### PR TITLE
thriftbp: Handle wrapped TException in prometheus middlewares

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -3,9 +3,7 @@ package thriftbp
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -361,11 +359,10 @@ func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware
 				clientActiveRequests.With(activeRequestLabels).Inc()
 
 				defer func() {
-					var exceptionTypeLabel, baseplateStatusCode, baseplateStatus string
+					var baseplateStatusCode, baseplateStatus string
+					exceptionTypeLabel := stringifyErrorType(err)
 					success := strconv.FormatBool(err == nil)
 					if err != nil {
-						exceptionTypeLabel = strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
-
 						var bpErr baseplateError
 						if errors.As(err, &bpErr) {
 							code := bpErr.GetCode()

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
@@ -431,11 +430,10 @@ func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) t
 		serverActiveRequests.With(activeRequestLabels).Inc()
 
 		defer func() {
-			var exceptionTypeLabel, baseplateStatusCode, baseplateStatus string
+			var baseplateStatusCode, baseplateStatus string
+			exceptionTypeLabel := stringifyErrorType(err)
 			success := strconv.FormatBool(err == nil)
 			if err != nil {
-				exceptionTypeLabel = strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
-
 				var bpErr baseplateError
 				if errors.As(err, &bpErr) {
 					code := bpErr.GetCode()


### PR DESCRIPTION
For thrift's server middleware, the error type is of TException instead
of error, so usually freeform errors need to be wrapped by
thrift.WrapTException, and just try to get the type via %T will hide the
actual type returned by the server handler.

Add a helper function stringifyErrorType to try to unwrap such cases.