### PR TITLE
thriftbp: Match thrift client pool metrics to baseplate spec

### DIFF
--- a/internal/prometheusbpint/high_watermark.go
+++ b/internal/prometheusbpint/high_watermark.go
@@ -59,7 +59,8 @@ func (hwv *HighWatermarkValue) Max() int64 {
 	return hwv.max
 }
 
-func (hwv *HighWatermarkValue) getBoth() (curr, max int64) {
+// GetBoth returns current and max values.
+func (hwv *HighWatermarkValue) GetBoth() (curr, max int64) {
 	hwv.lock.RLock()
 	defer hwv.lock.RUnlock()
 
@@ -87,7 +88,7 @@ func (hwg HighWatermarkGauge) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.
 func (hwg HighWatermarkGauge) Collect(ch chan<- prometheus.Metric) {
-	curr, max := hwg.HighWatermarkValue.getBoth()
+	curr, max := hwg.HighWatermarkValue.GetBoth()
 
 	if hwg.CurrGauge != nil {
 		ch <- prometheus.MustNewConstMetric(

--- a/redis/internal/redisprom/pools.go
+++ b/redis/internal/redisprom/pools.go
@@ -36,7 +36,7 @@ var (
 		prometheus.Labels{},
 	)
 	TotalConnectionGetsDesc = prometheus.NewDesc(
-		"redis_client_total_connection_gets",
+		"redis_client_connection_gets_total",
 		"incremented each time a connection is 'leased' from the pool",
 		[]string{redisPoolLabel},
 		prometheus.Labels{},

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -158,7 +158,7 @@ func (fakePool) NumAllocated() int32 {
 func TestClientPoolGaugeExporterRegister(t *testing.T) {
 	// This test is to make sure that a service creating more than one thrift
 	// client pool will not cause issues in prometheus metrics.
-	exporters := []clientPoolGaugeExporter{
+	exporters := []*clientPoolGaugeExporter{
 		{
 			slug: "foo",
 			pool: fakePool{},


### PR DESCRIPTION
Temporarily emit both new and old metrics, we will remove the old metrics after the next release (so the next release will have both).

While I'm here, also:

1. Remove statsd metrics from thrift client pool
2. Change redis client pool metric name following spec change
