### PR TITLE
Eliminate all explicit log.ErrorWithSentry(-Wrapper) calls

### DIFF
--- a/filewatcher/doc_test.go
+++ b/filewatcher/doc_test.go
@@ -36,7 +36,6 @@ func Example() {
 		filewatcher.Config{
 			Path:   path,
 			Parser: parser,
-			Logger: log.ErrorWithSentryWrapper(),
 		},
 	)
 	if err != nil {

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -215,7 +215,8 @@ type Config struct {
 	// of soft limit.
 	//
 	// If the soft limit is violated,
-	// the violation will be reported via log.ErrorWithSentry,
+	// the violation will be reported via log.DefaultWrapper and prometheus
+	// counter of limitopen_softlimit_violation_total,
 	// but it does not stop the normal parsing process.
 	//
 	// If the hard limit is violated,

--- a/internal/limitopen/limitopen.go
+++ b/internal/limitopen/limitopen.go
@@ -2,7 +2,6 @@ package limitopen
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -18,7 +17,8 @@ import (
 
 const (
 	promNamespace = "limitopen"
-	pathLabel     = "path"
+
+	pathLabel = "path"
 )
 
 var (
@@ -30,6 +30,12 @@ var (
 		Namespace: promNamespace,
 		Name:      "file_size_bytes",
 		Help:      "The size of the file opened by limitopen.Open",
+	}, sizeLabels)
+
+	softLimitCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Name:      "softlimit_violation_total",
+		Help:      "The total number of violations of softlimit",
 	}, sizeLabels)
 )
 
@@ -86,7 +92,8 @@ type readCloser struct {
 // (with "limitopen.size" as the metrics path and path label for statsd,
 // "limitopen_file_size_bytes" for prometheus).
 // When softLimit > 0 and the size of the path as reported by the os is larger,
-// it will also use log.ErrorWithSentry to report it.
+// it will also use log.DefaultWrapper to report it and increase prometheus
+// counter of limitopen_softlimit_violation_total.
 // When hardLimit > 0 and the size of the path as reported by the os is larger,
 // it will close the file and return an error directly.
 func OpenWithLimit(path string, softLimit, hardLimit int64) (io.ReadCloser, error) {
@@ -99,20 +106,20 @@ func OpenWithLimit(path string, softLimit, hardLimit int64) (io.ReadCloser, erro
 	metricsbp.M.RuntimeGauge("limitopen.size").With(
 		"path", pathValue,
 	).Set(float64(size))
-	sizeGauge.With(prometheus.Labels{
+	labels := prometheus.Labels{
 		pathLabel: pathValue,
-	}).Set(float64(size))
+	}
+	sizeGauge.With(labels).Set(float64(size))
 
 	if softLimit > 0 && size > softLimit {
-		const msg = "limitopen.OpenWithLimit: file size > soft limit"
-		log.ErrorWithSentry(
-			context.Background(),
-			msg,
-			errors.New(msg),
-			"path", path,
-			"size", size,
-			"limit", softLimit,
+		msg := fmt.Sprintf(
+			"limitopen.OpenWithLimit: file size > soft limit, path=%q size=%d limit=%d",
+			path,
+			size,
+			softLimit,
 		)
+		log.DefaultWrapper.Log(context.Background(), msg)
+		softLimitCounter.With(labels).Inc()
 	}
 
 	if hardLimit > 0 && size > hardLimit {

--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -54,12 +54,13 @@ type ConsumeMessageFunc func(ctx context.Context, msg *sarama.ConsumerMessage)
 //     consumer.Consume(
 //       consumeMessageFunc,
 //       func(err error) {
-//         log.ErrorWithSentry(
+//         log.Errorw(
 //           context.Background(),
 //           "kafka consumer error",
-//           err,
+//           "err", err,
 //           // additional key value pairs, for example topic info
 //         )
+//         // or a prometheus counter
 //         metricsbp.M.Counter("kafka.consumer.errors").With(/* key value pairs */).Add(1)
 //       },
 //     )

--- a/kafkabp/rack.go
+++ b/kafkabp/rack.go
@@ -10,7 +10,24 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/reddit/baseplate.go/log"
+)
+
+var (
+	awsRackFailure = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Name:      "aws_rack_id_failure_total",
+		Help:      "Total failures of getting rack id from AWS endpoint",
+	})
+
+	httpRackFailure = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Name:      "http_rack_id_failure_total",
+		Help:      "Total failures of getting rack id from http endpoint",
+	})
 )
 
 // RackIDFunc defines a function to provide the kafka rack id to use.
