### PR TITLE
log: Add tb.Helper() to TestWrapper

### DIFF
--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -206,6 +206,7 @@ func StdWrapper(logger *stdlog.Logger) Wrapper {
 // It fails the test when called.
 func TestWrapper(tb testing.TB) Wrapper {
 	return func(_ context.Context, msg string) {
+		tb.Helper()
 		tb.Errorf("logger called with msg: %q", msg)
 	}
 }


### PR DESCRIPTION
The filewatcher test becomes extremely flaky on Github Actions recently,
and without tb.Helper() call the line number is not useful at all.