### PR TITLE
Allow most numeric types for experiment targeting

### DIFF
--- a/experiments/targeting.go
+++ b/experiments/targeting.go
@@ -189,7 +189,8 @@ func NewEqualNode(inputNodes map[string]interface{}) (Targeting, error) {
 func (n *EqualNode) Evaluate(inputs map[string]interface{}) bool {
 	candidateValue := inputs[n.fieldName]
 	switch n := candidateValue.(type) {
-	case int, float64:
+	case int, float64, int8, int16, int32, int64, uint, uint8, uint16, uint32,
+		uint64, float32:
 		candidateValue = json.Number(fmt.Sprintf("%v", n))
 	}
 	for _, value := range n.acceptedValues {
@@ -291,7 +292,27 @@ func (n *ComparisonNode) Evaluate(inputs map[string]interface{}) bool {
 	case int:
 		return n.comparer(float64(cv), value)
 	case float64:
-		n.comparer(cv, value)
+		return n.comparer(cv, value)
+	case int8:
+		return n.comparer(float64(cv), value)
+	case int16:
+		return n.comparer(float64(cv), value)
+	case int32:
+		return n.comparer(float64(cv), value)
+	case int64:
+		return n.comparer(float64(cv), value)
+	case uint:
+		return n.comparer(float64(cv), value)
+	case uint8:
+		return n.comparer(float64(cv), value)
+	case uint16:
+		return n.comparer(float64(cv), value)
+	case uint32:
+		return n.comparer(float64(cv), value)
+	case uint64:
+		return n.comparer(float64(cv), value)
+	case float32:
+		return n.comparer(float64(cv), value)
 	}
 	return false
 }

--- a/experiments/targeting_test.go
+++ b/experiments/targeting_test.go
@@ -612,6 +612,156 @@ func TestComparisonNodeBadInput(t *testing.T) {
 	}
 }
 
+func TestNumberTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		targeting []byte
+		input     any
+	}{
+		{
+			name:      "gt-node-int",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     int(5),
+		},
+		{
+			name:      "gt-node-float64",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     float64(5),
+		},
+		{
+			name:      "gt-node-float32",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     float32(5),
+		},
+		{
+			name:      "gt-node-int64",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     int64(5),
+		},
+		{
+			name:      "gt-node-int32",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     int32(5),
+		},
+		{
+			name:      "gt-node-int16",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     int16(5),
+		},
+		{
+			name:      "gt-node-int8",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     int8(5),
+		},
+		{
+			name:      "gt-node-uint",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint(5),
+		},
+		{
+			name:      "gt-node-uint64",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint64(5),
+		},
+		{
+			name:      "gt-node-uint32",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint32(5),
+		},
+		{
+			name:      "gt-node-uint16",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint16(5),
+		},
+		{
+			name:      "gt-node-uint8",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint8(5),
+		},
+		{
+			name:      "eq-node-int",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     int(5),
+		},
+		{
+			name:      "eq-node-float64",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     float64(5),
+		},
+		{
+			name:      "eq-node-float32",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     float32(5),
+		},
+		{
+			name:      "eq-node-int64",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     int64(5),
+		},
+		{
+			name:      "eq-node-int32",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     int32(5),
+		},
+		{
+			name:      "eq-node-int16",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     int16(5),
+		},
+		{
+			name:      "eq-node-int8",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     int8(5),
+		},
+		{
+			name:      "eq-node-uint",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     uint(5),
+		},
+		{
+			name:      "eq-node-uint64",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     uint64(5),
+		},
+		{
+			name:      "eq-node-uint32",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     uint32(5),
+		},
+		{
+			name:      "eq-node-uint16",
+			targeting: []byte(`{"EQ": {"field": "num_field", "value": 5}}`),
+			input:     uint16(5),
+		},
+		{
+			name:      "gt-node-uint8",
+			targeting: []byte(`{"GE": {"field": "num_field", "value": 5}}`),
+			input:     uint8(5),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := map[string]any{
+				"num_field": tt.input,
+			}
+			targeting, err := NewTargeting(tt.targeting)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := targeting.Evaluate(input)
+			if !got {
+				t.Errorf("got %t, want: %t", got, true)
+			}
+		})
+	}
+}
+
 func inputSet() map[string]interface{} {
 	inputs := make(map[string]interface{})
 	inputs["bool_field"] = true


### PR DESCRIPTION
## 💸 TL;DR

The experiment targeting implementation is only working for the type `int` and `float64`. For inputs of type `int64`, `float32`, `uint`, etc. the node automatically evaluates to false. Instead, allow for most of Go's numeric types.

## 📜 Details

We had a bug where experiment targeting failed silently because an app build number was passed in as an `int64`. This change might be excessive but I also don't necessarily see why this should be applicable to a wider range of types. Alternatively, we could fire a log event for any unmapped type. 

## 🧪 Testing Steps / Validation

See tests added.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