@@ -41,7 +58,8 @@ type RackIDFunc func() string
 // - "aws": AWSAvailabilityZoneRackID.
 //
 // - "http://url" or "https://url": SimpleHTTPRackID with
-// log.ErrorWithSentryWrapper, default timeout & limit, and given URL.
+// log.DefaultWrapper and prometheus counter of
+// kafkabp_http_rack_id_failure_total, default timeout & limit, and given URL.
 //
 // - anything else: FixedRackID with the given value. For example "foobar" is
 // the same as "fixed:foobar".
@@ -61,8 +79,11 @@ func (r *RackIDFunc) UnmarshalText(text []byte) error {
 	// http cases
 	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
 		*r = SimpleHTTPRackID(SimpleHTTPRackIDConfig{
-			URL:    s,
-			Logger: log.ErrorWithSentryWrapper(),
+			URL: s,
+			Logger: log.PrometheusCounterWrapper(
+				nil, // delegate, let it fallback to DefaultWrapper
+				httpRackFailure,
+			),
 		})
 		return nil
 	}
@@ -190,13 +211,17 @@ const awsAZurl = "http://169.254.169.254/latest/meta-data/placement/availability
 //        // other configs
 //    })
 //
-// It uses SimpleHTTPRackIDConfig underneath with log.ErrorWithSentryWrapper and
-// default Limit & Timeout.
+// It uses SimpleHTTPRackIDConfig underneath with log.DefaultWrapper with a
+// prometheus counter of kafkabp_aws_rack_id_failure_total and default
+// Limit & Timeout.
 func AWSAvailabilityZoneRackID() string {
 	awsRackIDOnce.Do(func() {
 		awsCachedRackID = SimpleHTTPRackID(SimpleHTTPRackIDConfig{
-			URL:    awsAZurl,
-			Logger: log.ErrorWithSentryWrapper(),
+			URL: awsAZurl,
+			Logger: log.PrometheusCounterWrapper(
+				nil, // delegate, let it fallback to DefaultWrapper
+				awsRackFailure,
+			),
 		})()
 	})
 	return awsCachedRackID

--- a/secrets/config.go
+++ b/secrets/config.go
@@ -4,7 +4,22 @@ import (
 	"context"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/reddit/baseplate.go/log"
+)
+
+const (
+	promNamespace = "secrets"
+)
+
+var (
+	parserFailures = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: promNamespace,
+		Name:      "parser_failure_total",
+		Help:      "Total number of secret parser failures",
+	})
 )
 
 // Config is the confuration struct for the secrets package.
@@ -21,7 +36,10 @@ func InitFromConfig(ctx context.Context, cfg Config) (*Store, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
-	store, err := NewStore(ctx, cfg.Path, log.ErrorWithSentryWrapper())
+	store, err := NewStore(ctx, cfg.Path, log.PrometheusCounterWrapper(
+		nil, // delegate, let it fallback to DefaultWrapper
+		parserFailures,
+	))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Replace all current explicit log.ErrorWithSentry(-Wrapper) calls with
log.DefaultWrapper plus a prometheus counter.

This way, for services not migrated to prometheus, they still get the
same sentry report today (as log.DefaultWrapper is
ErrorWithSentryWrapper today); But for services migrated to prometheus,
they could override log.DefaultWrapper early in their main [1] to
eliminate unnecessary sentry reporting and monitor on the prometheus
counters instead.

[1]: Example:

    log.DefaultWrapper = log.ZapWrapper(log.ZapWrapperArgs{
      Level: log.WarnLevel,
      KVPairs: map[string]interface{}{
        "from": "default-wrapper",
      },
    })