### PR TITLE
filewatcher: Raise default file size limit

### DIFF
--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -45,9 +45,9 @@ var InitialReadInterval = time.Second / 2
 
 // DefaultMaxFileSize is the default MaxFileSize used when it's <= 0.
 //
-// It's 1MiB, which is following the size limit of Apache ZooKeeper nodes.
+// It's 10 MiB, with hard limit multiplier of 10.
 const (
-	DefaultMaxFileSize  = 1 << 20
+	DefaultMaxFileSize  = 10 << 20
 	HardLimitMultiplier = 10
 )
 


### PR DESCRIPTION
With the work of [1], the files watched by filewatcher will soon be no
longer limited to zookeeper nodes, so the previous size limitation
derivated from znode size limit will be hit in the near future.

[1]: https://github.com/reddit/baseplate.py/commit/093fbf4cc1699d244a3d022eeee507b08ce7b18d
