### PR TITLE
Metrics cleanups in other packages

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -61,11 +61,13 @@ type Config struct {
 	StopDelay time.Duration `yaml:"stopDelay"`
 
 	Log     log.Config       `yaml:"log"`
-	Metrics metricsbp.Config `yaml:"metrics"`
 	Runtime runtimebp.Config `yaml:"runtime"`
 	Secrets secrets.Config   `yaml:"secrets"`
 	Sentry  log.SentryConfig `yaml:"sentry"`
 	Tracing tracing.Config   `yaml:"tracing"`
+
+	// Deprecated: statsd metrics are deprecated.
+	Metrics metricsbp.Config `yaml:"metrics"`
 }
 
 // GetConfig implements Configer.
@@ -321,7 +323,6 @@ func New(ctx context.Context, args NewArgs) (context.Context, Baseplate, error) 
 	bp.closers.Add(batchcloser.WrapCancel(cancel))
 
 	log.InitFromConfig(cfg.Log)
-	bp.closers.Add(metricsbp.InitFromConfig(ctx, cfg.Metrics))
 
 	closer, err := log.InitSentry(cfg.Sentry)
 	if err != nil {

--- a/baseplate_test.go
+++ b/baseplate_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/reddit/baseplate.go/configbp"
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/log"
-	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/runtimebp"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/tracing"
@@ -285,10 +284,6 @@ func TestServeClosers(t *testing.T) {
 	}
 }
 
-func float64Ptr(v float64) *float64 {
-	return &v
-}
-
 type serviceConfig struct {
 	baseplate.Config `yaml:",inline"`
 
@@ -315,11 +310,6 @@ stopTimeout: 30s
 log:
  level: info
 
-metrics:
- namespace: baseplate-test
- endpoint: metrics:8125
- histogramSampleRate: 0.01
-
 runtime:
  numProcesses:
   max: 100
@@ -345,12 +335,6 @@ redis:
 
 		Log: log.Config{
 			Level: "info",
-		},
-
-		Metrics: metricsbp.Config{
-			Namespace:           "baseplate-test",
-			Endpoint:            "metrics:8125",
-			HistogramSampleRate: float64Ptr(0.01),
 		},
 
 		Runtime: runtimebp.Config{

--- a/httpbp/prometheus.go
+++ b/httpbp/prometheus.go
@@ -123,11 +123,17 @@ var (
 		methodLabel,
 	}
 
-	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+	// TODO: Remove after next release (v0.9.12)
+	legacyPanicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Namespace: promNamespace,
 		Subsystem: subsystemServer,
 		Name:      "panic_recover_total",
-		Help:      "The number of panics recovered from http server handlers",
+		Help:      "Deprecated: use httpbp_server_recovered_panics_total instead",
+	}, panicRecoverLabels)
+
+	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "httpbp_server_recovered_panics_total",
+		Help: "The number of panics recovered from http server handlers",
 	}, panicRecoverLabels)
 )
 

--- a/internal/limitopen/limitopen.go
+++ b/internal/limitopen/limitopen.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/reddit/baseplate.go/internal/prometheusbpint"
 	"github.com/reddit/baseplate.go/log"
