### PR TITLE
[BASE-29] Create internalv2compat library

### DIFF
--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -1,7 +1,7 @@
 // Package internalv2compat is an INTERNAL ONLY library provided for transitional projects that need
 // to use baseplate v2 and v0 in the same module.
 //
-// DO NOT USE THIS LIBRARY DIRECTLY.
+// DO NOT USE THIS LIBRARY DIRECTLY.  Breaking changes may be made to this package at any time.
 //
 // Deprecated: This is an internal library and should not be used directly.
 package internalv2compat

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -41,7 +41,7 @@ var v0logDisabled uint64
 // SetGlobalLogger allows baseplate v0 to set the global logger.
 func SetGlobalLogger(logger *zap.SugaredLogger) {
 	if atomic.LoadUint64(&v0logDisabled) > 0 {
-		globalLogger.Warnf("Suppressing global log override; use v2 loging instead")
+		globalLogger.Warn("ineffectual call to SetGlobalLogger; baseplate.go v2 compatibility mode is active")
 		return
 	}
 

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -1,0 +1,55 @@
+// Package internalv2compat is an INTERNAL ONLY library provided for transitional projects that need
+// to use baseplate v2 and v0 in the same module.
+//
+// DO NOT USE THIS LIBRARY DIRECTLY.
+//
+// Deprecated: This is an internal library and should not be used directly.
+package internalv2compat
+
+import (
+	"os"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// globalLogger() is used by all top-level log methods (e.g. Infof) in the log package.
+//
+// Before the Init methods are called, this logger will use a very basic config
+// that includes a `pre_init` key to distinguish this condition.
+var globalLogger = zap.New(
+	zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+		os.Stderr,
+		zapcore.DebugLevel,
+	),
+	zap.Fields(
+		zap.Bool("pre_init", true),
+	),
+).WithOptions(
+	zap.AddCallerSkip(1), // will always be called via a top-level function from this package
+).Sugar()
+
+// GlobalLogger is an inlineable accessor for the global logger to allow for injection from baseplate v2.
+func GlobalLogger() *zap.SugaredLogger {
+	return globalLogger
+}
+
+var v0logDisabled uint64
+
+// SetGlobalLogger allows baseplate v0 to set the global logger.
+func SetGlobalLogger(logger *zap.SugaredLogger) {
+	if atomic.LoadUint64(&v0logDisabled) > 0 {
+		globalLogger.Warnf("Suppressing global log override; use v2 loging instead")
+		return
+	}
+
+	globalLogger = logger
+}
+
+// OverrideLogger allows baseplate v2 to override the global logger irrevocably.
+func OverrideLogger(logger *zap.SugaredLogger) {
+	atomic.StoreUint64(&v0logDisabled, 1)
+	globalLogger = logger
+}

--- a/log/context.go
+++ b/log/context.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/reddit/baseplate.go/detach"
+	"github.com/reddit/baseplate.go/internalv2compat"
 )
 
 type contextKeyType struct{}
@@ -104,5 +105,5 @@ func C(ctx context.Context) *zap.SugaredLogger {
 	if logger, ok := ctx.Value(contextKey).(*zap.SugaredLogger); ok && logger != nil {
 		return logger
 	}
-	return globalLogger
+	return internalv2compat.GlobalLogger()
 }

--- a/log/context.go
+++ b/log/context.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/reddit/baseplate.go/detach"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 )
 

--- a/log/log.go
+++ b/log/log.go
@@ -4,6 +4,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 )
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,28 +1,11 @@
 package log
 
 import (
-	"os"
-
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-)
 
-// globalLogger is used by all top-level log methods (e.g. Infof).
-//
-// Before the Init methods are called, this logger will use a very basic config
-// that includes a `pre_init` key to distinguish this condition.
-var globalLogger = zap.New(
-	zapcore.NewCore(
-		zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
-		os.Stderr,
-		zapcore.DebugLevel,
-	),
-	zap.Fields(
-		zap.Bool("pre_init", true),
-	),
-).WithOptions(
-	zap.AddCallerSkip(1), // will always be called via a top-level function from this package
-).Sugar()
+	"github.com/reddit/baseplate.go/internalv2compat"
+)
 
 // Level is the verbose representation of log level
 type Level string
