### PR TITLE
detach: Fix flaky test

### DIFF
--- a/detach/detach_async_example_test.go
+++ b/detach/detach_async_example_test.go
@@ -114,7 +114,7 @@ func ExampleAsync() {
 	asyncDone.Wait()
 	fmt.Println("finished cleanup")
 
-	// Output:
+	// Unordered Output:
 	// running...
 	// timed out
 	// waiting for async cleanup


### PR DESCRIPTION
In the example, we used ordered output, but there's a race condition
that the order of two goroutines are not guaranteed. So change to
unordered output.

Example run:
https://github.com/reddit/baseplate.go/runs/5429490555?check_suite_focus=true