-	"github.com/reddit/baseplate.go/metricsbp"
 )
 
 const (
@@ -89,9 +88,8 @@ type readCloser struct {
 
 // OpenWithLimit calls Open with limit checks.
 //
-// It always reports the size of the path as a runtime gauge
-// (with "limitopen.size" as the metrics path and path label for statsd,
-// "limitopen_file_size_bytes" for prometheus).
+// It always reports the size of the path as a prometheus gauge of
+// "limitopen_file_size_bytes".
 // When softLimit > 0 and the size of the path as reported by the os is larger,
 // it will also use log.DefaultWrapper to report it and increase prometheus
 // counter of limitopen_softlimit_violation_total.
@@ -104,9 +102,6 @@ func OpenWithLimit(path string, softLimit, hardLimit int64) (io.ReadCloser, erro
 	}
 
 	pathValue := filepath.Base(path)
-	metricsbp.M.RuntimeGauge("limitopen.size").With(
-		"path", pathValue,
-	).Set(float64(size))
 	labels := prometheus.Labels{
 		pathLabel: pathValue,
 	}

--- a/redis/db/redisbp/example_monitored_client_test.go
+++ b/redis/db/redisbp/example_monitored_client_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/opentracing/opentracing-go"
 
-	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/redis/db/redisbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
@@ -37,14 +36,6 @@ func ExampleNewMonitoredClient() {
 	client := redisbp.NewMonitoredClient(name, &redis.Options{Addr: ":6379"})
 
 	defer client.Close()
-
-	// Spawn "MonitorPoolStats" in a separate goroutine.
-	go redisbp.MonitorPoolStats(
-		metricsbp.M.Ctx(),
-		client,
-		name,
-		metricsbp.Tags{"env": "test"},
-	)
 
 	// Create a "service" with a monitored client.
 	svc := Service{Redis: client}

--- a/redis/db/redisbp/monitored_client.go
+++ b/redis/db/redisbp/monitored_client.go
@@ -195,6 +195,9 @@ func NewMonitoredClusterClient(name string, opt *redis.ClusterOptions) *ClusterC
 // Ex:
 //
 //	go factory.MonitorPoolStats(metricsbp.M.Ctx(), tags)
+//
+// Deprecated: Statsd metrics are deprecated. Prometheus pool stats metrics are
+// always reported with a monitored client.
 func MonitorPoolStats(ctx context.Context, client PoolStatser, name string, tags metricsbp.Tags) {
 	t := tags.AsStatsdTags()
 	prefix := name + ".pool"

--- a/retrybp/doc_test.go
+++ b/retrybp/doc_test.go
@@ -5,16 +5,22 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/reddit/baseplate.go/breakerbp"
 	"github.com/reddit/baseplate.go/log"
-	"github.com/reddit/baseplate.go/metricsbp"
 	"github.com/reddit/baseplate.go/retrybp"
 )
 
 // This example demonstrates how to use retrybp to retry an operation.
 func Example() {
 	const timeout = time.Millisecond * 200
+
+	// prometheus counters
+	var (
+		errorCounter   prometheus.Counter
+		successCounter prometheus.Counter
+	)
 
 	// TODO: use the actual type of your operation.
 	type resultType = int
@@ -69,14 +75,14 @@ func Example() {
 		),
 		retry.OnRetry(func(attempts uint, err error) {
 			if err != nil {
-				metricsbp.M.Counter("operation.failure").Add(1)
+				errorCounter.Inc()
 				log.Errorw(
 					"operation failed",
 					"err", err,
 					"attempt", attempts,
 				)
 			} else {
-				metricsbp.M.Counter("operation.succeed").Add(1)
+				successCounter.Inc()
 			}
 		}),
 	)

--- a/signing/doc_test.go
+++ b/signing/doc_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/reddit/baseplate.go/metricsbp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/secrets"
 	"github.com/reddit/baseplate.go/signing"
 )
@@ -14,6 +14,9 @@ func Example() {
 	var (
 		store      *secrets.Store
 		secretPath string
+
+		invalidSignatureCounter prometheus.Counter
+		expiredSignatureCounter prometheus.Counter
 	)
 
 	secret, _ := store.GetVersionedSecret(secretPath)
@@ -30,12 +33,12 @@ func Example() {
 	// Verify
 	err := signing.Verify([]byte(msg), signature, secret)
 	if err != nil {
-		metricsbp.M.Counter("invalid-signature").Add(1)
+		invalidSignatureCounter.Inc()
 		var e signing.VerifyError
 		if errors.As(err, &e) {
 			switch e.Reason {
 			case signing.VerifyErrorReasonExpired:
-				metricsbp.M.Counter("signature-expired").Add(1)
+				expiredSignatureCounter.Inc()
 			}
 		}
 	}


### PR DESCRIPTION
Remove/deprecate statsd metrics, and rename an httpbp prometheus metrics similar to the thriftbp one in
https://github.com/reddit/baseplate.go/pull/581.
