### PR TITLE
Update gRPC metrics to match v2 and spec

### DIFF
--- a/grpcbp/client_middlewares.go
+++ b/grpcbp/client_middlewares.go
@@ -142,6 +142,7 @@ func PrometheusUnaryClientInterceptor(serverSlug string) grpc.UnaryClientInterce
 		activeRequestLabels := prometheus.Labels{
 			serviceLabel:    serviceName,
 			methodLabel:     method,
+			typeLabel:       unary,
 			clientNameLabel: serverSlug,
 		}
 		clientActiveRequests.With(activeRequestLabels).Inc()

--- a/grpcbp/prometheus.go
+++ b/grpcbp/prometheus.go
@@ -55,6 +55,7 @@ var (
 	serverActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
+		typeLabel,
 	}
 
 	serverActiveRequests = promauto.With(prometheusbpint.GlobalRegistry).NewGaugeVec(prometheus.GaugeOpts{
@@ -95,6 +96,7 @@ var (
 	clientActiveRequestsLabels = []string{
 		serviceLabel,
 		methodLabel,
+		typeLabel,
 		clientNameLabel,
 	}
 

--- a/grpcbp/server_middlewares.go
+++ b/grpcbp/server_middlewares.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/prometheusbp"
@@ -174,6 +175,7 @@ func InjectPrometheusUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 		activeRequestLabels := prometheus.Labels{
 			serviceLabel: serviceName,
+			typeLabel:    unary,
 			methodLabel:  method,
 		}
 		serverActiveRequests.With(activeRequestLabels).Inc()

--- a/grpcbp/server_middlewares_test.go
+++ b/grpcbp/server_middlewares_test.go
@@ -254,6 +254,7 @@ func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 
 			serverActiveRequestLabels := prometheus.Labels{
 				serviceLabel: serviceName,
+				typeLabel:    unary,
 				methodLabel:  tt.method,
 			}
 
@@ -277,6 +278,7 @@ func TestInjectPrometheusUnaryServerClientInterceptor(t *testing.T) {
 			clientActiveRequestLabels := prometheus.Labels{
 				serviceLabel:    serviceName,
 				methodLabel:     tt.method,
+				typeLabel:       unary,
 				clientNameLabel: serverSlug,
 			}
 

--- a/internal/prometheusbpint/spectest/spec.go
+++ b/internal/prometheusbpint/spectest/spec.go
@@ -216,12 +216,12 @@ func thriftSpecificLabels(name string) []string {
 //   - "service"
 //   - "method"
 func grpcSpecificLabels(name string) []string {
-	labelSuffixes := []string{"service", "method"}
+	labelSuffixes := []string{"service", "method", "type"}
 	switch {
 	case strings.HasSuffix(name, "_latency_seconds"):
-		labelSuffixes = append(labelSuffixes, "type", "success")
+		labelSuffixes = append(labelSuffixes, "success")
 	case strings.HasSuffix(name, "_requests_total"):
-		labelSuffixes = append(labelSuffixes, "type", "success", "code")
+		labelSuffixes = append(labelSuffixes, "success", "code")
 	case strings.HasSuffix(name, "_active_requests"):
 		// no op
 	default:

--- a/internal/prometheusbpint/spectest/spec_test.go
+++ b/internal/prometheusbpint/spectest/spec_test.go
@@ -418,6 +418,7 @@ func TestBuildLabelsGPRC(t *testing.T) {
 			want: map[string]struct{}{
 				"grpc_method":  {},
 				"grpc_service": {},
+				"grpc_type":    {},
 			},
 		},
 		{


### PR DESCRIPTION
To use v0 and v2 in the same binary, they require identical labels.  The v2 client currently is set up to match the spec, and so update the v0 middleware to do the same for legacy users of this middleware.