@@ -110,7 +93,7 @@ func InitLoggerJSON(logLevel Level) {
 // OutputPaths and ErrorOutputPaths.
 func InitLoggerWithConfig(logLevel Level, cfg zap.Config) error {
 	if logLevel == NopLevel {
-		globalLogger = zap.NewNop().Sugar()
+		internalv2compat.SetGlobalLogger(zap.NewNop().Sugar())
 		return nil
 	}
 	l, err := cfg.Build(
@@ -122,85 +105,85 @@ func InitLoggerWithConfig(logLevel Level, cfg zap.Config) error {
 	if err != nil {
 		return err
 	}
-	globalLogger = l.Sugar()
+	internalv2compat.SetGlobalLogger(l.Sugar())
 	if Version != "" {
-		globalLogger = globalLogger.With(zap.String(VersionLogKey, Version))
+		internalv2compat.SetGlobalLogger(internalv2compat.GlobalLogger().With(zap.String(VersionLogKey, Version)))
 	}
 	return nil
 }
 
 // Debug uses fmt.Sprint to construct and log a message.
 func Debug(args ...interface{}) {
-	globalLogger.Debug(args...)
+	internalv2compat.GlobalLogger().Debug(args...)
 }
 
 // Info uses fmt.Sprint to construct and log a message.
 func Info(args ...interface{}) {
-	globalLogger.Info(args...)
+	internalv2compat.GlobalLogger().Info(args...)
 }
 
 // Warn uses fmt.Sprint to construct and log a message.
 func Warn(args ...interface{}) {
-	globalLogger.Warn(args...)
+	internalv2compat.GlobalLogger().Warn(args...)
 }
 
 // Error uses fmt.Sprint to construct and log a message.
 func Error(args ...interface{}) {
-	globalLogger.Error(args...)
+	internalv2compat.GlobalLogger().Error(args...)
 }
 
 // DPanic uses fmt.Sprint to construct and log a message.
 //
 // In development, the logger then panics. (See DPanicLevel for details.)
 func DPanic(args ...interface{}) {
-	globalLogger.DPanic(args...)
+	internalv2compat.GlobalLogger().DPanic(args...)
 }
 
 // Panic uses fmt.Sprint to construct and log a message, then panics.
 func Panic(args ...interface{}) {
-	globalLogger.Panic(args...)
+	internalv2compat.GlobalLogger().Panic(args...)
 }
 
 // Fatal uses fmt.Sprint to construct and log a message, then calls os.Exit.
 func Fatal(args ...interface{}) {
-	globalLogger.Fatal(args...)
+	internalv2compat.GlobalLogger().Fatal(args...)
 }
 
 // Debugf uses fmt.Sprintf to log a templated message.
 func Debugf(template string, args ...interface{}) {
-	globalLogger.Debugf(template, args...)
+	internalv2compat.GlobalLogger().Debugf(template, args...)
 }
 
 // Infof uses fmt.Sprintf to log a templated message.
 func Infof(template string, args ...interface{}) {
-	globalLogger.Infof(template, args...)
+	internalv2compat.GlobalLogger().Infof(template, args...)
 }
 
 // Warnf uses fmt.Sprintf to log a templated message.
 func Warnf(template string, args ...interface{}) {
-	globalLogger.Warnf(template, args...)
+	internalv2compat.GlobalLogger().Warnf(template, args...)
 }
 
 // Errorf uses fmt.Sprintf to log a templated message.
 func Errorf(template string, args ...interface{}) {
-	globalLogger.Errorf(template, args...)
+	internalv2compat.GlobalLogger().Errorf(template, args...)
 }
 
 // DPanicf uses fmt.Sprintf to log a templated message.
 //
 // In development, the logger then panics. (See DPanicLevel for details.)
 func DPanicf(template string, args ...interface{}) {
-	globalLogger.DPanicf(template, args...)
+	internalv2compat.GlobalLogger().DPanicf(template, args...)
 }
 
 // Panicf uses fmt.Sprintf to log a templated message, then panics.
 func Panicf(template string, args ...interface{}) {
-	globalLogger.Panicf(template, args...)
+	internalv2compat.GlobalLogger().Panicf(template, args...)
 }
 
 // Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit.
 func Fatalf(template string, args ...interface{}) {
-	globalLogger.Fatalf(template, args...)
+	internalv2compat.GlobalLogger().Fatalf(template, args...)
 }
 
 // Debugw logs a message with some additional context.
@@ -211,28 +194,28 @@ func Fatalf(template string, args ...interface{}) {
 //
 //     With(keysAndValues).Debug(msg)
 func Debugw(msg string, keysAndValues ...interface{}) {
-	globalLogger.Debugw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Debugw(msg, keysAndValues...)
 }
 
 // Infow logs a message with some additional context.
 //
 // The variadic key-value pairs are treated as they are in With.
 func Infow(msg string, keysAndValues ...interface{}) {
-	globalLogger.Infow(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Infow(msg, keysAndValues...)
 }
 
 // Warnw logs a message with some additional context.
 //
 // The variadic key-value pairs are treated as they are in With.
 func Warnw(msg string, keysAndValues ...interface{}) {
-	globalLogger.Warnw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Warnw(msg, keysAndValues...)
 }
 
 // Errorw logs a message with some additional context.
 //
 // The variadic key-value pairs are treated as they are in With.
 func Errorw(msg string, keysAndValues ...interface{}) {
-	globalLogger.Errorw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Errorw(msg, keysAndValues...)
 }
 
 // DPanicw logs a message with some additional context.
@@ -241,29 +224,29 @@ func Errorw(msg string, keysAndValues ...interface{}) {
 //
 // The variadic key-value pairs are treated as they are in With.
 func DPanicw(msg string, keysAndValues ...interface{}) {
-	globalLogger.DPanicw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().DPanicw(msg, keysAndValues...)
 }
 
 // Panicw logs a message with some additional context, then panics.
 //
 // The variadic key-value pairs are treated as they are in With.
 func Panicw(msg string, keysAndValues ...interface{}) {
-	globalLogger.Panicw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Panicw(msg, keysAndValues...)
 }
 
 // Fatalw logs a message with some additional context, then calls os.Exit.
 //
 // The variadic key-value pairs are treated as they are in With.
 func Fatalw(msg string, keysAndValues ...interface{}) {
-	globalLogger.Fatalw(msg, keysAndValues...)
+	internalv2compat.GlobalLogger().Fatalw(msg, keysAndValues...)
 }
 
 // Sync flushes any buffered log entries.
 func Sync() error {
-	return globalLogger.Sync()
+	return internalv2compat.GlobalLogger().Sync()
 }
 
 // With wraps around the underline logger's With.
 func With(args ...interface{}) *zap.SugaredLogger {
-	return globalLogger.With(args...)
+	return internalv2compat.GlobalLogger().With(args...)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 )
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/reddit/baseplate.go/internalv2compat"
 )
 
 func TestZapLogger(t *testing.T) {
 	InitLogger(DebugLevel)
-	log(globalLogger)
+	log(internalv2compat.GlobalLogger())
 
 	Version = "test-version"
 	InitLoggerJSON(DebugLevel)
-	log(globalLogger)
+	log(internalv2compat.GlobalLogger())
 }
 
 func TestInitSentry(t *testing.T) {


### PR DESCRIPTION
## 💸 TL;DR
This PR introduces the hooks necessary for the upcoming v2 compatibility module.
This does not introduce any new user-facing APIs, and it is very clearly indicated that this is not to be used by users.

## 📜 Details
See BASE-29.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
