### PR TITLE
🐛 | Swap Prometheus and recoverPanic middlewares

### DIFF
--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -69,9 +69,9 @@ type DefaultProcessorMiddlewaresArgs struct {
 //
 // 5. ReportPayloadSizeMetrics
 //
-// 6. RecoverPanic
+// 6. PrometheusServerMiddleware
 //
-// 7. PrometheusServerMiddleware
+// 7. RecoverPanic
 func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) []thrift.ProcessorMiddleware {
 	return []thrift.ProcessorMiddleware{
 		ExtractDeadlineBudget,
@@ -79,8 +79,8 @@ func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) 
 		InjectEdgeContext(args.EdgeContextImpl),
 		AbandonCanceledRequests,
 		ReportPayloadSizeMetrics(args.ReportPayloadSizeMetricsSampleRate),
-		RecoverPanic,
 		PrometheusServerMiddleware,
+		RecoverPanic,
 	}
 }
 


### PR DESCRIPTION
Right now PrometheusMiddleware is the leaf middleware. This means that its defer function doesn't see panics as being a wrapped error. So it logs them as successes. Making the RecoverPanic middleware the leaf appears to solve this problem