### PR TITLE
Relax interface for bpError in the Prometheus middlewares

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -363,7 +363,7 @@ func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware
 					exceptionTypeLabel := stringifyErrorType(err)
 					success := strconv.FormatBool(err == nil)
 					if err != nil {
-						var bpErr baseplateError
+						var bpErr baseplateErrorCode
 						if errors.As(err, &bpErr) {
 							code := bpErr.GetCode()
 							baseplateStatusCode = strconv.FormatInt(int64(code), 10)

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -363,7 +363,7 @@ func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware
 					exceptionTypeLabel := stringifyErrorType(err)
 					success := strconv.FormatBool(err == nil)
 					if err != nil {
-						var bpErr baseplateErrorCode
+						var bpErr baseplateErrorCoder
 						if errors.As(err, &bpErr) {
 							code := bpErr.GetCode()
 							baseplateStatusCode = strconv.FormatInt(int64(code), 10)

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -255,3 +255,12 @@ func stringifyErrorType(err error) string {
 	}
 	return strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
 }
+
+// We create this interface instead of using baseplateError because we want it to always match
+// regardless of the version of the thrift file the user has put in their repository.
+type baseplateErrorCode interface {
+	thrift.TException
+
+	IsSetCode() bool
+	GetCode() int32
+}

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -255,12 +255,3 @@ func stringifyErrorType(err error) string {
 	}
 	return strings.TrimPrefix(fmt.Sprintf("%T", err), "*")
 }
-
-// We create this interface instead of using baseplateError because we want it to always match
-// regardless of the version of the thrift file the user has put in their repository.
-type baseplateErrorCode interface {
-	thrift.TException
-
-	IsSetCode() bool
-	GetCode() int32
-}

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -434,7 +434,7 @@ func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) t
 			exceptionTypeLabel := stringifyErrorType(err)
 			success := strconv.FormatBool(err == nil)
 			if err != nil {
-				var bpErr baseplateErrorCode
+				var bpErr baseplateErrorCoder
 				if errors.As(err, &bpErr) {
 					code := bpErr.GetCode()
 					baseplateStatusCode = strconv.FormatInt(int64(code), 10)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -434,7 +434,7 @@ func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) t
 			exceptionTypeLabel := stringifyErrorType(err)
 			success := strconv.FormatBool(err == nil)
 			if err != nil {
-				var bpErr baseplateError
+				var bpErr baseplateErrorCode
 				if errors.As(err, &bpErr) {
 					code := bpErr.GetCode()
 					baseplateStatusCode = strconv.FormatInt(int64(code), 10)


### PR DESCRIPTION
Right now we expect the user to have the same definition of `baseplate.thrift` than we do but nothing enforces it. In the case of the Prometheus middleware this leads to us not recognizing an error as being a Baseplate.Error and therefore not adding the labels for the error code.

This PR introduces a relaxed interface only to be used by the prometheus middleware to ensure that they will identity a Baseplate.Error as such regardless of past or future changes to the `baseplate.thrift` file.