### PR TITLE
Add baseplate admin package

### DIFF
--- a/admin/doc.go
+++ b/admin/doc.go
@@ -1,0 +1,2 @@
+// Package admin is baseplate boilerplate for admin features.
+package admin

--- a/admin/server.go
+++ b/admin/server.go
@@ -1,0 +1,55 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/reddit/baseplate.go/log"
+)
+
+const (
+	DefaultAdminAddr = ":6060"
+)
+
+// ServerArgs contain optional configuration for the admin server.
+type ServerArgs struct {
+	// AdminAddr is a custom address for the admin server. Defaults to port 6060 on localhost if not set.
+	AdminAddr string
+	// HealthCheckFn is the HTTP handler for health check.
+	HealthCheckFn func(w http.ResponseWriter, r *http.Request)
+}
+
+// NewServer returns a new admin server for internal functionality.
+func NewServer(args *ServerArgs) *Server {
+	adminAddr := args.AdminAddr
+	if args.AdminAddr == "" {
+		adminAddr = DefaultAdminAddr
+	}
+
+	return &Server{
+		adminAddr:     adminAddr,
+		healthCheckFn: args.HealthCheckFn,
+	}
+}
+
+type Server struct {
+	adminAddr     string
+	healthCheckFn func(w http.ResponseWriter, r *http.Request)
+}
+
+// Serve starts an HTTP server for internal functions:
+//    metrics       - serve /metrics for prometheus
+//    health check  - serve /health for health checking
+//    pprof         - https://blog.golang.org/pprof
+// Default server address is http://localhost:6060.
+func (s *Server) Serve() {
+	go func() {
+		if s.healthCheckFn != nil {
+			http.HandleFunc("/health", s.healthCheckFn)
+		}
+		http.Handle("/metrics", promhttp.Handler())
+		log.Infof("Serving admin on %s", s.adminAddr)
+		log.Warnw("admin http serve exited", "err", http.ListenAndServe(s.adminAddr, nil))
+	}()
+}

--- a/httpbp/example_server_test.go
+++ b/httpbp/example_server_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/admin"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/httpbp"
 	"github.com/reddit/baseplate.go/log"
@@ -25,27 +26,35 @@ type body struct {
 	Y int `json:"y"`
 }
 
-type Handlers struct {
+type isHealthyResponse struct {
+	Status string `json:"status,omitempty"`
+}
+
+type TestService struct {
 	secrets    *secrets.Store
 	redisAddrs []string
 }
 
-func (h Handlers) Home(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (s *TestService) IsHealthy(w http.ResponseWriter, r *http.Request) {
+	httpbp.NewResponse(isHealthyResponse{Status: "healthy"})
+}
+
+func (s *TestService) Home(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return httpbp.WriteJSON(w, httpbp.NewResponse(body{X: 1, Y: 2}))
 }
 
-func (h Handlers) ServerErr(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (s *TestService) ServerErr(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return httpbp.JSONError(httpbp.InternalServerError(), errors.New("example"))
 }
 
-func (h Handlers) Ratelimit(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (s *TestService) Ratelimit(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return httpbp.JSONError(
 		httpbp.TooManyRequests().Retryable(w, time.Minute),
 		errors.New("rate-limit"),
 	)
 }
 
-func (h Handlers) InvalidInput(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+func (s *TestService) InvalidInput(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	return httpbp.JSONError(
 		httpbp.BadRequest().WithDetails(map[string]string{
 			"foo": "must be >= 0",
@@ -55,26 +64,26 @@ func (h Handlers) InvalidInput(ctx context.Context, w http.ResponseWriter, r *ht
 	)
 }
 
-func (h Handlers) Endpoints() map[httpbp.Pattern]httpbp.Endpoint {
+func (s *TestService) Endpoints() map[httpbp.Pattern]httpbp.Endpoint {
 	return map[httpbp.Pattern]httpbp.Endpoint{
 		"/": {
 			Name:    "home",
-			Handle:  h.Home,
+			Handle:  s.Home,
 			Methods: []string{http.MethodGet},
 		},
 		"/err": {
 			Name:    "err",
-			Handle:  h.ServerErr,
+			Handle:  s.ServerErr,
 			Methods: []string{http.MethodGet, http.MethodPost},
 		},
 		"/ratelimit": {
 			Name:    "ratelimit",
-			Handle:  h.Ratelimit,
+			Handle:  s.Ratelimit,
 			Methods: []string{http.MethodGet},
 		},
 		"/invalid-input": {
 			Name:    "invalid-input",
-			Handle:  h.InvalidInput,
+			Handle:  s.InvalidInput,
 			Methods: []string{http.MethodPost},
 		},
 	}
@@ -110,17 +119,19 @@ func ExampleNewBaseplateServer() {
 	}
 	defer bp.Close()
 
-	handlers := Handlers{
+	svc := TestService{
 		secrets:    bp.Secrets(),
 		redisAddrs: cfg.Redis.Addrs,
 	}
 	server, err := httpbp.NewBaseplateServer(httpbp.ServerArgs{
 		Baseplate:   bp,
-		Endpoints:   handlers.Endpoints(),
+		Endpoints:   svc.Endpoints(),
 		Middlewares: []httpbp.Middleware{loggingMiddleware},
 	})
 	if err != nil {
 		panic(err)
 	}
+	adminServer := admin.NewServer(&admin.ServerArgs{HealthCheckFn: svc.IsHealthy})
+	adminServer.Serve()
 	log.Info(baseplate.Serve(ctx, baseplate.ServeArgs{Server: server}))
 }

--- a/thriftbp/example_server_test.go
+++ b/thriftbp/example_server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/reddit/baseplate.go"
+	"github.com/reddit/baseplate.go/admin"
 	"github.com/reddit/baseplate.go/ecinterface"
 	bpgen "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/log"
@@ -41,5 +42,7 @@ func ExampleNewBaseplateServer() {
 		log.Fatal(err)
 	}
 
+	adminServer := admin.NewServer(&admin.ServerArgs{})
+	adminServer.Serve()
 	log.Info(baseplate.Serve(ctx, baseplate.ServeArgs{Server: server}))
 }


### PR DESCRIPTION
baseplate-cookiecutter adds this boilerplate to new baseplate services ([code](https://github.snooguts.net/reddit/baseplate-cookiecutter/blob/master/baseplate_cookiecutter/make_project/go/%7B%7Bcookiecutter.project_slug%7D%7D/main.go#L86)):
```
func serveAdmin() {
    // This goroutine opens http://localhost:6060/ for internal functions:
    //    pprof   - https://blog.golang.org/pprof
    //    metrics - will serve /metrics for prometheus (TBD)
    //    status  - will serve /health for health checking
    go func() {
        http.HandleFunc("/health", service.IsHealthy)
        http.Handle("/metrics", promhttp.Handler())
        log.Infof("Serving admin on %s", *adminAddr)
        log.Warnw("admin http serve exited", "err", http.ListenAndServe(*adminAddr, nil))
    }()
}
```

This PR adds that boilerplate into baseplate.go to create an opinionated `baseplate.go/admin` package that reduces this boilerplate (per Ben's rec [here](https://reddit.slack.com/archives/CLMUD9GTE/p1645719276430109)).