### PR TITLE
thriftbp: Minor Prometheus label change

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -129,7 +129,7 @@ var (
 )
 
 const (
-	protoLabel = "proto"
+	protoLabel = "thrift_proto"
 )
 
 var (


### PR DESCRIPTION
In all prometheus labels used in thriftbp, the proto one is currently
the only one without thrft_ prefix, so add the prefix to keep it
consistent.
