### PR TITLE
add graceful drain thrift middleware

### DIFF
--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -132,6 +132,7 @@ func NewBaseplateServer(
 			EdgeContextImpl:                    bp.EdgeContextImpl(),
 			ErrorSpanSuppressor:                cfg.ErrorSpanSuppressor,
 			ReportPayloadSizeMetricsSampleRate: cfg.ReportPayloadSizeMetricsSampleRate,
+			RuntimeStateReader:                 bp.State,
 		},
 	)
 	middlewares = append(middlewares, cfg.Middlewares...)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"strconv"
-	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/reddit/baseplate.go/runtimebp"
 
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"
@@ -87,7 +84,7 @@ func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) 
 		AbandonCanceledRequests,
 		ReportPayloadSizeMetrics(args.ReportPayloadSizeMetricsSampleRate),
 		PrometheusServerMiddleware,
-		EnvoyGracefulDrainHeader(),
+		EnvoyGracefulDrainHeader,
 		RecoverPanic,
 	}
 }
@@ -486,30 +483,16 @@ func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) t
 }
 
 // EnvoyGracefulDrainHeader returns middleware which sets a drain signal header on server responses.
-func EnvoyGracefulDrainHeader() thrift.ProcessorMiddleware {
-
-	const envoyDrainHeader = ":drain"
-
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-	var shouldDrain int32
-	go func() {
-		<-sig
-		atomic.StoreInt32(&shouldDrain, 1)
-	}()
-
-	return func(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
-
-		return thrift.WrappedTProcessorFunction{
-			Wrapped: func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (ok bool, err thrift.TException) {
-				if atomic.LoadInt32(&shouldDrain) > 0 {
-					if t, ok := out.(*thrift.THeaderProtocol); ok {
-						t.SetWriteHeader(envoyDrainHeader, "true")
-					}
+func EnvoyGracefulDrainHeader(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+	return thrift.WrappedTProcessorFunction{
+		Wrapped: func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (ok bool, err thrift.TException) {
+			if runtimebp.ServerState() == runtimebp.StateShuttingDown {
+				if t, ok := out.(*thrift.THeaderProtocol); ok {
+					t.SetWriteHeader(transport.HeaderEnvoyThriftDrain, "true")
 				}
+			}
 
-				return next.Process(ctx, seqID, in, out)
-			},
-		}
+			return next.Process(ctx, seqID, in, out)
+		},
 	}
 }

--- a/transport/headers.go
+++ b/transport/headers.go
@@ -25,4 +25,14 @@ const (
 	HeaderTracingSampledTrue = "1"
 	// Number of milliseconds, 64-bit integer encoded in decimal.
 	HeaderDeadlineBudget = "Deadline-Budget"
+
+	// HeaderEnvoyThriftDrain is a checked by envoy to determine is an upstream
+	// connection should be drained.
+	//
+	// This header is used by the thriftbp.EnvoyGracefulDrainHeader middleware and attached
+	// to all thrift responses while the server state is runtimebp.StateShuttingDown
+	//
+	// Relevant Envoy PR implementing connection draining
+	// https://github.com/envoyproxy/envoy/pull/20236
+	HeaderEnvoyThriftDrain = ":drain"
 )


### PR DESCRIPTION

## 💸 TL;DR
This PR introduces a thrift middleware that will attach a "drain" header to a response if the application is currently terminating

## 📜 Details
The specific header is `:drain` which is explicitly checked by envoy while handling an upstream response. This envoy feature was introduced in the following PR:
https://github.com/envoyproxy/envoy/pull/20236

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
