### PR TITLE
thrifttest: fix bug where Server.Close hangs

### DIFF
--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -113,14 +113,14 @@ func (s *Server) Start(ctx context.Context) {
 
 // Close the underying Server and Baseplate as well as the thriftbp.ClientPool.
 func (s *Server) Close() error {
-	bc := batchcloser.New()
+	closers := batchcloser.New()
 	// close the ClientPool first so the server doesn't hang waiting for it to
 	// close while trying to close itself.
 	if s.ClientPool != nil {
-		bc.Add(s.ClientPool)
+		closers.Add(s.ClientPool)
 	}
-	bc.Add(s.Server, s.Baseplate())
-	return bc.Close()
+	closers.Add(s.Server, s.Baseplate())
+	return closers.Close()
 }
 
 // NewBaseplateServer returns a new, Baseplate thrift server listening on the

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -115,7 +115,7 @@ func (s *Server) Start(ctx context.Context) {
 // Close the underying Server and Baseplate as well as the thriftbp.ClientPool.
 func (s *Server) Close() error {
 	closers := make([]io.Closer, 0, 3)
-	// close the ClientPool first so the server doesn't hang waiting for them to
+	// close the ClientPool first so the server doesn't hang waiting for it to
 	// close while trying to close itself.
 	if s.ClientPool != nil {
 		closers = append(closers, s.ClientPool)


### PR DESCRIPTION
## 💸 TL;DR
Update thrifttest.Server.Close to close the ClientPool before
trying to close the server. If you don't do this, then the
underlying server.Close will hang while it waits for the client
to close (which won't happen until the server closes) unless
you explicitly set thift.ServerStopTimeout

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
