### PR TITLE
log: Add fallback to debug.BuildInfo to version stamping

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17.8]
+        go-version: [1.18.1]
 
     container:
       image: golang:${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reddit/baseplate.go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Shopify/sarama v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -412,7 +412,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da h1:NimzV1aGyq29m5ukMK0AMWEhFaL/lrEOaephfuoiARg=
 github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -484,7 +483,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -521,7 +519,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -541,7 +538,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -587,9 +583,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=

--- a/log/log.go
+++ b/log/log.go
@@ -24,40 +24,6 @@ var globalLogger = zap.New(
 	zap.AddCallerSkip(1), // will always be called via a top-level function from this package
 ).Sugar()
 
-// Version is the version tag value to be added to the global logger.
-//
-// If it's changed to non-empty value before the calling of Init* functions
-// (InitFromConfig/InitLogger/InitLoggerJSON/InitLoggerWithConfig/InitSentry),
-// the global logger initialized will come with a tag of VersionKey("v"),
-// added to every line of logs.
-// For InitSentry the global sentry will also be initialized with a tag of
-// "version".
-//
-// In order to use it, either set it in your main function early,
-// before calling InitLogger* functions,
-// with the value coming from flag/config file/etc..
-// For example:
-//
-//     func main() {
-//       log.Version = *flagVersion
-//       log.InitLoggerJSON(log.Level(*logLevel))
-//       // ...
-//     }
-//
-// Or just "stamp" it during build time,
-// by passing additional ldflags to go build command.
-// For example:
-//
-//     go build -ldflags "-X github.com/reddit/baseplate.go/log.Version=$(git rev-parse HEAD)"
-//
-// Change its value after calling Init* functions will have no effects,
-// unless you call Init* functions again.
-var (
-	VersionLogKey = "v"
-
-	Version string
-)
-
 // Level is the verbose representation of log level
 type Level string
 

--- a/log/version.go
+++ b/log/version.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"runtime/debug"
+)
+
+// Version is the version tag value to be added to the global logger.
+//
+// If it's changed to non-empty value before the calling of Init* functions
+// (InitFromConfig/InitLogger/InitLoggerJSON/InitLoggerWithConfig/InitSentry),
+// the global logger initialized will come with a tag of VersionKey("v"),
+// added to every line of logs.
+// For InitSentry the global sentry will also be initialized with a tag of
+// "version".
+//
+// In order to use it, either set it in your main function early,
+// before calling InitLogger* functions,
+// with the value coming from flag/config file/etc..
+// For example:
+//
+//     func main() {
+//       log.Version = *flagVersion
+//       log.InitLoggerJSON(log.Level(*logLevel))
+//       // ...
+//     }
+//
+// Or just "stamp" it during build time,
+// by passing additional ldflags to go build command.
+// For example:
+//
+//     go build -ldflags "-X github.com/reddit/baseplate.go/log.Version=$(git rev-parse HEAD)"
+//
+// Change its value after calling Init* functions will have no effects,
+// unless you call Init* functions again.
+//
+// Starting from go 1.18, if Version is not stamped at compile time,
+// we'll try to fill it from runtime/debug.ReadBuildInfo, if available.
+var (
+	VersionLogKey = "v"
+
+	Version string
+)
+
+func init() {
+	// Try to read version from build info if it's not stamped at compile time.
+	if Version == "" {
+		if info, _ := debug.ReadBuildInfo(); info != nil {
+			Version = getVersionFromBuildInfo(info)
+		}
+	}
+}
+
+func getVersionFromBuildInfo(info *debug.BuildInfo) string {
+	const (
+		versionKey  = "vcs.revision"
+		dirtyKey    = "vcs.modified"
+		dirtyValue  = "true"
+		dirtySuffix = "-dirty"
+
+		untaggedMainVersion = "(devel)"
+	)
+	var v string
+	var dirty bool
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case versionKey:
+			v = setting.Value
+		case dirtyKey:
+			dirty = setting.Value == dirtyValue
+		}
+	}
+	if v != "" {
+		if dirty {
+			v = v + dirtySuffix
+		}
+		return v
+	}
+	// fallback to the main module version if that's a tagged version
+	if info.Main.Version != untaggedMainVersion {
+		return info.Main.Version
+	}
+	return ""
+}

--- a/log/version_test.go
+++ b/log/version_test.go
@@ -1,0 +1,119 @@
+package log
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestGetVersionFromBuildInfo(t *testing.T) {
+	for _, c := range []struct {
+		label string
+		want  string
+		info  *debug.BuildInfo
+	}{
+		{
+			label: "normal",
+			want:  "deadbeef",
+			info: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{
+						Key:   "vcs.revision",
+						Value: "deadbeef",
+					},
+					{
+						Key:   "vcs.modified",
+						Value: "false",
+					},
+				},
+			},
+		},
+		{
+			label: "reverse-order",
+			want:  "deadbeef",
+			info: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{
+						Key:   "vcs.modified",
+						Value: "false",
+					},
+					{
+						Key:   "vcs.revision",
+						Value: "deadbeef",
+					},
+				},
+			},
+		},
+		{
+			label: "dirty",
+			want:  "deadbeef-dirty",
+			info: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{
+						Key:   "vcs.revision",
+						Value: "deadbeef",
+					},
+					{
+						Key:   "vcs.modified",
+						Value: "true",
+					},
+				},
+			},
+		},
+		{
+			label: "reverse-dirty",
+			want:  "deadbeef-dirty",
+			info: &debug.BuildInfo{
+				Settings: []debug.BuildSetting{
+					{
+						Key:   "vcs.modified",
+						Value: "true",
+					},
+					{
+						Key:   "vcs.revision",
+						Value: "deadbeef",
+					},
+				},
+			},
+		},
+		{
+			label: "revision-over-tag",
+			want:  "deadbeef",
+			info: &debug.BuildInfo{
+				Main: debug.Module{
+					Version: "v1.0",
+				},
+				Settings: []debug.BuildSetting{
+					{
+						Key:   "vcs.revision",
+						Value: "deadbeef",
+					},
+				},
+			},
+		},
+		{
+			label: "tag-only",
+			want:  "v1.0",
+			info: &debug.BuildInfo{
+				Main: debug.Module{
+					Version: "v1.0",
+				},
+			},
+		},
+		{
+			label: "untagged-no-fallback",
+			want:  "",
+			info: &debug.BuildInfo{
+				Main: debug.Module{
+					Version: "(devel)",
+				},
+			},
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			got := getVersionFromBuildInfo(c.info)
+			if got != c.want {
+				t.Errorf("got: %q, want: %q", got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Taking advantage of go 1.18's new -buildvcs flag, read the version info
from runtime/debug.BuildInfo when no version is stamped in log package.

Although we don't have -buildvcs in our production builds yet, this
makes us ready to take advantage of that whenever it's ready.

This also requires us to drop support to go 1.17, as
runtime/debug.BuildSetting is added in go 1.18.