### PR TITLE
Fix typo in thrift connection housekeeping metric name

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -123,8 +123,8 @@ var (
 	ttlClientReplaceCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: subsystemTTLClient,
-		Name:      "connection_houskeeping_total",
-		Help:      "Total connection housekeeping (replace the connection in the background) done in thrift ttlClient",
+		Name:      "connection_housekeeping_total",
+		Help:      "Total connection housekeeping (replacing the connection in the background) done in thrift ttlClient",
 	}, ttlClientReplaceLabels)
 )
 


### PR DESCRIPTION
## 💸 TL;DR
Metric name typo.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
