### PR TITLE
Update NumCPU for unlimited quota

### DIFF
--- a/runtimebp/cpu_test.go
+++ b/runtimebp/cpu_test.go
@@ -59,6 +59,10 @@ func TestReadNumberFromFile(t *testing.T) {
 			Content: "123.456",
 			Error:   true,
 		},
+		"negative": {
+			Content:  "-1",
+			Expected: -1,
+		},
 	}
 
 	for label, data := range cases {


### PR DESCRIPTION
## 💸 TL;DR

Simplify runtimebp.NumCPU() by removing defer function.

Explicitly return runtime.NumCPU() when `cpu.cfs_quota_us` returns `-1`,
which is usef for no quota. This matches normal Go behavior.

[0]: https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt

Signed-off-by: SuperQ <superq@gmail.com>

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
