### PR TITLE
thriftbp+httpbp: Rename the RecoverPanic middlewares

### DIFF
--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -281,12 +281,12 @@ func SupportedMethods(method string, additional ...string) Middleware {
 	}
 }
 
-// recoverPanic recovers from any panics, logs them, and sets the returned error
-// to a generic 500 error. recoverPanic is always the last middleware in the
+// recoverPanik recovers from any panics, logs them, and sets the returned error
+// to a generic 500 error. recoverPanik is always the last middleware in the
 // middleware chain, so it is the first one when returning which lets the error
 // bubble up into other middlewares. Since it is always added to the middleware
 // chain is a specific position, it is not exported.
-func recoverPanic(name string, next HandlerFunc) HandlerFunc {
+func recoverPanik(name string, next HandlerFunc) HandlerFunc {
 	counter := panicRecoverCounter.With(prometheus.Labels{
 		methodLabel: name,
 	})

--- a/httpbp/server.go
+++ b/httpbp/server.go
@@ -48,15 +48,15 @@ type httpHandlerFactory struct {
 }
 
 func (f httpHandlerFactory) NewHandler(endpoint Endpoint) http.Handler {
-	// +2 because we always add SupportedMethods and recoverPanic
+	// +2 because we always add SupportedMethods and recoverPanik
 	wrappers := make([]Middleware, 0, len(f.middlewares)+len(endpoint.Middlewares)+2)
 	wrappers = append(wrappers, f.middlewares...)
 	wrappers = append(wrappers, SupportedMethods(endpoint.Methods[0], endpoint.Methods[1:]...))
 	wrappers = append(wrappers, endpoint.Middlewares...)
-	// Always inject recoverPanic as the final middleware in the chain. This
+	// Always inject recoverPanik as the final middleware in the chain. This
 	// allows it to capture any panics before other middlewares return and bubble
 	// up the panic as an error to those middlewares.
-	wrappers = append(wrappers, recoverPanic)
+	wrappers = append(wrappers, recoverPanik)
 	return NewHandler(endpoint.Name, endpoint.Handle, wrappers...)
 }
 

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -70,7 +70,7 @@ type DefaultProcessorMiddlewaresArgs struct {
 //
 // 5. PrometheusServerMiddleware
 //
-// 6. RecoverPanic
+// 6. RecoverPanik
 func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) []thrift.ProcessorMiddleware {
 	return []thrift.ProcessorMiddleware{
 		ExtractDeadlineBudget,
@@ -78,7 +78,7 @@ func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) 
 		InjectEdgeContext(args.EdgeContextImpl),
 		ReportPayloadSizeMetrics(args.ReportPayloadSizeMetricsSampleRate),
 		PrometheusServerMiddleware,
-		RecoverPanic,
+		RecoverPanik,
 	}
 }
 
@@ -375,10 +375,15 @@ func tHeaderProtocol2String(proto thrift.THeaderProtocolID) string {
 	}
 }
 
-// RecoverPanic recovers from panics raised in the TProccessorFunction chain,
+// RecoverPanic is an alias of RecoverPanik.
+func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+	return RecoverPanik(name, next)
+}
+
+// RecoverPanik recovers from panics raised in the TProccessorFunction chain,
 // logs them, and records a metric indicating that the endpoint recovered from a
 // panic.
-func RecoverPanic(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+func RecoverPanik(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 	counter := panicRecoverCounter.With(prometheus.Labels{
 		methodLabel: name,
 	})


### PR DESCRIPTION
Because server middlewares are in most call stacks, having "panic" in the function names will cause searching for actual panics in log ingester much harder (you don't want to use "-RecoverPanic" either because they might be part of the actual panic call stack as well).

For thriftbp, since RecoverPanic was exported, keep it as an alias to newly renamed RecoverPanik, but don't use it by default.
