### PR TITLE
runtimebp: Support cgroup v2

### DIFF
--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -2,6 +2,7 @@ package runtimebp
 
 import (
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"runtime"
@@ -12,75 +13,110 @@ import (
 // NumCPU returns the number of CPUs assigned to this running container.
 //
 // This is the container aware version of runtime.NumCPU.
-// It reads from the cgroup cpu.cfs_quota_us and cpu.cfs_period_us values
-// to determine the hard CPU limit of the container.
+// It reads from the cgroup v2 cpu.max values to determine the hard CPU limit of
+// the container.
 //
+// If the current process is not running with cgroup v2,
+// it falls back to read from the cgroup v1 cpu.cfs_quota_us and
+// cpu.cfs_period_us values.
 // If the current process is not running inside a container,
 // or if there's no limit set in cgroup,
 // it will fallback to runtime.NumCPU() instead.
 func NumCPU() float64 {
+	// Big enough buffer to read the numbers in the files wholly into memory.
+	buf := make([]byte, 1024)
+
+	n, err := numCPUCgroupsV2(buf)
+	if err == nil {
+		return n
+	}
+
+	// fallback to cgroups v1
+	fmt.Fprintf(
+		os.Stderr,
+		"runtimebp.NumCPU: Failed to read cgroup v2, fallback to cgroup v1: %v\n",
+		err,
+	)
+	n, err = numCPUCgroupsV1(buf)
+	if err == nil {
+		return n
+	}
+
+	// Fallback to the standard runtime package value.
+	fmt.Fprintf(
+		os.Stderr,
+		"runtimebp.NumCPU: Failed to read cgroup v1, fallback to NumCPU on the physical machine: %v\n",
+		err,
+	)
+	return float64(runtime.NumCPU())
+}
+
+func numCPUCgroupsV2(buf []byte) (float64, error) {
+	const (
+		maxPath = "/sys/fs/cgroup/cpu.max"
+	)
+
+	values, err := readNumbersFromFile(maxPath, buf, 2)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read max file: %w", err)
+	}
+
+	return values[0] / values[1], nil
+}
+
+func numCPUCgroupsV1(buf []byte) (float64, error) {
 	const (
 		quotaPath  = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
 		periodPath = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 	)
 
-	// Default to the standard runtime package value.
-	defaultCPUs := float64(runtime.NumCPU())
-
-	// Big enough buffer to read the number in the file wholly into memory.
-	buf := make([]byte, 1024)
-
-	quota, err := readNumberFromFile(quotaPath, buf)
-	if err != nil {
-		fmt.Fprintf(
-			os.Stderr,
-			"NumCPU: Failed to read quota file, falling back to use runtime.NumCPU(): %v\n",
-			err,
-		)
-		return defaultCPUs
+	quota, err := readNumbersFromFile(quotaPath, buf, 1)
+	if err != nil || len(quota) != 1 {
+		return 0, fmt.Errorf("failed to read quota file: %w", err)
 	}
 
 	// CFS quota returns -1 if there is no limit, return the default.
-	if quota < 0 {
-		fmt.Fprintf(
-			os.Stderr,
-			"NumCPU: Quota file returned %f, falling back to use runtime.NumCPU(): %v\n",
-			quota,
-			err,
+	if quota[0] < 0 {
+		return 0, fmt.Errorf(
+			"quota file returned %f",
+			quota[0],
 		)
-		return defaultCPUs
 	}
 
-	period, err := readNumberFromFile(periodPath, buf)
+	period, err := readNumbersFromFile(periodPath, buf, 1)
 	if err != nil {
-		fmt.Fprintf(
-			os.Stderr,
-			"NumCPU: Failed to read period file, falling back to use runtime.NumCPU(): %v\n",
-			err,
-		)
-		return defaultCPUs
+		return 0, fmt.Errorf("failed to read period file: %w", err)
 	}
 
-	return quota / period
+	return quota[0] / period[0], nil
 }
 
-func readNumberFromFile(path string, buf []byte) (float64, error) {
+func readNumbersFromFile(path string, buf []byte, numbers int) ([]float64, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to open %q: %w", path, err)
+		return nil, fmt.Errorf("failed to open %q: %w", path, err)
 	}
 	defer file.Close()
 
-	n, err := file.Read(buf)
-	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to read %q: %w", path, err)
+	n, err := io.ReadFull(file, buf)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return nil, fmt.Errorf("failed to read %q: %w", path, err)
 	}
 
-	f, err := strconv.ParseInt(strings.TrimSpace(string(buf[:n])), 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("runtimebp: failed to parse %q: %w", path, err)
+	line := strings.TrimSpace(string(buf[:n]))
+	strs := strings.Fields(line)
+	if numbers != len(strs) {
+		return nil, fmt.Errorf("got %d numbers instead of %d: %q", len(strs), numbers, line)
 	}
-	return float64(f), nil
+	result := make([]float64, numbers)
+	for i, s := range strs {
+		f, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q: %w (#%d of %q)", path, err, i, line)
+		}
+		result[i] = float64(f)
+	}
+	return result, nil
 }
 
 // MaxProcsFormula is the function to calculate GOMAXPROCS based on NumCPU value

--- a/runtimebp/cpu_test.go
+++ b/runtimebp/cpu_test.go
@@ -1,25 +1,40 @@
 package runtimebp
 
 import (
+	"io"
 	"math"
 	"os"
+	"strings"
 	"testing"
 )
 
-func TestReadNumberFromFile(t *testing.T) {
+func TestReadNumbersFromFile(t *testing.T) {
 	buf := make([]byte, 1024)
 
-	compareFloat64 := func(t *testing.T, expected, actual float64) {
+	compareFloat64Slices := func(t *testing.T, want, got []float64) {
 		t.Helper()
-		if math.Abs(expected-actual) > 1e-5 {
-			t.Errorf("Expected %f, got %f", expected, actual)
+		t.Logf("compareFloat64Slices: want %v got %v", want, got)
+		if len(want) != len(got) {
+			t.Errorf(
+				"Slice length mismatch: want %d got %d",
+				len(want),
+				len(got),
+			)
+			return
+		}
+		for i, fWant := range want {
+			fGot := got[i]
+			if math.Abs(fWant-fGot) > 1e-5 {
+				t.Errorf("#%d want %f, got %f", i, fWant, fGot)
+			}
 		}
 	}
 
 	writeFile := func(t *testing.T, content string) string {
 		t.Helper()
 
-		file, err := os.CreateTemp("", "")
+		dir := t.TempDir()
+		file, err := os.CreateTemp(dir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -28,7 +43,7 @@ func TestReadNumberFromFile(t *testing.T) {
 				t.Fatal(err)
 			}
 		}()
-		if _, err := file.Write([]byte(content)); err != nil {
+		if _, err := io.Copy(file, strings.NewReader(content)); err != nil {
 			t.Fatal(err)
 		}
 		return file.Name()
@@ -36,54 +51,86 @@ func TestReadNumberFromFile(t *testing.T) {
 
 	cases := map[string]struct {
 		Content  string
+		Numbers  int
 		Error    bool
-		Expected float64
+		Expected []float64
 	}{
-		"normal": {
+		"normal-v1": {
 			Content:  "15000",
-			Expected: 15000,
+			Numbers:  1,
+			Expected: []float64{15000},
+		},
+		"normal-v2": {
+			Content:  "15000 1000",
+			Numbers:  2,
+			Expected: []float64{15000, 1000},
+		},
+		"v2-line-break": {
+			Content:  "15000\n1000",
+			Numbers:  2,
+			Expected: []float64{15000, 1000},
+		},
+		"v2-max": {
+			Content: "max 1000",
+			Numbers: 2,
+			Error:   true,
 		},
 		"with-line-break": {
 			Content:  "15000\n",
-			Expected: 15000,
+			Numbers:  1,
+			Expected: []float64{15000},
 		},
 		"with-extra-data": {
 			Content: "15000foobar",
+			Numbers: 1,
 			Error:   true,
 		},
 		"total-garbage": {
 			Content: "Hello, world!",
+			Numbers: 1,
 			Error:   true,
 		},
 		"not-int": {
 			Content: "123.456",
+			Numbers: 1,
 			Error:   true,
 		},
 		"negative": {
 			Content:  "-1",
-			Expected: -1,
+			Numbers:  1,
+			Expected: []float64{-1},
+		},
+		"mismatch-numbers-1": {
+			Content: "15000",
+			Numbers: 2,
+			Error:   true,
+		},
+		"mismatch-numbers-2": {
+			Content: "15000 1000",
+			Numbers: 1,
+			Error:   true,
 		},
 	}
 
 	for label, data := range cases {
-		t.Run(
-			label,
-			func(t *testing.T) {
-				path := writeFile(t, data.Content)
-				defer os.Remove(path)
-				f, err := readNumberFromFile(path, buf)
-				if data.Error {
-					if err == nil {
-						t.Errorf("Expected an error for %+v, got nil", data)
-					}
-				} else {
-					if err != nil {
-						t.Fatalf("Got error for %+v: %v", data, err)
-					}
-					compareFloat64(t, data.Expected, f)
+		t.Run(label, func(t *testing.T) {
+			path := writeFile(t, data.Content)
+			t.Cleanup(func() {
+				os.Remove(path)
+			})
+
+			values, err := readNumbersFromFile(path, buf, data.Numbers)
+			if data.Error {
+				if err == nil {
+					t.Errorf("Expected an error for %+v, got nil", data)
 				}
-			},
-		)
+			} else {
+				if err != nil {
+					t.Fatalf("Got error for %+v: %v", data, err)
+				}
+				compareFloat64Slices(t, data.Expected, values)
+			}
+		})
 	}
 }
 
@@ -130,14 +177,11 @@ func TestBoundNtoMinMax(t *testing.T) {
 	}
 
 	for label, data := range cases {
-		t.Run(
-			label,
-			func(t *testing.T) {
-				actual := boundNtoMinMax(data.N, data.Min, data.Max)
-				if actual != data.Expected {
-					t.Errorf("Got %d for data %+v", actual, data)
-				}
-			},
-		)
+		t.Run(label, func(t *testing.T) {
+			actual := boundNtoMinMax(data.N, data.Min, data.Max)
+			if actual != data.Expected {
+				t.Errorf("Got %d for data %+v", actual, data)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Apparently cgroup v2 uses different files from v1 for cpu limits, so
the current code does not work in v2 and will always fallback to NumCPU
on the node.
