### PR TITLE
[fix] `httpbp` middleware doesn't flush chunked responses

### DIFF
--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -537,9 +537,9 @@ func allowFlushHijack(original, rw http.ResponseWriter) http.ResponseWriter {
 	case isFlusher && isHijacker:
 		return &wrappedFlushHijacker{rw, flusher, hijacker}
 	case isFlusher:
-		return &wrappedFlusher{rw, flusher}
+		return allowFlush(original, rw)
 	case isHijacker:
-		return &wrappedHijacker{rw, hijacker}
+		return allowHijack(original, rw)
 	default:
 		return rw
 	}

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -514,7 +514,6 @@ func (rr *responseRecorder) WriteHeader(code int) {
 	rr.responseCode = code
 }
 
-// wrappers
 type wrappedHijacker struct {
 	http.ResponseWriter
 	http.Hijacker

--- a/httpbp/middlewares_test.go
+++ b/httpbp/middlewares_test.go
@@ -327,7 +327,7 @@ func TestSupportedMethods(t *testing.T) {
 	}
 }
 
-func TestMiddlewareWrapping(t *testing.T) {
+func TestMiddlewareResponseWrapping(t *testing.T) {
 	store := newSecretsStore(t)
 	defer store.Close()
 
@@ -381,7 +381,7 @@ func TestMiddlewareWrapping(t *testing.T) {
 	}
 
 	// Test the a flushable response
-	t.Run("flushable response", func(t *testing.T) {
+	t.Run("flushable-response", func(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "/test", nil)
 		w := httptest.NewRecorder()
 		args.EndpointRegistry.ServeHTTP(w, r)

--- a/httpbp/response_wrappers.go
+++ b/httpbp/response_wrappers.go
@@ -1,32 +1,75 @@
-// DO NOT EDIT.
-// This code was partially generated and then made human readable.
-// This approach was adapted from https://github.com/badgerodon/contextaware/blob/4c442dfd39106512496bdd13c42c451da8ddeff3/internal/generate-wrap/main.go
-// See also https://www.doxsey.net/blog/fixing-interface-erasure-in-go/ for more context
-
 package httpbp
 
 import (
 	"net/http"
 )
 
+type optionalResponseWriter uint64
+
+const (
+	flusher optionalResponseWriter = 1 << iota
+	hijacker
+	pusher
+)
+
 func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
-	var f uint64
-	flusher, isFlusher := orig.(http.Flusher)
-	if isFlusher { f |= 0x0001 }
-	hijacker, isHijacker := orig.(http.Hijacker)
-	if isHijacker { f |= 0x0002 }
-	pusher, isPusher := orig.(http.Pusher)
-	if isPusher { f |= 0x0004 }
+	var f optionalResponseWriter
+	fl, isFlusher := orig.(http.Flusher)
+	if isFlusher {
+		f |= flusher
+	}
+	h, isHijacker := orig.(http.Hijacker)
+	if isHijacker {
+		f |= hijacker
+	}
+	p, isPusher := orig.(http.Pusher)
+	if isPusher {
+		f |= pusher
+	}
 
 	switch f {
-	case 0x0000: return wrapped
-	case 0x0001: return struct{http.ResponseWriter;http.Flusher}{wrapped, flusher}
-	case 0x0002: return struct{http.ResponseWriter;http.Hijacker}{wrapped, hijacker}
-	case 0x0003: return struct{http.ResponseWriter;http.Flusher;http.Hijacker}{wrapped, flusher,hijacker}
-	case 0x0004: return struct{http.ResponseWriter;http.Pusher}{wrapped, pusher}
-	case 0x0005: return struct{http.ResponseWriter;http.Flusher;http.Pusher}{wrapped,flusher,pusher}
-	case 0x0006: return struct{http.ResponseWriter;http.Hijacker;http.Pusher}{wrapped, hijacker,pusher}
-	case 0x0007: return struct{http.ResponseWriter;http.Flusher;http.Hijacker;http.Pusher}{wrapped, flusher,hijacker,pusher}
+	case 0:
+		return wrapped
+	case flusher:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+		}{wrapped, fl}
+	case hijacker:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+		}{wrapped, h}
+	case flusher | hijacker:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+		}{wrapped, fl, h}
+	case pusher:
+		return struct {
+			http.ResponseWriter
+			http.Pusher
+		}{wrapped, p}
+	case flusher | pusher:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Pusher
+		}{wrapped, fl, p}
+	case hijacker | pusher:
+		return struct {
+			http.ResponseWriter
+			http.Hijacker
+			http.Pusher
+		}{wrapped, h, p}
+	case flusher | hijacker | pusher:
+		return struct {
+			http.ResponseWriter
+			http.Flusher
+			http.Hijacker
+			http.Pusher
+		}{wrapped, fl, h, p}
 	}
 
 	return wrapped

--- a/httpbp/response_wrappers.go
+++ b/httpbp/response_wrappers.go
@@ -1,0 +1,33 @@
+// DO NOT EDIT.
+// This code was partially generated and then made human readable.
+// This approach was adapted from https://github.com/badgerodon/contextaware/blob/4c442dfd39106512496bdd13c42c451da8ddeff3/internal/generate-wrap/main.go
+// See also https://www.doxsey.net/blog/fixing-interface-erasure-in-go/ for more context
+
+package httpbp
+
+import (
+	"net/http"
+)
+
+func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
+	var f uint64
+	flusher, isFlusher := orig.(http.Flusher)
+	if isFlusher { f |= 0x0001 }
+	hijacker, isHijacker := orig.(http.Hijacker)
+	if isHijacker { f |= 0x0002 }
+	pusher, isPusher := orig.(http.Pusher)
+	if isPusher { f |= 0x0004 }
+
+	switch f {
+	case 0x0000: return wrapped
+	case 0x0001: return struct{http.ResponseWriter;http.Flusher}{wrapped, flusher}
+	case 0x0002: return struct{http.ResponseWriter;http.Hijacker}{wrapped, hijacker}
+	case 0x0003: return struct{http.ResponseWriter;http.Flusher;http.Hijacker}{wrapped, flusher,hijacker}
+	case 0x0004: return struct{http.ResponseWriter;http.Pusher}{wrapped, pusher}
+	case 0x0005: return struct{http.ResponseWriter;http.Flusher;http.Pusher}{wrapped,flusher,pusher}
+	case 0x0006: return struct{http.ResponseWriter;http.Hijacker;http.Pusher}{wrapped, hijacker,pusher}
+	case 0x0007: return struct{http.ResponseWriter;http.Flusher;http.Hijacker;http.Pusher}{wrapped, flusher,hijacker,pusher}
+	}
+
+	return wrapped
+}

