### PR TITLE
thriftbp: Deprecate ClientPoolConfig.InitialConnectionsFallback

### DIFF
--- a/clientpool/channel_test.go
+++ b/clientpool/channel_test.go
@@ -58,9 +58,12 @@ func TestChannelPoolWithOpenerFailure(t *testing.T) {
 	t.Run(
 		"new-with-min-2-should-fail-initialization",
 		func(t *testing.T) {
-			_, err := clientpool.NewChannelPool(2, max, opener())
+			pool, err := clientpool.NewChannelPool(2, max, opener())
 			if err == nil {
 				t.Error("NewChannelPool with min = 2 should fail but did not.")
+			}
+			if pool == nil {
+				t.Error("NewChannelPool with min = 2 should return non-nil pool.")
 			}
 		},
 	)

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -62,9 +62,23 @@ type ClientPoolConfig struct {
 	// "${host}:${port}"
 	Addr string `yaml:"addr"`
 
-	// InitialConnections is the inital number of thrift connections created by
-	// the client pool.
-	InitialConnections int `yaml:"initialConnections"`
+	// InitialConnections is the desired inital number of thrift connections
+	// created by the client pool.
+	//
+	// If an error occurred when we try to establish the initial N connections for
+	// the pool, we log the error with InitialConnectionsFallbackLogger,
+	// then return the pool with the <N connections we already established.
+	//
+	// If that's unacceptable, then RequiredInitialConnections can be used to set
+	// the hard requirement of minimal initial connections to be established.
+	// Note that enabling this can cause cascading failures during an outage,
+	// so it shall only be used for extreme circumstances.
+	InitialConnections               int         `yaml:"initialConnections"`
+	InitialConnectionsFallbackLogger log.Wrapper `yaml:"initialConnectionsFallbackLogger"`
+	RequiredInitialConnections       int         `yaml:"requiredInitialConnections"`
+	// Deprecated: InitialConnectionsFallback is always true and setting it to
+	// false won't do anything.
+	InitialConnectionsFallback bool `yaml:"initialConnectionsFallback"`
 
 	// MaxConnections is the maximum number of thrift connections the client
 	// pool can maintain.
@@ -169,20 +183,6 @@ type ClientPoolConfig struct {
 	//
 	// This is optional. If it's not set IDLExceptionSuppressor will be used.
 	ErrorSpanSuppressor errorsbp.Suppressor
-
-	// When InitialConnectionsFallback is set to true and an error occurred when
-	// we try to initialize the client pool, instead of returning that error,
-	// we try again with InitialConnections falls back to 0.
-	//
-	// If the fallback attempt succeeded, we log the initial error with
-	// InitialConnectionsFallbackLogger, and returns nil error.
-	// If the fallback attempt also failed, we return both errors.
-	//
-	// This is useful when the server is unstable that some connection errors are
-	// expected, so that we still try to create InitialConnections when possible,
-	// but returns an usable client pool with 0 initial connections as fallback.
-	InitialConnectionsFallback       bool        `yaml:"initialConnectionsFallback"`
-	InitialConnectionsFallbackLogger log.Wrapper `yaml:"initialConnectionsFallbackLogger"`
 
 	// When BreakerConfig is non-nil,
 	// a breakerbp.FailureRatioBreaker will be created for the pool,
@@ -414,35 +414,27 @@ func newClientPool(
 		opener,
 	)
 	if err != nil {
-		if cfg.InitialConnectionsFallback {
-			// do the InitialConnectionsFallback
-			var fallbackErr error
-			pool, fallbackErr = clientpool.NewChannelPool(
-				0, // initialClients
-				cfg.MaxConnections,
-				opener,
-			)
-			if fallbackErr == nil {
-				cfg.InitialConnectionsFallbackLogger.Log(context.Background(), fmt.Sprintf(
-					"thriftbp: error initializing thrift clientpool for %q but fallback to 0 initial connections worked. Original error: %v",
-					cfg.ServiceSlug,
-					err,
-				))
-				err = nil
-			} else {
+		if pool == nil || int(pool.NumAllocated()) < cfg.RequiredInitialConnections {
+			if pool != nil {
 				var batch errorsbp.Batch
 				batch.Add(err)
-				batch.Add(fallbackErr)
+				batch.AddPrefix("close", pool.Close())
 				err = batch.Compile()
 			}
-		}
-		if err != nil {
 			return nil, fmt.Errorf(
 				"thriftbp: error initializing thrift clientpool for %q: %w",
 				cfg.ServiceSlug,
 				err,
 			)
 		}
+
+		cfg.InitialConnectionsFallbackLogger.Log(context.Background(), fmt.Sprintf(
+			"thriftbp: Established %d of %d InitialConnections asked for thrift clientpool for %q: %v",
+			pool.NumAllocated(),
+			cfg.InitialConnections,
+			cfg.ServiceSlug,
+			err,
+		))
 	}
 	if cfg.ReportPoolStats {
 		go reportPoolStats(


### PR DESCRIPTION
Currently ClientPoolConfig.InitialConnectionsFallback is default to
false, due to how zero values in go work. Deprecate it to make it
default to true, because cascading failures during an outage is in
general much worse.

Add InitialConnectionsNoFallback to allow the current default behavior
(that could cause cascading failures) for services that absolutely need
it.

Also instead of fallback to 0 connections, return whatever connections
we already established with the pool. This requires a small behavior
change inside clientpool package, that clientpool.NewChannelPool now
could return both non-nil Pool and error. An internal code search shows
that there are 2 services using that directly (we probably should have
made that an internal package to avoid that, but that ship has already
sailed). I'll send out separated PRs to handle the both non-nil Pool and
error case for the 2 services to avoid connection leaks when they
upgrade Baseplate.go to this version.