### PR TITLE
thriftbp: Add prometheus histogram from client set timeout

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -215,6 +215,25 @@ var (
 	)
 )
 
+const (
+	clientLabel = "thrift_client"
+)
+
+var (
+	deadlineBudgetLabels = []string{
+		methodLabel,
+		clientLabel,
+	}
+
+	deadlineBudgetHisto = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: promNamespace,
+		Subsystem: subsystemServer,
+		Name:      "extracted_deadline_budget_seconds",
+		Help:      "Baseplate deadline budget extracted from client set header",
+		Buckets:   prometheusbp.DefaultBuckets,
+	}, deadlineBudgetLabels)
+)
+
 type clientPoolGaugeExporter struct {
 	slug string
 	pool clientpool.Pool


### PR DESCRIPTION
This can be useful for the service owners to get a sense of what their
clients are setting for the request timeout, and for example if their
SLO is 100ms but a lot of the client requests have a timeout <100ms,
they can talk to the client owners to fix the timeouts.

Note that due to the unusual nature of this histogram, we are usually
looking at the "reverted percentile" of it, for example instead of
looking at 99th percentile, we should be looking at the 1st percentile
for "the 1% of the lowest client set timeouts". As a result this
histogram will not work in a statsd metric, but it should work in a
prometheus metric.
