### PR TITLE
runtimebp: New GOMAXPROCS heuristic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prometheus/client_model v0.2.0
 	github.com/sony/gobreaker v0.4.1
+	go.uber.org/automaxprocs v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886
 	google.golang.org/grpc v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
@@ -391,8 +392,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -435,6 +436,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/automaxprocs v1.5.1 h1:e1YG66Lrk73dn4qhg8WFSvhF0JuFQF0ERIp4rpuV8Qk=
+go.uber.org/automaxprocs v1.5.1/go.mod h1:BF4eumQw0P9GtnuxxovUd06vwm1o18oMzFtK66vU6XU=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -1,9 +1,7 @@
 package runtimebp
 
 import (
-	"fmt"
-	"math"
-	"os"
+	"github.com/reddit/baseplate.go/runtimebp/internal/maxprocs"
 )
 
 // Config is the configuration struct for the runtimebp package.
@@ -20,21 +18,8 @@ type Config struct {
 	} `yaml:"numProcesses"`
 }
 
-// InitFromConfig sets GOMAXPROCS using the given config.
-//
-// NOTE: If the GOMAXPROCS environment variable is set,
-// this function will skip setting GOMAXPROCS,
-// even if the environment variable is set to some bogus value
-// (in that case it will be set to number of physical CPUs).
-func InitFromConfig(cfg Config) {
-	if v, ok := os.LookupEnv("GOMAXPROCS"); ok {
-		fmt.Fprintf(
-			os.Stderr,
-			"runtimebp.InitFromConfig: GOMAXPROCS environment variable is set to %q, skipping setting GOMAXPROCS.",
-			v,
-		)
-	} else {
-		prev, current := GOMAXPROCS(1, math.MaxInt)
-		fmt.Fprintf(os.Stderr, "GOMAXPROCS: Old: %d New: %d\n", prev, current)
-	}
+// InitFromConfig sets GOMAXPROCS based on an overridable heuristic described in maxprocs.
+// N.B. It does NOT respect the passed-in config.
+func InitFromConfig(_ Config) {
+	maxprocs.Set()
 }

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -18,7 +18,15 @@ type Config struct {
 	} `yaml:"numProcesses"`
 }
 
