### PR TITLE
bug(prom) | Re-add the global constant label that got dropped on 9814ca

### DIFF
--- a/redis/internal/redisprom/pools.go
+++ b/redis/internal/redisprom/pools.go
@@ -3,12 +3,15 @@ package redisprom
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 )
 
 const redisPoolLabel = "redis_pool"
 
 var (
-	MaxSizeGauge = promauto.NewGaugeVec(
+	MaxSizeGauge = promauto.With(internalv2compat.GlobalRegistry).NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redis_client_max_size",
 			Help: "configured maximum number of clients to keep in the pool (for showing % used in dashboards)",


### PR DESCRIPTION
## 💸 TL;DR
Previous changes went in concurrently and we ended up missing a label. This adds it back.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
