### PR TITLE
thriftbp: Fix panic caused by typed-nil

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -430,8 +430,11 @@ func getClientError(result thrift.TStruct, err error) error {
 		if typ.Field(i).Name == "Success" {
 			continue
 		}
-		field := v.Field(i).Interface()
-		tExc, ok := field.(thrift.TException)
+		field := v.Field(i)
+		if field.IsZero() {
+			continue
+		}
+		tExc, ok := field.Interface().(thrift.TException)
 		if ok && tExc != nil && tExc.TExceptionType() == thrift.TExceptionTypeCompiled {
 			return tExc
 		}


### PR DESCRIPTION
cccd1f1 would cause panic because of typed nil:

    panic: value method path/to/baseplate.Error.TExceptionType called using nil *Error pointer

Check reflect value's IsZero instead.