### PR TITLE
Ensure const metrics are applied with a lint check

### DIFF
--- a/redis/db/redisbp/monitored_client.go
+++ b/redis/db/redisbp/monitored_client.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/reddit/baseplate.go/internal/prometheusbp"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/redis/internal/redisprom"
 )
@@ -52,7 +54,7 @@ func NewMonitoredClient(name string, opt *redis.Options) *redis.Client {
 	})
 	redisprom.MaxSizeGauge.WithLabelValues(name).Set(float64(opt.PoolSize))
 
-	if err := prometheus.Register(exporter{
+	if err := internalv2compat.GlobalRegistry.Register(exporter{
 		client: client,
 		name:   name,
 	}); err != nil {
@@ -83,7 +85,7 @@ func NewMonitoredFailoverClient(name string, opt *redis.FailoverOptions) *redis.
 	})
 	redisprom.MaxSizeGauge.WithLabelValues(name).Set(float64(opt.PoolSize))
 
-	if err := prometheus.Register(exporter{
+	if err := internalv2compat.GlobalRegistry.Register(exporter{
 		client: client,
 		name:   name,
 	}); err != nil {
@@ -150,7 +152,7 @@ func NewMonitoredClusterClient(name string, opt *redis.ClusterOptions) *ClusterC
 	})
 	redisprom.MaxSizeGauge.WithLabelValues(name).Set(float64(opt.PoolSize))
 
-	if err := prometheus.Register(exporter{
+	if err := internalv2compat.GlobalRegistry.Register(exporter{
 		client: client,
 		name:   name,
 	}); err != nil {

--- a/redis/db/redisbp/prometheus_test.go
+++ b/redis/db/redisbp/prometheus_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/go-redis/redis/v8"
 	"github.com/prometheus/client_golang/prometheus"
+
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 )
 
 type fakeClient redis.Client
@@ -35,7 +38,7 @@ func TestRedisPoolExporterRegister(t *testing.T) {
 		},
 	}
 	for i, exporter := range exporters {
-		if err := prometheus.Register(exporter); err != nil {
+		if err := internalv2compat.GlobalRegistry.Register(exporter); err != nil {
 			t.Errorf("Register #%d failed: %v", i, err)
 		}
 	}

--- a/redis/internal/redisprom/pools.go
+++ b/redis/internal/redisprom/pools.go
@@ -3,12 +3,15 @@ package redisprom
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 )
 
 const redisPoolLabel = "redis_pool"
 
 var (
-	MaxSizeGauge = promauto.NewGaugeVec(
+	MaxSizeGauge = promauto.With(internalv2compat.GlobalRegistry).NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redis_client_max_size",
 			Help: "configured maximum number of clients to keep in the pool (for showing % used in dashboards)",

--- a/scripts/linters.sh
+++ b/scripts/linters.sh
@@ -42,4 +42,12 @@ if [ -n "$STATICCHECK" ]; then
   FAILED=1
 fi
 
+if grep -ri 'promauto.New' $(find . -name "*.go" -not -name "*_test.go") | grep -v "//.*promauto.New"; then
+  echo "*** Uses of promauto above should use With(internalv2compat.GlobalRegistry)"
+fi
+if grep -ri 'prometheus.Register' $(find . -name "*.go" -not -name "*_test.go") | grep -v "//.*prometheus.Register"; then
+  echo "*** Uses of prometheus.Register above should use internalv2compat.GlobalRegistry.Register instead"
+fi
+
+
 exit $FAILED

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -17,6 +17,8 @@ import (
 	"github.com/reddit/baseplate.go/clientpool"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/metricsbp"
 )
@@ -445,7 +447,7 @@ func newClientPool(
 			tags,
 		)
 
-		if err := prometheus.Register(clientPoolGaugeExporter{
+		if err := internalv2compat.GlobalRegistry.Register(clientPoolGaugeExporter{
 			slug: cfg.ServiceSlug,
 			pool: pool,
 		}); err != nil {

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/reddit/baseplate.go/clientpool"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/internal/prometheusbp/spectest"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
+	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/prometheusbp/promtest"
 )
@@ -168,7 +170,7 @@ func TestClientPoolGaugeExporterRegister(t *testing.T) {
 		},
 	}
 	for i, exporter := range exporters {
-		if err := prometheus.Register(exporter); err != nil {
+		if err := internalv2compat.GlobalRegistry.Register(exporter); err != nil {
 			t.Errorf("Register #%d failed: %v", i, err)
 		}
 	}


### PR DESCRIPTION
A few metrics that use `prometheus.Register` were missed in https://github.com/reddit/baseplate.go/pull/555 .  This adds them and adds a lint check to prevent future misses.