### PR TITLE
runtimebp: Clearly log the `GOMAXPROCS` configuration on startup

### DIFF
--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -37,5 +37,5 @@ func InitFromConfig(cfg Config) {
 		min = cfg.NumProcesses.Min
 	}
 	prev, current := GOMAXPROCS(min, max)
-	fmt.Fprintf(os.Stderr, "GOMAXPROCS: %d %d\n", prev, current)
+	fmt.Fprintf(os.Stderr, "GOMAXPROCS: previous: %d current: %d\n", prev, current)
 }

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -37,5 +37,5 @@ func InitFromConfig(cfg Config) {
 		min = cfg.NumProcesses.Min
 	}
 	prev, current := GOMAXPROCS(min, max)
-	fmt.Fprintf(os.Stderr, "GOMAXPROCS: previous: %d current: %d\n", prev, current)
+	fmt.Fprintf(os.Stderr, "GOMAXPROCS: Old: %d New: %d\n", prev, current)
 }


### PR DESCRIPTION
Logs like `GOMAXPROCS: 48 4` aren't very clear.  Identifying the configuration values in the default
and updated states is useful to the operator.