### PR TITLE
upgrade log to panic

### DIFF
--- a/httpbp/admin.go
+++ b/httpbp/admin.go
@@ -21,6 +21,6 @@ func ServeAdmin(healthCheck HandlerFunc) {
 	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
 		log.Info("httpbp: server closed")
 	} else {
-		log.Panicw("httpbp: admin serving exited", "err", err)
+		log.Panicw("httpbp: admin serving failed", "err", err)
 	}
 }

--- a/httpbp/admin.go
+++ b/httpbp/admin.go
@@ -1,6 +1,9 @@
 package httpbp
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/reddit/baseplate.go/internal/admin"
 	"github.com/reddit/baseplate.go/log"
 )
@@ -15,5 +18,9 @@ import (
 // This function blocks, so it should be run as its own goroutine.
 func ServeAdmin(healthCheck HandlerFunc) {
 	admin.Mux.Handle("/health", handler{handle: healthCheck})
-	log.Warnw("httpbp: admin serving exited", "err", admin.Serve())
+	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
+		log.Info("httpbp: server closed")
+	} else {
+		log.Panicw("httpbp: admin serving exited", "err", err)
+	}
 }

--- a/httpbp/admin.go
+++ b/httpbp/admin.go
@@ -19,7 +19,7 @@ import (
 func ServeAdmin(healthCheck HandlerFunc) {
 	admin.Mux.Handle("/health", handler{handle: healthCheck})
 	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
-		log.Info("httpbp: server closed")
+		log.Info("httpbp: admin server closed")
 	} else {
 		log.Panicw("httpbp: admin serving failed", "err", err)
 	}

--- a/thriftbp/admin.go
+++ b/thriftbp/admin.go
@@ -19,6 +19,6 @@ func ServeAdmin() {
 	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
 		log.Info("thriftbp: server closed")
 	} else {
-		log.Panicw("thriftbp: admin serving exited", "err", err)
+		log.Panicw("thriftbp: admin serving failed", "err", err)
 	}
 }

--- a/thriftbp/admin.go
+++ b/thriftbp/admin.go
@@ -13,5 +13,5 @@ import (
 //
 // This function blocks, so it should be run as its own goroutine.
 func ServeAdmin() {
-	log.Warnw("thriftbp: admin serving exited", "err", admin.Serve())
+	log.Panicw("thriftbp: admin serving exited", "err", admin.Serve())
 }

--- a/thriftbp/admin.go
+++ b/thriftbp/admin.go
@@ -17,7 +17,7 @@ import (
 // This function blocks, so it should be run as its own goroutine.
 func ServeAdmin() {
 	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
-		log.Info("thriftbp: server closed")
+		log.Info("thriftbp: admin server closed")
 	} else {
 		log.Panicw("thriftbp: admin serving failed", "err", err)
 	}

--- a/thriftbp/admin.go
+++ b/thriftbp/admin.go
@@ -1,6 +1,9 @@
 package thriftbp
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/reddit/baseplate.go/internal/admin"
 	"github.com/reddit/baseplate.go/log"
 )
@@ -13,5 +16,9 @@ import (
 //
 // This function blocks, so it should be run as its own goroutine.
 func ServeAdmin() {
-	log.Panicw("thriftbp: admin serving exited", "err", admin.Serve())
+	if err := admin.Serve(); errors.Is(err, http.ErrServerClosed) {
+		log.Info("thriftbp: server closed")
+	} else {
+		log.Panicw("thriftbp: admin serving exited", "err", err)
+	}
 }


### PR DESCRIPTION
## 💸 TL;DR
Currently, if the `admin.Serve()` crashes, the resulting error is logged with a warning and the process keeps chugging along without everything it provides (like metrics). Upgrading the log to a Panicw will cause the go routine to panic and crash the program meaning the software can never be in a state where the metics server is not also running successfully.

## 🧪 Testing Steps / Validation
Test suite ran with `make test`
