### PR TITLE
metricsbp|prometheusbp: Add BoolString

### DIFF
--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -3,7 +3,6 @@ package grpcbp
 import (
 	"context"
 	"errors"
-	"strconv"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -12,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/reddit/baseplate.go/ecinterface"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -147,7 +147,7 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 		clientActiveRequests.With(activeRequestLabels).Inc()
 
 		defer func() {
-			success := strconv.FormatBool(err == nil)
+			success := prometheusbp.BoolString(err == nil)
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -3,7 +3,6 @@ package grpcbp
 import (
 	"context"
 	"errors"
-	"strconv"
 	"time"
 
 	"google.golang.org/grpc"
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/tracing"
 	"github.com/reddit/baseplate.go/transport"
 )
@@ -179,7 +179,7 @@ func InjectPrometheusUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		serverActiveRequests.With(activeRequestLabels).Inc()
 
 		defer func() {
-			success := strconv.FormatBool(err == nil)
+			success := prometheusbp.BoolString(err == nil)
 			status, _ := status.FromError(err)
 
 			latencyLabels := prometheus.Labels{

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -17,6 +17,7 @@ import (
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -485,7 +486,7 @@ func PrometheusServerMetrics(_ string) Middleware {
 //   1) no error is returned from the request and
 //   2) the HTTP status code is in the range [100, 400).
 func isRequestSuccessful(httpStatusCode int, requestErr error) string {
-	return strconv.FormatBool(requestErr == nil && isSuccessStatusCode(httpStatusCode))
+	return prometheusbp.BoolString(requestErr == nil && isSuccessStatusCode(httpStatusCode))
 }
 
 // responeRecorder records the following:

--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
 
@@ -181,14 +182,14 @@ func (kc *consumer) reset() error {
 	if err != nil {
 		metricsbp.M.Counter("kafka.consumer.rebalance.failure").Add(1)
 		rebalanceCounter.With(prometheus.Labels{
-			successLabel: "false",
+			successLabel: prometheusbp.BoolString(false),
 		}).Inc()
 		return err
 	}
 
 	metricsbp.M.Counter("kafka.consumer.rebalance.success").Add(1)
 	rebalanceCounter.With(prometheus.Labels{
-		successLabel: "true",
+		successLabel: prometheusbp.BoolString(true),
 	}).Inc()
 	return nil
 }

--- a/metricsbp/baseplate_hooks.go
+++ b/metricsbp/baseplate_hooks.go
@@ -98,13 +98,7 @@ func (h *spanHook) OnPreStop(span *tracing.Span, err error) error {
 	).With(tags.AsStatsdTags()...))
 	timer.OverrideStartTime(h.startTime).ObserveWithEndTime(stop)
 
-	var successResult string
-	if err != nil {
-		successResult = "False"
-	} else {
-		successResult = "True"
-	}
-	tags[tracing.TagKeySuccess] = successResult
+	tags[tracing.TagKeySuccess] = BoolString(err == nil)
 	h.metrics.Counter(fmt.Sprintf(baseplateCounter, typeStr)).With(tags.AsStatsdTags()...).Add(1)
 
 	return nil
@@ -138,3 +132,12 @@ var (
 	_ tracing.AddSpanCounterHook   = (*spanHook)(nil)
 	_ tracing.StartStopSpanHook    = countActiveRequestsHook{}
 )
+
+// BoolString returns the string version of a boolean value that should be used
+// in a statsd metric tag.
+func BoolString(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
+}

--- a/prometheusbp/metrics.go
+++ b/prometheusbp/metrics.go
@@ -6,3 +6,12 @@ import (
 
 // DefaultBuckets is the default bucket values for a prometheus histogram metric.
 var DefaultBuckets = prometheus.ExponentialBuckets(0.0001, 2.5, 14) // 100us ~ 14.9s
+
+// BoolString returns the string version of a boolean value that should be used
+// in a prometheus metric label.
+func BoolString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -15,6 +15,7 @@ import (
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/retrybp"
 	"github.com/reddit/baseplate.go/tracing"
 	"github.com/reddit/baseplate.go/transport"
@@ -361,7 +362,7 @@ func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware
 				defer func() {
 					var baseplateStatusCode, baseplateStatus string
 					exceptionTypeLabel := stringifyErrorType(err)
-					success := strconv.FormatBool(err == nil)
+					success := prometheusbp.BoolString(err == nil)
 					if err != nil {
 						var bpErr baseplateErrorCoder
 						if errors.As(err, &bpErr) {

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strconv"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	baseplatethrift "github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/internal/prometheusbp/spectest"
 	"github.com/reddit/baseplate.go/mqsend"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/retrybp"
 	"github.com/reddit/baseplate.go/thriftbp"
 	"github.com/reddit/baseplate.go/thriftbp/thrifttest"
@@ -501,13 +501,13 @@ func TestPrometheusClientMiddleware(t *testing.T) {
 
 			latencyLabels := prometheus.Labels{
 				methodLabel:            methodIsHealthy,
-				successLabel:           strconv.FormatBool(!tt.wantFail),
+				successLabel:           prometheusbp.BoolString(!tt.wantFail),
 				remoteServiceSlugLabel: thrifttest.DefaultServiceSlug,
 			}
 
 			totalRequestLabels := prometheus.Labels{
 				methodLabel:              methodIsHealthy,
-				successLabel:             strconv.FormatBool(!tt.wantFail),
+				successLabel:             prometheusbp.BoolString(!tt.wantFail),
 				exceptionLabel:           tt.exceptionType,
 				baseplateStatusCodeLabel: "",
 				baseplateStatusLabel:     "",

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/reddit/baseplate.go/clientpool"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/internal/prometheusbp/spectest"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/prometheusbp/promtest"
 )
 
@@ -64,7 +64,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 				exceptionType = strings.TrimPrefix(fmt.Sprintf("%T", tt.wantErr), "*")
 			}
 
-			success := strconv.FormatBool(tt.wantErr == nil)
+			success := prometheusbp.BoolString(tt.wantErr == nil)
 
 			activeRequestLabels := prometheus.Labels{
 				methodLabel: method,

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reddit/baseplate.go/iobp"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/randbp"
 	"github.com/reddit/baseplate.go/tracing"
 	"github.com/reddit/baseplate.go/transport"
@@ -432,7 +433,7 @@ func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) t
 		defer func() {
 			var baseplateStatusCode, baseplateStatus string
 			exceptionTypeLabel := stringifyErrorType(err)
-			success := strconv.FormatBool(err == nil)
+			success := prometheusbp.BoolString(err == nil)
 			if err != nil {
 				var bpErr baseplateErrorCoder
 				if errors.As(err, &bpErr) {

--- a/thriftbp/ttl_client.go
+++ b/thriftbp/ttl_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/randbp"
 )
 
@@ -105,10 +106,10 @@ func (c *ttlClient) refresh() {
 		// We cannot replace this connection in the background,
 		// leave client and transport be,
 		// this connection will be replaced by the pool upon next use.
-		c.replaceCounter.With("success", "False").Add(1)
+		c.replaceCounter.With("success", metricsbp.BoolString(false)).Add(1)
 		ttlClientReplaceCounter.With(prometheus.Labels{
 			serverSlugLabel: c.slug,
-			successLabel:    "false",
+			successLabel:    prometheusbp.BoolString(false),
 		}).Inc()
 		return
 	}
@@ -131,10 +132,10 @@ func (c *ttlClient) refresh() {
 		state.transport.Close()
 	}
 	state.transport = transport
-	c.replaceCounter.With("success", "True").Add(1)
+	c.replaceCounter.With("success", metricsbp.BoolString(true)).Add(1)
 	ttlClientReplaceCounter.With(prometheus.Labels{
 		serverSlugLabel: c.slug,
-		successLabel:    "true",
+		successLabel:    prometheusbp.BoolString(true),
 	}).Inc()
 }
 


### PR DESCRIPTION
Currently in Baseplate spec, we want different string values for bool
values in statsd vs. prometheus metric tags/labels: In statsd we want
capitalized "True"/"False" while in prometheus we want "true"/"false".
This can be confusing and lead to inconsistency, especially when
services are transitioning from statsd to prometheus metrics.

Provide metricsbp.BoolString and prometheusbp.BoolString in hope to help
reduce the confusion. For devs it should be easier to:

* If I'm using metricsbp to emit a metric, use metricsbp.BoolString
* If I'm using prometheus to emit a metric, use prometheusbp.BoolString