--- a/httpbp/response_wrappers.go
+++ b/httpbp/response_wrappers.go
@@ -13,28 +13,28 @@ const (
 )
 
 func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
-	var f optionalResponseWriter
-	fl, isFlusher := orig.(http.Flusher)
+	var w optionalResponseWriter
+	f, isFlusher := orig.(http.Flusher)
 	if isFlusher {
-		f |= flusher
+		w |= flusher
 	}
 	h, isHijacker := orig.(http.Hijacker)
 	if isHijacker {
-		f |= hijacker
+		w |= hijacker
 	}
 	p, isPusher := orig.(http.Pusher)
 	if isPusher {
-		f |= pusher
+		w |= pusher
 	}
 
-	switch f {
+	switch w {
 	case 0:
 		return wrapped
 	case flusher:
 		return struct {
 			http.ResponseWriter
 			http.Flusher
-		}{wrapped, fl}
+		}{wrapped, f}
 	case hijacker:
 		return struct {
 			http.ResponseWriter
@@ -45,7 +45,7 @@ func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
 			http.ResponseWriter
 			http.Flusher
 			http.Hijacker
-		}{wrapped, fl, h}
+		}{wrapped, f, h}
 	case pusher:
 		return struct {
 			http.ResponseWriter
@@ -56,7 +56,7 @@ func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
 			http.ResponseWriter
 			http.Flusher
 			http.Pusher
-		}{wrapped, fl, p}
+		}{wrapped, f, p}
 	case hijacker | pusher:
 		return struct {
 			http.ResponseWriter
@@ -69,7 +69,7 @@ func wrapResponseWriter(orig, wrapped http.ResponseWriter) http.ResponseWriter {
 			http.Flusher
 			http.Hijacker
 			http.Pusher
-		}{wrapped, fl, h, p}
+		}{wrapped, f, h, p}
 	}
 
 	return wrapped


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
`httpbp` middleware, in particular `RecordStatusCode`  and `PrometheusServerMetrics` don't work with chunked HTTP responses because they wrap `http.ResponseWriter` and do not implement `http.Flush`. This updates our response wrapping within in the Middleware to support both the `http.Flush` and `http.Hijacker` interface.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
