### PR TITLE
maxprocs: Print newline after log

### DIFF
--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -74,7 +74,7 @@ var (
 		ubermaxprocs.Set(
 			ubermaxprocs.Min(2),
 			ubermaxprocs.Logger(func(s string, i ...interface{}) {
-				fmt.Fprintf(os.Stderr, s, i...) // contains context
+				fmt.Fprintf(os.Stderr, s+"\n", i...) // contains context
 			}),
 		)
 	}

--- a/runtimebp/internal/maxprocs/maxprocs.go
+++ b/runtimebp/internal/maxprocs/maxprocs.go
@@ -74,7 +74,8 @@ var (
 		ubermaxprocs.Set(
 			ubermaxprocs.Min(2),
 			ubermaxprocs.Logger(func(s string, i ...interface{}) {
-				fmt.Fprintf(os.Stderr, s+"\n", i...) // contains context
+				fmt.Fprintf(os.Stderr, s, i...) // contains context
+				fmt.Fprintln(os.Stderr, "")
 			}),
 		)
 	}


### PR DESCRIPTION
## 💸 TL;DR

Since we're not using a real logger here (artifact of previous implementation, I _think_ because logging isn't initialized when this is called – but if that's not the case we can update to use zap) we weren't logging a newline. This was not caught by tests because the maxprocs library doesn't bake in any testing affordances so we had to stub it out.



## 📜 Details
Before:
```
maxprocs: Updating GOMAXPROCS=8: determined from CPU quotapanic: runtime error: invalid memory address or nil pointer dereference
```

After:
```
maxprocs: Updating GOMAXPROCS=8: determined from CPU quota
panic: runtime error: invalid memory address or nil pointer dereference
```

## 🧪 Testing Steps / Validation
Will test in a sample service.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
