### PR TITLE
Allow detecting HTTP and Thrift implementations of baseplate.Server without using reflection

### DIFF
--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
 )

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
 )
 
@@ -225,12 +226,14 @@ func NewBaseplateServer(args ServerArgs) (baseplate.Server, error) {
 	for _, f := range args.OnShutdown {
 		srv.RegisterOnShutdown(f)
 	}
-	return &server{args.Baseplate, srv}, nil
+	return &server{bp: args.Baseplate, srv: srv}, nil
 }
 
 type server struct {
 	bp  baseplate.Baseplate
 	srv *http.Server
+
+	internalv2compat.IsHTTP
 }
 
 func (s server) Baseplate() baseplate.Baseplate {

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -53,3 +53,13 @@ func OverrideLogger(logger *zap.SugaredLogger) {
 	atomic.StoreUint64(&v0logDisabled, 1)
 	globalLogger = logger
 }
+
+// IsHTTP allows detecting the unexported httpbp.server without resorting to reflection.
+type IsHTTP interface {
+	isHTTP()
+}
+
+// IsThrift allows detecting the unexported thriftbp.server without resorting to reflection.
+type IsThrift interface {
+	isThrift()
+}

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -6,12 +6,11 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	"github.com/reddit/baseplate.go/internalv2compat"
-	"github.com/reddit/baseplate.go/metricsbp"
-
 	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/metricsbp"
 )
 
 const (

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/reddit/baseplate.go"
 	"github.com/reddit/baseplate.go/errorsbp"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/apache/thrift/lib/go/thrift"
+
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/metricsbp"
 
 	"github.com/reddit/baseplate.go"
@@ -181,6 +183,8 @@ func ApplyBaseplate(bp baseplate.Baseplate, server *thrift.TSimpleServer) basepl
 type impl struct {
 	bp  baseplate.Baseplate
 	srv *thrift.TSimpleServer
+
+	internalv2compat.IsThrift
 }
 
 func (s impl) Baseplate() baseplate.Baseplate {


### PR DESCRIPTION
For v2 interop, I want to know what protocol the baseplate.Server implements so we can automatically wire up health checks.