-// InitFromConfig sets GOMAXPROCS based on an overridable heuristic described in maxprocs.
+// InitFromConfig configures the runtime's GOMAXPROCS using the following heuristic:
+//   1. If $GOMAXPROCS is set, it relinquishes control to the Go runtime.
+//      This should cause the runtime to respect this value directly.
+//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, it relinquishes control to automaxprocs, minimum 2.
+//      See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
+//   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
+//      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
+//
+// InitFromConfig also exports several metrics to facilitate further tuning/analysis.
 //
 // NOTE: It does NOT respect the passed-in config.
 func InitFromConfig(_ Config) {

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -19,12 +19,13 @@ type Config struct {
 }
 
 // InitFromConfig configures the runtime's GOMAXPROCS using the following heuristic:
-//   1. If $GOMAXPROCS is set, it relinquishes control to the Go runtime.
-//      This should cause the runtime to respect this value directly.
-//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, it relinquishes control to automaxprocs, minimum 2.
-//      See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
-//   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
-//      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
+//
+// 1. If $GOMAXPROCS is set, it relinquishes control to the Go runtime.
+//    This should cause the runtime to respect this value directly.
+// 2. If $BASEPLATE_CPU_REQUEST is unset/invalid, it relinquishes control to automaxprocs, minimum 2.
+//    See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
+// 3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
+//    (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
 //
 // InitFromConfig also exports several metrics to facilitate further tuning/analysis.
 //

--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -19,7 +19,8 @@ type Config struct {
 }
 
 // InitFromConfig sets GOMAXPROCS based on an overridable heuristic described in maxprocs.
-// N.B. It does NOT respect the passed-in config.
+//
+// NOTE: It does NOT respect the passed-in config.
 func InitFromConfig(_ Config) {
 	maxprocs.Set()
 }

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -23,7 +23,12 @@ import (
 // or if there's no limit set in cgroup,
 // it will fallback to runtime.NumCPU() instead.
 //
-// Deprecated: NumCPU is deprecated. Instead, tune GOMAXPROCS as described in runtimebp.InitFromConfig.
+// Depending on your application, $BASEPLATE_CPU_REQUEST may also be helpful.
+// Infrared sets $BASEPLATE_CPU_REQUEST to the container's Kubernetes CPU
+// _request_ (rather than _limit_ as this function returns), rounded up to the
+// nearest whole CPU.
+//
+// To tune GOMAXPROCS, see runtimebp.InitFromConfig.
 func NumCPU() float64 {
 	// Big enough buffer to read the numbers in the files wholly into memory.
 	buf := make([]byte, 1024)

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -22,6 +22,8 @@ import (
 // If the current process is not running inside a container,
 // or if there's no limit set in cgroup,
 // it will fallback to runtime.NumCPU() instead.
+//
+// Deprecated: NumCPU is deprecated. See runtimebp/internal/maxprocs.
 func NumCPU() float64 {
 	// Big enough buffer to read the numbers in the files wholly into memory.
 	buf := make([]byte, 1024)
@@ -131,12 +133,16 @@ func defaultMaxProcsFormula(n float64) int {
 // in bound of [min, max].
 //
 // Currently the default formula is NumCPU() rounding up.
+//
+// Deprecated: GOMAXPROCS is deprecated. See runtimebp/internal/maxprocs.
 func GOMAXPROCS(min, max int) (oldVal, newVal int) {
 	return GOMAXPROCSwithFormula(min, max, defaultMaxProcsFormula)
 }
 
 // GOMAXPROCSwithFormula sets runtime.GOMAXPROCS with the given formula,
 // in bound of [min, max].
+//
+// Deprecated: GOMAXPROCSwithFormula is deprecated. See runtimebp/internal/maxprocs.
 func GOMAXPROCSwithFormula(min, max int, formula MaxProcsFormula) (oldVal, newVal int) {
 	newVal = boundNtoMinMax(formula(NumCPU()), min, max)
 	oldVal = runtime.GOMAXPROCS(newVal)

--- a/runtimebp/cpu.go
+++ b/runtimebp/cpu.go
@@ -23,7 +23,7 @@ import (
 // or if there's no limit set in cgroup,
 // it will fallback to runtime.NumCPU() instead.
 //
-// Deprecated: NumCPU is deprecated. See runtimebp/internal/maxprocs.
+// Deprecated: NumCPU is deprecated. Instead, tune GOMAXPROCS as described in runtimebp.InitFromConfig.
 func NumCPU() float64 {
 	// Big enough buffer to read the numbers in the files wholly into memory.
 	buf := make([]byte, 1024)
@@ -134,7 +134,7 @@ func defaultMaxProcsFormula(n float64) int {
 //
 // Currently the default formula is NumCPU() rounding up.
 //
-// Deprecated: GOMAXPROCS is deprecated. See runtimebp/internal/maxprocs.
+// Deprecated: GOMAXPROCS is deprecated. Instead, tune GOMAXPROCS as described in runtimebp.InitFromConfig.
 func GOMAXPROCS(min, max int) (oldVal, newVal int) {
 	return GOMAXPROCSwithFormula(min, max, defaultMaxProcsFormula)
 }
@@ -142,7 +142,7 @@ func GOMAXPROCS(min, max int) (oldVal, newVal int) {
 // GOMAXPROCSwithFormula sets runtime.GOMAXPROCS with the given formula,
 // in bound of [min, max].
 //
-// Deprecated: GOMAXPROCSwithFormula is deprecated. See runtimebp/internal/maxprocs.
+// Deprecated: GOMAXPROCSwithFormula is deprecated. Instead, tune GOMAXPROCS as described in runtimebp.InitFromConfig.
 func GOMAXPROCSwithFormula(min, max int, formula MaxProcsFormula) (oldVal, newVal int) {
 	newVal = boundNtoMinMax(formula(NumCPU()), min, max)
 	oldVal = runtime.GOMAXPROCS(newVal)

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -86,7 +86,9 @@ func Set() {
 	}
 
 	setBy := setByGOMAXPROCS
-	defer func() { initialGOMAXPROCS.WithLabelValues(setBy).Set(currentGOMAXPROCS()) }()
+	defer func() {
+		initialGOMAXPROCS.WithLabelValues(setBy).Set(currentGOMAXPROCS())
+	}()
 
 	if envGOMAXPROCS.present {
 		return // let Go runtime handle it

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -71,7 +71,7 @@ var (
 //   1. If $GOMAXPROCS is set, Set relinquishes control to the Go runtime.
 //      This should cause the runtime to respect this value directly.
 //   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to automaxprocs, minimum 2.
-//      See automaxprocs' package documentation for specific behavior.
+//      See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
 //   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
 //      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
 //

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -68,7 +68,7 @@ var (
 // Set configures the runtime's GOMAXPROCS using the following heuristic:
 //   1. If $GOMAXPROCS is set, Set relinquishes control to the Go runtime.
 //      This should cause the runtime to respect this value directly.
-//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to automaxprocs.
+//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to automaxprocs, minimum 2.
 //      See automaxprocs' package documentation for specific behavior.
 //   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
 //      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -79,12 +79,13 @@ var (
 )
 
 // Set configures the runtime's GOMAXPROCS using the following heuristic:
-//   1. If $GOMAXPROCS is set, Set relinquishes control to the Go runtime.
-//      This should cause the runtime to respect this value directly.
-//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to automaxprocs, minimum 2.
-//      See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
-//   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
-//      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
+//
+// 1. If $GOMAXPROCS is set, Set relinquishes control to the Go runtime.
+//    This should cause the runtime to respect this value directly.
+// 2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to automaxprocs, minimum 2.
+//    See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
+// 3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
+//    (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
 //
 // Set also exports several metrics to facilitate further tuning/analysis.
 func Set() {

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -69,7 +69,7 @@ func Set() {
 
 	for _, env := range []*floatEnv{envGOMAXPROCS, envCPURequest, envCPURequestScale} {
 		env.raw, env.present = os.LookupEnv(env.key)
-		env.val, _ = strconv.ParseFloat(env.raw, 64)
+		env.val, _ = strconv.ParseFloat(env.raw, 64) // error not needed as we check val > 0 and save raw
 		env.gauge.WithLabelValues(strconv.FormatBool(env.present)).Set(env.val)
 	}
 

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -2,6 +2,8 @@
 // It attempts to balance application performance with cluster-level resource utilization.
 // Applications may tune GOMAXPROCS as necessary (see Set).
 // The defaults in this package are subject to change.
+//
+// NOTE: this is manually copied from internal baseplate/v2/internal/maxprocs/maxprocs.go
 package maxprocs
 
 import (

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -115,7 +115,9 @@ func Set() {
 
 	if envCPURequest.val <= 0 {
 		// This should always be valid positive float in infrared-deployed applications.
-		fmt.Fprintf(os.Stderr, "maxprocs: $BASEPLATE_CPU_REQUEST=%q, want positive float. Falling back to Go's default", envCPURequest.raw)
+		fmt.Fprintf(os.Stderr, "maxprocs: $BASEPLATE_CPU_REQUEST=%q, want positive float. Falling back to automaxprocs", envCPURequest.raw)
+		setBy = setByAutomaxprocs
+		setWithAutomaxprocs()
 		return
 	}
 

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -44,16 +44,27 @@ const (
 )
 
 var (
-	mEnvGOMAXPROCS      = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_gomaxprocs"}, []string{"present"})
-	mEnvCPURequest      = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_baseplate_cpu_request"}, []string{"present"})
-	mEnvCPURequestScale = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_baseplate_cpu_request_scale"}, []string{"present"})
+	mEnvGOMAXPROCS = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "baseplate_go_env_gomaxprocs",
+		Help: "Value of the GOMAXPROCS environment variable at startup. 0 if not a number",
+	}, []string{"present"})
+	mEnvCPURequest = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "baseplate_go_env_baseplate_cpu_request",
+		Help: "Value of the BASEPLATE_CPU_REQUEST environment variable at startup. 0 if not a number",
+	}, []string{"present"})
+	mEnvCPURequestScale = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "baseplate_go_env_baseplate_cpu_request_scale",
+		Help: "Value of the BASEPLATE_CPU_REQUEST_SCALE environment variable at startup. 0 if not a number",
+	}, []string{"present"})
 
 	initialGOMAXPROCS = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "baseplate_go_initial_gomaxprocs",
+		Help: "Resolved value of GOMAXPROCS at startup",
 	}, []string{"set_by"})
 
 	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "baseplate_go_current_gomaxprocs",
+		Help: "Current value of GOMAXPROCS",
 	}, currentGOMAXPROCS)
 
 	// overridable for tests

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -1,0 +1,111 @@
+// Package maxprocs optimizes GOMAXPROCS for Infrared environments.
+// It attempts to balance application performance with cluster-level resource utilization.
+// Applications may tune GOMAXPROCS as necessary (see Set).
+// The defaults in this package are subject to change.
+package maxprocs
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type floatEnv struct {
+	key   string
+	gauge *prometheus.GaugeVec
+
+	present bool
+	raw     string
+	val     float64
+}
+
+const (
+	// The default scale applies when request is set but not scale (or scale is
+	// invalid). It defaults to some "oversubscription" to take advantage of
+	// excess Kubernetes node capacity when available.
+	//
+	// Extremely performance-sensitive services should set scale to 1.0 to
+	// ensure consistent performance.
+	//
+	// This value was NOT chosen scientifically and IS subject to change.
+	defaultCPURequestScale = 1.5
+
+	setByGOMAXPROCS = "gomaxprocs"
+	setByRequest    = "cpu_request"
+)
+
+var (
+	mEnvGOMAXPROCS      = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_gomaxprocs"}, []string{"present"})
+	mEnvCPURequest      = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_baseplate_cpu_request"}, []string{"present"})
+	mEnvCPURequestScale = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "baseplate_go_env_baseplate_cpu_request_scale"}, []string{"present"})
+
+	initialGOMAXPROCS = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "baseplate_go_initial_gomaxprocs",
+	}, []string{"set_by"})
+
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: "baseplate_go_current_gomaxprocs",
+	}, currentGOMAXPROCS)
+)
+
+// Set configures the runtime's GOMAXPROCS using the following heuristic:
+//   1. If $GOMAXPROCS is set, Set relinquishes control to the Go runtime.
+//      This should cause the runtime to respect this value directly.
+//   2. If $BASEPLATE_CPU_REQUEST is unset/invalid, Set relinquishes control to the Go runtime.
+//      This should cause the runtime to use the detected number of CPUs on this machine.
+//   3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
+//      (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
+//
+// Set also exports several metrics to facilitate further tuning/analysis.
+func Set() {
+	envGOMAXPROCS := &floatEnv{key: "GOMAXPROCS", gauge: mEnvGOMAXPROCS}
+	envCPURequest := &floatEnv{key: "BASEPLATE_CPU_REQUEST", gauge: mEnvCPURequest}
+	envCPURequestScale := &floatEnv{key: "BASEPLATE_CPU_REQUEST_SCALE", gauge: mEnvCPURequestScale}
+
+	for _, env := range []*floatEnv{envGOMAXPROCS, envCPURequest, envCPURequestScale} {
+		env.raw, env.present = os.LookupEnv(env.key)
+		env.val, _ = strconv.ParseFloat(env.raw, 64)
+		env.gauge.WithLabelValues(strconv.FormatBool(env.present)).Set(env.val)
+	}
+
+	setBy := setByGOMAXPROCS
+	defer func() { initialGOMAXPROCS.WithLabelValues(setBy).Set(currentGOMAXPROCS()) }()
+
+	if envGOMAXPROCS.present {
+		return // let Go runtime handle it
+	}
+
+	if !envCPURequest.present {
+		return // let Go runtime handle it
+	}
+
+	if envCPURequest.val <= 0 {
+		// This should always be valid positive float in infrared-deployed applications.
+		fmt.Fprintf(os.Stderr, "maxprocs: $BASEPLATE_CPU_REQUEST=%q, want positive float. Falling back to Go's default", envCPURequest.raw)
+		return
+	}
+
+	scale := defaultCPURequestScale
+	if envCPURequestScale.val > 0 {
+		scale = envCPURequestScale.val
+	} else if envCPURequestScale.present {
+		fmt.Fprintf(os.Stderr, "maxprocs: $BASEPLATE_CPU_REQUEST_SCALE=%q, want positive float. Falling back to default of %g", envCPURequestScale.raw, scale)
+	}
+
+	setBy = setByRequest
+	runtime.GOMAXPROCS(int(
+		math.Max(
+			2, // to ensure some minimal parallelism
+			math.Ceil(envCPURequest.val*scale),
+		),
+	))
+}
+
+func currentGOMAXPROCS() float64 {
+	return float64(runtime.GOMAXPROCS(0))
+}

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -3,8 +3,6 @@ package maxprocs
 import (
 	"runtime"
 	"testing"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestSet(t *testing.T) {
@@ -99,11 +97,6 @@ func TestSet(t *testing.T) {
 			defer runtime.GOMAXPROCS(orig)
 			// set GOMAXPROCS to a known value
 			runtime.GOMAXPROCS(sentinel)
-
-			// clear out metrics between runs since we care about the zero value
-			for _, m := range []*prometheus.GaugeVec{mEnvGOMAXPROCS, mEnvCPURequest, mEnvCPURequestScale, initialGOMAXPROCS} {
-				m.Reset()
-			}
 
 			for k, v := range tt.env {
 				t.Setenv(k, v)

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -1,0 +1,115 @@
+package maxprocs
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestSet(t *testing.T) {
+	sentinel := 99
+
+	for _, tt := range []struct {
+		name           string
+		env            map[string]string
+		wantGOMAXPROCS int
+	}{
+		{
+			name: "GOMAXPROCS",
+			env: map[string]string{
+				"GOMAXPROCS": "42",
+			},
+			wantGOMAXPROCS: sentinel, // since our package abdicates responsibility to Go
+		},
+		{
+			name: "request_no_scale",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST": "42",
+			},
+			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
+		},
+		{
+			name: "request_with_scale",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST":       "42",
+				"BASEPLATE_CPU_REQUEST_SCALE": "0.9",
+			},
+			wantGOMAXPROCS: 38, // ceil(42 * 0.9)
+		},
+		{
+			name: "invalid_request",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST": "not a number",
+			},
+			wantGOMAXPROCS: sentinel,
+		},
+		{
+			name: "invalid_scale",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST":       "42",
+				"BASEPLATE_CPU_REQUEST_SCALE": "not a number",
+			},
+			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
+		},
+		{
+			name: "zero_request",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST": "0",
+			},
+			wantGOMAXPROCS: sentinel,
+		},
+		{
+			name: "zero_scale",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST":       "42",
+				"BASEPLATE_CPU_REQUEST_SCALE": "0",
+			},
+			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
+		},
+		{
+			name: "min_2",
+			env: map[string]string{
+				"BASEPLATE_CPU_REQUEST":       "1",
+				"BASEPLATE_CPU_REQUEST_SCALE": "1",
+			},
+			wantGOMAXPROCS: 2,
+		},
+		{
+			name: "gomaxprocs_and_request",
+			env: map[string]string{
+				"GOMAXPROCS":            "anything at all",
+				"BASEPLATE_CPU_REQUEST": "12",
+			},
+			wantGOMAXPROCS: sentinel, // since our package abdicates responsibility to Go
+		},
+		{
+			name:           "nothing_set",
+			env:            map[string]string{},
+			wantGOMAXPROCS: sentinel, // since our package abdicates responsibility to Go
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := runtime.GOMAXPROCS(0)
+			defer runtime.GOMAXPROCS(orig)
+			// set GOMAXPROCS to a known value
+			runtime.GOMAXPROCS(sentinel)
+
+			// clear out metrics between runs since we care about the zero value
+			for _, m := range []*prometheus.GaugeVec{mEnvGOMAXPROCS, mEnvCPURequest, mEnvCPURequestScale, initialGOMAXPROCS} {
+				m.Reset()
+			}
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			Set(context.Background())
+
+			if got, want := runtime.GOMAXPROCS(0), tt.wantGOMAXPROCS; got != want {
+				t.Errorf("got GOMAXPROCS=%d, want %d", got, want)
+			}
+		})
+	}
+}

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -1,7 +1,6 @@
 package maxprocs
 
 import (
-	"context"
 	"runtime"
 	"testing"
 
@@ -105,7 +104,7 @@ func TestSet(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			Set(context.Background())
+			Set()
 
 			if got, want := runtime.GOMAXPROCS(0), tt.wantGOMAXPROCS; got != want {
 				t.Errorf("got GOMAXPROCS=%d, want %d", got, want)

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -45,7 +45,7 @@ func TestSet(t *testing.T) {
 			env: map[string]string{
 				"BASEPLATE_CPU_REQUEST": "not a number",
 			},
-			wantGOMAXPROCS: sentinel,
+			wantGOMAXPROCS: automaxprocsSentinel,
 		},
 		{
 			name: "invalid_scale",
@@ -60,7 +60,7 @@ func TestSet(t *testing.T) {
 			env: map[string]string{
 				"BASEPLATE_CPU_REQUEST": "0",
 			},
-			wantGOMAXPROCS: sentinel,
+			wantGOMAXPROCS: automaxprocsSentinel,
 		},
 		{
 			name: "zero_scale",

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -9,6 +9,11 @@ import (
 
 func TestSet(t *testing.T) {
 	sentinel := 99
+	automaxprocsSentinel := 111
+
+	origAutomaxprocs := setWithAutomaxprocs
+	defer func() { setWithAutomaxprocs = origAutomaxprocs }()
+	setWithAutomaxprocs = func() { runtime.GOMAXPROCS(automaxprocsSentinel) }
 
 	for _, tt := range []struct {
 		name           string
@@ -86,7 +91,7 @@ func TestSet(t *testing.T) {
 		{
 			name:           "nothing_set",
 			env:            map[string]string{},
-			wantGOMAXPROCS: sentinel, // since our package abdicates responsibility to Go
+			wantGOMAXPROCS: automaxprocsSentinel,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## 💸 TL;DR
Recent baseplate and internal infrastructure changes have led us to revisit our GOMAXPROCS strategy. We will now set GOMAXPROCS (if not specified) based on Kubernetes CPU requests (rather than limits) with a configurable scale multiplier. 

## 📜 Details
Continuation of https://github.com/reddit/baseplate.go/pull/546.

See: [Design Doc](https://docs.google.com/document/d/10Wd96OT0WpcSStb9GFIoMRM8UTSLtj-xHx439-LgEOg/edit)

## 🧪 Testing Steps / Validation
I am working on a corresponding Infrared change to plumb through `BASEPLATE_CPU_REQUEST` to all containers and will not merge this until that is deployed.

⚠️ This is a behavior change for services running outside Reddit, and for services running inside Reddit that set their CPU limit != request (we audited this in the design doc).

Unit tests build confidence in the logic; metrics can help us build confidence and tune the heuristic.