### PR TITLE
Register important prometheus error counters

### DIFF
--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -35,6 +35,13 @@ var (
 	}, rebalanceLabels)
 )
 
+func init() {
+	// Register the error counter so that it can be monitored.
+	rebalanceCounter.With(prometheus.Labels{
+		successLabel: prometheusbp.BoolString(false),
+	})
+}
+
 // ConsumeMessageFunc is a function type for consuming consumer messages.
 //
 // The implementation is expected to handle all consuming errors.
@@ -179,8 +186,7 @@ func (kc *consumer) reset() error {
 		return nil
 	}
 
-	err := rebalance()
-	if err != nil {
+	if err := rebalance(); err != nil {
 		metricsbp.M.Counter("kafka.consumer.rebalance.failure").Add(1)
 		rebalanceCounter.With(prometheus.Labels{
 			successLabel: prometheusbp.BoolString(false),

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -486,6 +486,15 @@ func newClientPool(
 	//
 	// pooledClient is now ready for use.
 	pooledClient.wrapCalls(middlewares...)
+
+	// Register the error prometheus counters so they can be monitored
+	labels := prometheus.Labels{
+		serverSlugLabel: cfg.ServiceSlug,
+	}
+	clientPoolExhaustedCounter.With(labels)
+	clientPoolClosedConnectionsCounter.With(labels)
+	clientPoolReleaseErrorCounter.With(labels)
+
 	return pooledClient, nil
 }
 

--- a/thriftbp/ttl_client.go
+++ b/thriftbp/ttl_client.go
@@ -165,5 +165,12 @@ func newTTLClient(generator ttlClientGenerator, ttl time.Duration, jitter float6
 	}
 	state.renew(time.Now(), c)
 	c.state <- state
+
+	// Register the error counter so it can be monitored
+	ttlClientReplaceCounter.With(prometheus.Labels{
+		serverSlugLabel: c.slug,
+		successLabel:    prometheusbp.BoolString(false),
+	})
+
 	return c, nil
 }


### PR DESCRIPTION
For important prometheus error counters with labels, register them
(With the labels but without Inc/Add), so that we are always emitting 0
even if those error counters never fire. This way they can be monitored
correctly (with rate query producing expected results).