### PR TITLE
secrets: Fix bug about not wait for secrets.json to become available

### DIFF
--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -372,7 +372,7 @@ func New(ctx context.Context, cfg Config) (*Result, error) {
 
 		var err error
 		data, mtime, files, err = openAndParse(cfg.Path, cfg.Parser, limit, hardLimit)
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			time.Sleep(InitialReadInterval)
 			continue
 		}

--- a/filewatcher/filewatcher_test.go
+++ b/filewatcher/filewatcher_test.go
@@ -304,14 +304,14 @@ func updateDirWithContents(tb testing.TB, dst string, contents map[string]string
 	for p, content := range contents {
 		path := filepath.Join(dir, p)
 		parent := filepath.Dir(path)
-		if err := os.Mkdir(parent, 0777); err != nil && !os.IsExist(err) {
+		if err := os.Mkdir(parent, 0777); err != nil && !errors.Is(err, fs.ErrExist) {
 			tb.Fatalf("Failed to create directory %q for %q: %v", parent, path, err)
 		}
 		if err := os.WriteFile(path, []byte(content), 0666); err != nil {
 			tb.Fatalf("Failed to write file %q: %v", path, err)
 		}
 	}
-	if err := os.RemoveAll(dst); err != nil && !os.IsNotExist(err) {
+	if err := os.RemoveAll(dst); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		tb.Fatalf("Failed to remove %q: %v", dst, err)
 	}
 	if err := os.Rename(dir, dst); err != nil {

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
@@ -45,12 +46,12 @@ func NewStore(ctx context.Context, path string, logger log.Wrapper, middlewares 
 	}
 	store.secretHandler(middlewares...)
 	fileInfo, err := os.Stat(path)
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 
 	parser := store.parser
-	if fileInfo.IsDir() {
+	if fileInfo != nil && fileInfo.IsDir() {
 		parser = filewatcher.WrapDirParser(store.dirParser)
 	}
 


### PR DESCRIPTION
When we added support for CSI directories, we introduced a bug that we no longer wait for secrets.json to become available, because os.Stat call would fail with file not exist error immediately.

Since in CSI directories case the directory would be guaranteed to be available immediately (unlike the vault case), assume file not exist errors from os.Stat as using file instead of directory, and let filewatcher.New to handle the waiting as before. Also add a test for it.

While I'm here, also remove the usages of os.IsNotExist and os.IsExist follow the docs.
