### PR TITLE
breakerbp: Fix prometheus gauge

### DIFF
--- a/breakerbp/failure_ratio.go
+++ b/breakerbp/failure_ratio.go
@@ -99,6 +99,11 @@ func NewFailureRatioBreaker(config Config) FailureRatioBreaker {
 	if config.EmitStatusMetrics {
 		go failureBreaker.runStatsProducer(config.EmitStatusMetricsInterval)
 	}
+
+	breakerClosed.With(prometheus.Labels{
+		nameLabel: config.Name,
+	}).Set(1)
+
 	return failureBreaker
 }
 


### PR DESCRIPTION
In the current implementation, the gauge value is only set when the state of the breaker changes. Which means if a breaker never got tripped, we would not report the gauge value at all.

Set an initial value of 1 in constructor.
