### PR TITLE
internal/prometheusbp: Add HighWatermarkValue and HighWatermarkGauge

### DIFF
--- a/internal/prometheusbp/doc.go
+++ b/internal/prometheusbp/doc.go
@@ -1,0 +1,3 @@
+// Package prometheusbp provides common code used by Baseplate.go regarding
+// Prometheus metrics.
+package prometheusbp

--- a/internal/prometheusbp/high_watermark.go
+++ b/internal/prometheusbp/high_watermark.go
@@ -1,0 +1,111 @@
+package prometheusbp
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// HighWatermarkValue implements an int64 gauge with high watermark value.
+type HighWatermarkValue struct {
+	lock sync.RWMutex
+	curr int64
+	max  int64
+}
+
+// Inc increases the gauge value by 1.
+func (hwv *HighWatermarkValue) Inc() {
+	hwv.lock.Lock()
+	defer hwv.lock.Unlock()
+
+	hwv.curr++
+	if hwv.curr > hwv.max {
+		hwv.max = hwv.curr
+	}
+}
+
+// Dec decreases the gauge value by 1.
+func (hwv *HighWatermarkValue) Dec() {
+	hwv.lock.Lock()
+	defer hwv.lock.Unlock()
+
+	hwv.curr--
+}
+
+// Set sets the current value, and updates high watermark if needed.
+func (hwv *HighWatermarkValue) Set(v int64) {
+	hwv.lock.Lock()
+	defer hwv.lock.Unlock()
+
+	hwv.curr = v
+	if hwv.curr > hwv.max {
+		hwv.max = hwv.curr
+	}
+}
+
+// Get gets the current gauge value.
+func (hwv *HighWatermarkValue) Get() int64 {
+	hwv.lock.RLock()
+	defer hwv.lock.RUnlock()
+
+	return hwv.curr
+}
+
+// Max returns the max gauge value (the high watermark).
+func (hwv *HighWatermarkValue) Max() int64 {
+	hwv.lock.RLock()
+	defer hwv.lock.RUnlock()
+
+	return hwv.max
+}
+
+func (hwv *HighWatermarkValue) getBoth() (curr, max int64) {
+	hwv.lock.RLock()
+	defer hwv.lock.RUnlock()
+
+	return hwv.curr, hwv.max
+}
+
+// HighWatermarkGauge implements a prometheus.Collector that reports up to 2
+// gauges backed by a HighWatermarkValue.
+type HighWatermarkGauge struct {
+	*HighWatermarkValue
+
+	// Optional gauge to report the current value when scraped
+	CurrGauge            *prometheus.Desc
+	CurrGaugeLabelValues []string
+
+	// Optional gauge to report the max value when scraped
+	MaxGauge            *prometheus.Desc
+	MaxGaugeLabelValues []string
+}
+
+// Describe implements prometheus.Collector.
+func (hwg HighWatermarkGauge) Describe(ch chan<- *prometheus.Desc) {
+	// All metrics are described dynamically.
+}
+
+// Collect implements prometheus.Collector.
+func (hwg HighWatermarkGauge) Collect(ch chan<- prometheus.Metric) {
+	curr, max := hwg.HighWatermarkValue.getBoth()
+
+	if hwg.CurrGauge != nil {
+		ch <- prometheus.MustNewConstMetric(
+			hwg.CurrGauge,
+			prometheus.GaugeValue,
+			float64(curr),
+			hwg.CurrGaugeLabelValues...,
+		)
+	}
+
+	if hwg.MaxGauge != nil {
+		ch <- prometheus.MustNewConstMetric(
+			hwg.MaxGauge,
+			prometheus.GaugeValue,
+			float64(max),
+			hwg.MaxGaugeLabelValues...,
+		)
+	}
+}
+
+var _ prometheus.Collector = HighWatermarkGauge{}

--- a/internal/prometheusbp/high_watermark_test.go
+++ b/internal/prometheusbp/high_watermark_test.go
@@ -1,0 +1,125 @@
+package prometheusbp_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/reddit/baseplate.go/internal/prometheusbp"
+)
+
+func TestHighWatermarkValue(t *testing.T) {
+	for _, c := range []struct {
+		label string
+		get   int64
+		max   int64
+		setup func(*prometheusbp.HighWatermarkValue)
+	}{
+		{
+			label: "inc-once",
+			get:   1,
+			max:   1,
+			setup: func(hwv *prometheusbp.HighWatermarkValue) {
+				hwv.Inc()
+			},
+		},
+		{
+			label: "inc-inc-dec",
+			get:   1,
+			max:   2,
+			setup: func(hwv *prometheusbp.HighWatermarkValue) {
+				hwv.Inc()
+				hwv.Inc()
+				hwv.Dec()
+			},
+		},
+		{
+			label: "dec-once",
+			get:   -1,
+			max:   0,
+			setup: func(hwv *prometheusbp.HighWatermarkValue) {
+				hwv.Dec()
+			},
+		},
+		{
+			label: "set-2-3-5-8-1",
+			get:   1,
+			max:   8,
+			setup: func(hwv *prometheusbp.HighWatermarkValue) {
+				hwv.Set(2)
+				hwv.Set(3)
+				hwv.Set(5)
+				hwv.Set(8)
+				hwv.Set(1)
+			},
+		},
+		{
+			label: "parallel-100",
+			get:   100,
+			max:   100,
+			setup: func(hwv *prometheusbp.HighWatermarkValue) {
+				const n = 100
+				var wg sync.WaitGroup
+				wg.Add(n)
+				for i := 0; i < n; i++ {
+					go func() {
+						hwv.Inc()
+						wg.Done()
+					}()
+				}
+				wg.Wait()
+			},
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			var hwv prometheusbp.HighWatermarkValue
+			c.setup(&hwv)
+			if got, want := hwv.Get(), c.get; got != want {
+				t.Errorf("Get() got %d, want %d", got, want)
+			}
+			if got, want := hwv.Max(), c.max; got != want {
+				t.Errorf("Max() got %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func BenchmarkHighWatermarkValue(b *testing.B) {
+	operations := [...]func(*prometheusbp.HighWatermarkValue){
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Inc()
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Dec()
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Set(2)
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Set(3)
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Set(5)
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Set(8)
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Get()
+		},
+		func(hwv *prometheusbp.HighWatermarkValue) {
+			hwv.Max()
+		},
+	}
+	hwv := new(prometheusbp.HighWatermarkValue)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		var counter int
+		for pb.Next() {
+			counter++
+			n := counter % len(operations)
+			operations[n](hwv)
+		}
+	})
+}


### PR DESCRIPTION
Benchmark result:

    $ go test -bench .
    goos: linux
    goarch: amd64
    pkg: github.com/reddit/baseplate.go/internal/prometheusbp
    cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
    BenchmarkHighWatermarkValue-12          24221392                48.11 ns/op            0 B/op          0 allocs/op
    PASS
    ok      github.com/reddit/baseplate.go/internal/prometheusbp    1.221s

cc @nanassito