### PR TITLE
runtimebp: Extend GOMAXPROCS logic to account for additional scenarios

### DIFF
--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -34,7 +34,7 @@ func InitFromConfig(cfg Config) {
 			v,
 		)
 	} else {
-		prev, current := GOMAXPROCS(2, math.MaxInt)
+		prev, current := GOMAXPROCS(defaultMultiplier, math.MaxInt)
 		fmt.Fprintf(os.Stderr, "GOMAXPROCS: Old: %d New: %d\n", prev, current)
 	}
 }

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -34,7 +34,7 @@ func InitFromConfig(cfg Config) {
 			v,
 		)
 	} else {
-		prev, current := GOMAXPROCS(1, math.MaxInt)
+		prev, current := GOMAXPROCS(2, math.MaxInt)
 		fmt.Fprintf(os.Stderr, "GOMAXPROCS: Old: %d New: %d\n", prev, current)
 	}
 }

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 )
 
+var millicoreRegexp = regexp.MustCompile(`^(P<millis>[1-9][0-9]*)m$`)
+
 // NumCPU returns the number of CPUs assigned to this running container.
 //
 // This is the container aware version of runtime.NumCPU.
@@ -167,7 +169,6 @@ func fetchCPURequest() (int, error) {
 			// k8s automatically rounds it up to the nearest integer unit.  That's how
 			// we plan to set this variable, but just in case it might be worth doing this
 			// check in case they ever break that.  There's no official contract for that.
-			millicoreRegexp := regexp.MustCompile(`^(P<millis>[1-9][0-9]*)m$`)
 			match := millicoreRegexp.FindStringSubmatch(v)
 			if match == nil {
 				fmt.Fprintf(

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -133,7 +133,7 @@ func defaultMaxProcsFormula(n float64) int {
 
 func scaledMaxProcsFormula(n float64) int {
 	i := fetchMaxProcsMult()
-	return int(math.Ceil(n) * float64(i))
+	return int(math.Ceil(n * float64(i)))
 }
 
 func fetchMaxProcsMult() int {

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -179,7 +179,7 @@ func fetchCPURequest() (int, error) {
 			} else {
 				m, err := strconv.Atoi(match[0])
 				if err != nil {
-					req = int(math.Ceil(float64(m / 1000.0)))
+					req = int(math.Ceil(float64(m) / 1000.0))
 				} else {
 					fmt.Fprintf(
 						os.Stderr,
@@ -187,8 +187,8 @@ func fetchCPURequest() (int, error) {
 						req,
 						err,
 					)
+					req = 1
 				}
-				req = 1
 			}
 		}
 		return scaledMaxProcsFormula(float64(req)), nil

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -162,6 +162,11 @@ func fetchCPURequest() (int, error) {
 	if v, ok := os.LookupEnv("CPUREQUEST"); ok {
 		req, err := strconv.Atoi(v)
 		if err != nil {
+			// This case will probably never be hit, but I'm keeping it just in case.
+			// In k8s 1.21 and newer, when you present the CPU request via the Downward API
+			// k8s automatically rounds it up to the nearest integer unit.  That's how
+			// we plan to set this variable, but just in case it might be worth doing this
+			// check in case they ever break that.  There's no official contract for that.
 			millicoreRegexp := regexp.MustCompile(`^(P<millis>[1-9][0-9]*)m$`)
 			match := millicoreRegexp.FindStringSubmatch(v)
 			if match == nil {

--- a/runtimebp/cpu_test.go
+++ b/runtimebp/cpu_test.go
@@ -185,3 +185,55 @@ func TestBoundNtoMinMax(t *testing.T) {
 		})
 	}
 }
+
+func TestFetchCPURequest(t *testing.T) {
+	cases := map[string]struct {
+		N        string
+		Expected int
+		Ok       bool
+	}{
+		"plainInt": {
+			N:        "3",
+			Expected: 6,
+			Ok:       true,
+		},
+		"goodMilliLessThanOne": {
+			N:        "500m",
+			Expected: 2,
+			Ok:       true,
+		},
+		"goodMilliGreaterThanOne": {
+			N:        "1400m",
+			Expected: 3,
+			Ok:       true,
+		},
+		"badMilli": {
+			N:        "0m",
+			Expected: 2,
+			Ok:       true,
+		},
+		"noMilli": {
+			N:        "",
+			Expected: 0,
+			Ok:       false,
+		},
+	}
+
+	for label, data := range cases {
+		t.Run(label, func(t *testing.T) {
+			if data.N == "" {
+				os.Unsetenv("BASEPLATE_CPU_REQUEST")
+			} else {
+				os.Setenv("BASEPLATE_CPU_REQUEST", data.N)
+				defer os.Unsetenv("BASEPLATE_CPU_REQUEST")
+			}
+			actual, ok := fetchCPURequest()
+			if actual != data.Expected {
+				t.Errorf("Got %d for data %+v", actual, data)
+			}
+			if data.Ok != ok {
+				t.Errorf("Got %v for ok check on %+v", ok, data)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On discussion with kevlar, we came to the conclusion that there should be
4 possible settings for GOMAXPROCS which should cover all needs and
ensure adequate automation.  These are:
1. GOMAXPROCS if provided,
2. limit if known (with configurable multiplier),
3. fallback to a known environment variable Infrared can provide,
4. exactly 2 (for minimum parallelism)

By providing this hierarchy, we give maximum flexibility for devs,
while also providing safe and sane guardrails to work with, and
never end up in a scenario where bp.go tries to use physical core count.