### PR TITLE
🐛 | Fix handling of baseplateError by unwrapping the TException

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -245,6 +245,10 @@ func stringifyErrorType(err error) string {
 	if err == nil {
 		return ""
 	}
+	return strings.TrimPrefix(fmt.Sprintf("%T", unwrapTException(err)), "*")
+}
+
+func unwrapTException(err error) error {
 	var te thrift.TException
 	if errors.As(err, &te) && te.TExceptionType() == thrift.TExceptionTypeUnknown {
 		// This usually means the error was wrapped by thrift.WrapTException,
@@ -253,5 +257,5 @@ func stringifyErrorType(err error) string {
 			err = unwrapped
 		}
 	}
-	return strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
+	return err
 }


### PR DESCRIPTION
While using thrift_version=9bee87, I crafted a request so that the response is a Baseplate.Error. I noticed that the baseplate.Error specific labels were missing.

So I added  a break point in the `PrometheusServerMiddleware` and I can see that err is github.com/apache/thrift/lib/go/thrift.TException(*github.snooguts.net/reddit/reddit-service-authentication-go/thrift/reddit/baseplate.Error) *{Code: *401, Message: *"Unauthorized", Details: map[string]string ["reason": "could not find user Identity. NotFoundError({})", ]} But then stepping through execution I can see it pass over the `if errors.As(err, &bpErr) {...}` block.

This PR makes sure we enter this block.

However I am unclear if we need a similar change for the client side instrumentation since I haven't been able to craft a failing query there.