### PR TITLE
thriftbp: Metrics cleanup

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -167,11 +167,17 @@ var (
 		methodLabel,
 	}
 
-	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+	// TODO: Remove after the next release (v0.9.12)
+	legacyPanicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: subsystemServer,
 		Name:      "panic_recover_total",
-		Help:      "The number of panics recovered from thrift server handlers",
+		Help:      "Deprecated: Use thriftbp_server_recovered_panics_total instead",
+	}, panicRecoverLabels)
+
+	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "thriftbp_server_recovered_panics_total",
+		Help: "The number of panics recovered from thrift server handlers",
 	}, panicRecoverLabels)
 )
 
@@ -181,25 +187,35 @@ var (
 		"thrift_pool",
 	}
 
-	clientPoolExhaustedCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+	// TODO: Remove after the next release (v0.9.12)
+	legacyClientPoolExhaustedCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: subsystemClientPool,
 		Name:      "exhausted_total",
-		Help:      "The number of pool exhaustion for a thrift client pool",
+		Help:      "Deprecated: Use thriftbp_client_pool_exhaustions_total instead",
+	}, clientPoolLabels)
+
+	clientPoolExhaustedCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "thriftbp_client_pool_exhaustions_total",
+		Help: "The number of pool exhaustions for a thrift client pool",
 	}, clientPoolLabels)
 
 	clientPoolClosedConnectionsCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemClientPool,
-		Name:      "closed_connections_total",
-		Help:      "The number of times we closed the client after used it from the pool",
+		Name: "thriftbp_client_pool_closed_connections_total",
+		Help: "The number of times we closed the client after used it from the pool",
 	}, clientPoolLabels)
 
-	clientPoolReleaseErrorCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+	// TODO: Remove after the next release (v0.9.12)
+	legacyClientPoolReleaseErrorCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: subsystemClientPool,
 		Name:      "release_error_total",
-		Help:      "The number of times we failed to release a client back to the pool",
+		Help:      "Deprecated: Use thriftbp_client_pool_release_errors_total instead",
+	}, clientPoolLabels)
+
+	clientPoolReleaseErrorCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "thriftbp_client_pool_release_errors_total",
+		Help: "The number of times we failed to release a client back to the pool",
 	}, clientPoolLabels)
 
 	clientPoolGetsCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -11,11 +11,6 @@ import (
 	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
-	"github.com/reddit/baseplate.go/metricsbp"
-)
-
-const (
-	meterNameThriftSocketErrorCounter = "thrift.socket.timeout"
 )
 
 // ServerConfig is the arg struct for both NewServer and NewBaseplateServer.
@@ -58,6 +53,8 @@ type ServerConfig struct {
 	//
 	// Report the number of clients connected to the server as a runtime gauge
 	// with metric name of 'thrift.connections'
+	//
+	// Deprecated: This feature is removed.
 	ReportConnectionCount bool
 
 	// Optional, used only by NewServer.
@@ -108,10 +105,6 @@ func NewServer(cfg ServerConfig) (*thrift.TSimpleServer, error) {
 		transport = cfg.Socket
 	}
 
-	if cfg.ReportConnectionCount {
-		transport = &CountedTServerTransport{transport}
-	}
-
 	server := thrift.NewTSimpleServer4(
 		thrift.WrapProcessor(cfg.Processor, cfg.Middlewares...),
 		transport,
@@ -160,10 +153,8 @@ func NewBaseplateServer(
 }
 
 func suppressTimeoutLogger(logger thrift.Logger) thrift.Logger {
-	c := metricsbp.M.Counter(meterNameThriftSocketErrorCounter)
 	return func(msg string) {
 		if strings.Contains(msg, "i/o timeout") {
-			c.Add(1)
 			return
 		}
 

--- a/thriftbp/server_transport.go
+++ b/thriftbp/server_transport.go
@@ -13,6 +13,8 @@ const meterNameTransportConnCounter = "thrift.connections"
 
 // CountedTServerTransport is a wrapper around thrift.TServerTransport that
 // emits a gauge of the number of client connections.
+//
+// Deprecated: This is deprecated with statsd metrics.
 type CountedTServerTransport struct {
 	thrift.TServerTransport
 }

--- a/thriftbp/thrifttest/server.go
+++ b/thriftbp/thrifttest/server.go
@@ -46,6 +46,8 @@ const (
 
 	// ReportClientPoolStats is the value that is always used for
 	// ServerConfig.ClientConfig.ReportPoolStats.
+	//
+	// Deprecated: deprecated with the server config field.
 	ReportClientPoolStats = false
 
 	loopbackAddr = "127.0.0.1:0"
@@ -169,7 +171,6 @@ func NewBaseplateServer(cfg ServerConfig) (*Server, error) {
 	server := &Server{Server: thriftbp.ApplyBaseplate(bp, srv)}
 
 	cfg.ClientConfig.Addr = server.Baseplate().GetConfig().Addr
-	cfg.ClientConfig.ReportPoolStats = ReportClientPoolStats
 	cfg.ClientConfig.InitialConnections = InitialClientConnections
 
 	if cfg.ClientConfig.ConnectTimeout == 0 {

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -32,7 +32,7 @@ func TestTTLClient(t *testing.T) {
 	ttl := time.Millisecond
 	jitter := 0.1
 
-	client, err := newTTLClient(firstSuccessGenerator(transport), ttl, jitter, "", nil)
+	client, err := newTTLClient(firstSuccessGenerator(transport), ttl, jitter, "")
 	if err != nil {
 		t.Fatalf("newTTLClient returned error: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestTTLClient(t *testing.T) {
 		t.Error("Expected IsOpen call after sleep to return false, got true.")
 	}
 
-	client, err = newTTLClient(firstSuccessGenerator(transport), ttl, -jitter, "", nil)
+	client, err = newTTLClient(firstSuccessGenerator(transport), ttl, -jitter, "")
 	if err != nil {
 		t.Fatalf("newTTLClient returned error: %v", err)
 	}
@@ -63,7 +63,7 @@ func TestTTLClientNegativeTTL(t *testing.T) {
 	transport := thrift.NewTMemoryBuffer()
 	ttl := time.Millisecond
 
-	client, err := newTTLClient(firstSuccessGenerator(transport), -ttl, 0.1, "", nil)
+	client, err := newTTLClient(firstSuccessGenerator(transport), -ttl, 0.1, "")
 	if err != nil {
 		t.Fatalf("newTTLClient returned error: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestTTLClientRefresh(t *testing.T) {
 		)
 
 		g := alwaysSuccessGenerator{transport: &transport}
-		client, err := newTTLClient(g.generator(), ttl, jitter, "", nil)
+		client, err := newTTLClient(g.generator(), ttl, jitter, "")
 		if err != nil {
 			t.Fatalf("newTTLClient returned error: %v", err)
 		}


### PR DESCRIPTION
Remove statsd metrics, and rename some prometheus metrics to comply with prometheus naming convention. For renamed prometheus metrics, temporarily emitting both old and new, but mark old ones as deprecated to be removed later.

Also remove some statsd only features:

1. CountedServerTransport is marked as deprecated and no longer used by other code.
2. In ReportPayloadSizeMetrics server middleware, the rate arg is deprecated and the prometheus metrics is always reported.
3. ClientPoolConfig.MetricsTags & ClientPoolConfig.ReportPoolStats are deprecated. The pool stats are always reported as prometheus metrrics.
