### PR TITLE
Update kafka offset commit frequency to 5s

### DIFF
--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -101,11 +101,11 @@ type ConsumerConfig struct {
 	// You are advised to test before using non-empty rack id in production.
 	RackID RackIDFunc `yaml:"rackID"`
 
-	// Optional. Defaults to 5. Values are in seconds.
+	// Optional. Defaults to 5 seconds.
 	//
 	// This affects how often the kafka consumer writes its offsets back to
 	// the cluster.
-	AutoCommitInterval time.Duration `yaml:"autoCommitInterval"`
+	AutoCommitIntervalSeconds int `yaml:"autoCommitInterval"`
 }
 
 // Since not all sarama's default config are zero values,
@@ -147,8 +147,8 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 
 	// Set the commit frequency to 5 seconds or other config value if provided
 	c.Consumer.Offsets.AutoCommit.Enable = true
-	if cfg.AutoCommitInterval != 0 {
-		c.Consumer.Offsets.AutoCommit.Interval = cfg.AutoCommitInterval * time.Second
+	if cfg.AutoCommitIntervalSeconds != 0 {
+		c.Consumer.Offsets.AutoCommit.Interval = time.Duration(cfg.AutoCommitIntervalSeconds) * time.Second
 	} else {
 		c.Consumer.Offsets.AutoCommit.Interval = 5 * time.Second
 	}

--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -3,6 +3,7 @@ package kafkabp
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/Shopify/sarama"
 

--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -101,7 +101,7 @@ type ConsumerConfig struct {
 	// You are advised to test before using non-empty rack id in production.
 	RackID RackIDFunc `yaml:"rackID"`
 
-	// Optional. Defaults to 5s. Values are in seconds.
+	// Optional. Defaults to 5. Values are in seconds.
 	//
 	// This affects how often the kafka consumer writes its offsets back to
 	// the cluster.
@@ -145,7 +145,7 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 	// Return any errors that occurred to the Errors channel.
 	c.Consumer.Return.Errors = true
 
-	// Set the commit frequency to 5s or other config value if provided
+	// Set the commit frequency to 5 seconds or other config value if provided
 	c.Consumer.Offsets.AutoCommit.Enable = true
 	if cfg.AutoCommitInterval != 0 {
 		c.Consumer.Offsets.AutoCommit.Interval = time.Duration(cfg.AutoCommitInterval) * time.Second

--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -138,6 +138,10 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 	// Return any errors that occurred to the Errors channel.
 	c.Consumer.Return.Errors = true
 
+	// Set the commit frequency to 5s
+	c.Consumer.Offsets.AutoCommit.Enable = true
+	c.Consumer.Offsets.AutoCommit.Interval = 5 * time.Second
+
 	c.ClientID = cfg.ClientID
 	c.Version = version
 

--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -105,7 +105,7 @@ type ConsumerConfig struct {
 	//
 	// This affects how often the kafka consumer writes its offsets back to
 	// the cluster.
-	AutoCommitInterval int `yaml:"autoCommitInterval"`
+	AutoCommitInterval time.Duration `yaml:"autoCommitInterval"`
 }
 
 // Since not all sarama's default config are zero values,
@@ -148,7 +148,7 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 	// Set the commit frequency to 5 seconds or other config value if provided
 	c.Consumer.Offsets.AutoCommit.Enable = true
 	if cfg.AutoCommitInterval != 0 {
-		c.Consumer.Offsets.AutoCommit.Interval = time.Duration(cfg.AutoCommitInterval) * time.Second
+		c.Consumer.Offsets.AutoCommit.Interval = cfg.AutoCommitInterval * time.Second
 	} else {
 		c.Consumer.Offsets.AutoCommit.Interval = 5 * time.Second
 	}

--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -145,7 +145,7 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 	// Return any errors that occurred to the Errors channel.
 	c.Consumer.Return.Errors = true
 
-	// Set the commit frequency to 5 seconds or other config value if provided
+	// Set the kafka offset commit frequency to 5 seconds or other config value if provided
 	c.Consumer.Offsets.AutoCommit.Enable = true
 	if cfg.AutoCommitIntervalSeconds != 0 {
 		c.Consumer.Offsets.AutoCommit.Interval = time.Duration(cfg.AutoCommitIntervalSeconds) * time.Second

--- a/kafkabp/config_test.go
+++ b/kafkabp/config_test.go
@@ -110,7 +110,7 @@ func TestConsumerConfig(t *testing.T) {
 		}
 	})
 
-	cfg.AutoCommitInterval = 8
+	cfg.AutoCommitIntervalSeconds = 8
 	t.Run("auto-commit-interval", func(t *testing.T) {
 		sc, err := cfg.NewSaramaConfig()
 		if err != nil {
@@ -124,7 +124,7 @@ func TestConsumerConfig(t *testing.T) {
 		}
 	})
 
-	cfg.AutoCommitInterval = 0
+	cfg.AutoCommitIntervalSeconds = 0
 	t.Run("no-auto-commit-interval", func(t *testing.T) {
 		sc, err := cfg.NewSaramaConfig()
 		if err != nil {

--- a/kafkabp/config_test.go
+++ b/kafkabp/config_test.go
@@ -3,6 +3,7 @@ package kafkabp_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/reddit/baseplate.go/kafkabp"
 )
@@ -106,6 +107,34 @@ func TestConsumerConfig(t *testing.T) {
 		}
 		if sc.RackID != "" {
 			t.Errorf("expected sarama rack id to be empty, got %q", sc.ClientID)
+		}
+	})
+
+	cfg.AutoCommitInterval = 8
+	t.Run("auto-commit-interval", func(t *testing.T) {
+		sc, err := cfg.NewSaramaConfig()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if sc == nil {
+			t.Fatal("expected config to be non-nil, got nil")
+		}
+		if sc.Consumer.Offsets.AutoCommit.Interval != 8 * time.Second {
+			t.Errorf("expected auto-commit interval to be %q, got %q", 8, sc.Consumer.Offsets.AutoCommit.Interval)
+		}
+	})
+
+	cfg.AutoCommitInterval = 0
+	t.Run("no-auto-commit-interval", func(t *testing.T) {
+		sc, err := cfg.NewSaramaConfig()
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if sc == nil {
+			t.Fatal("expected config to be non-nil, got nil")
+		}
+		if sc.Consumer.Offsets.AutoCommit.Interval != 5 * time.Second {
+			t.Errorf("expected auto-commit interval to be %q, got %q", 5, sc.Consumer.Offsets.AutoCommit.Interval)
 		}
 	})
 }

--- a/kafkabp/config_test.go
+++ b/kafkabp/config_test.go
@@ -119,7 +119,7 @@ func TestConsumerConfig(t *testing.T) {
 		if sc == nil {
 			t.Fatal("expected config to be non-nil, got nil")
 		}
-		if sc.Consumer.Offsets.AutoCommit.Interval != 8 * time.Second {
+		if sc.Consumer.Offsets.AutoCommit.Interval != 8*time.Second {
 			t.Errorf("expected auto-commit interval to be %q, got %q", 8, sc.Consumer.Offsets.AutoCommit.Interval)
 		}
 	})
@@ -133,7 +133,7 @@ func TestConsumerConfig(t *testing.T) {
 		if sc == nil {
 			t.Fatal("expected config to be non-nil, got nil")
 		}
-		if sc.Consumer.Offsets.AutoCommit.Interval != 5 * time.Second {
+		if sc.Consumer.Offsets.AutoCommit.Interval != 5*time.Second {
 			t.Errorf("expected auto-commit interval to be %q, got %q", 5, sc.Consumer.Offsets.AutoCommit.Interval)
 		}
 	})


### PR DESCRIPTION
The kafka library we use [defaults](https://github.com/Shopify/sarama/blob/main/config.go#L370-L387) to committing offsets every 1 second. Frequent offset commits can be hard on kafka clusters if there are many consumers, so lets change the default to commit a bit less frequently (Kafka's default is every 5s). This was successfully tested on one baseplate service already, so I'm confident it works.