### PR TITLE
Drop support for go 1.18

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.18
           - 1.19
 
     container:

--- a/drainer.go
+++ b/drainer.go
@@ -18,15 +18,15 @@ type HealthCheckCloser interface {
 }
 
 type drainer struct {
-	closed int64
+	closed atomic.Int64
 }
 
 func (d *drainer) IsHealthy(_ context.Context) bool {
-	return atomic.LoadInt64(&d.closed) == 0
+	return d.closed.Load() == 0
 }
 
 func (d *drainer) Close() error {
-	atomic.StoreInt64(&d.closed, 1)
+	d.closed.Store(1)
 	return nil
 }
 

--- a/ecinterface/global_test.go
+++ b/ecinterface/global_test.go
@@ -85,7 +85,6 @@ func BenchmarkAtomics(b *testing.B) {
 			b.Fatalf("this is just to avoid eliding the call")
 		}
 	})
-	/* If you have go1.19 with the new atomic APIs, you can throw this one in for fun:
 	b.Run("atomicPointer", func(b *testing.B) {
 		var global atomic.Pointer[Interface]
 		var impl Interface = nop{}
@@ -102,5 +101,4 @@ func BenchmarkAtomics(b *testing.B) {
 			b.Fatalf("this is just to avoid eliding the call")
 		}
 	})
-	*/
 }

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -45,7 +45,7 @@ func TestV2(t *testing.T) {
 
 	// put
 	var wg sync.WaitGroup
-	var failed int64
+	var failed atomic.Int64
 	const expectedFailures = 1
 	const n = queueSize + expectedFailures
 
@@ -58,7 +58,7 @@ func TestV2(t *testing.T) {
 			before := time.Now()
 			if err := v2.Put(ctx, mockTStruct{}); err != nil {
 				t.Log("Put failed with:", err)
-				atomic.AddInt64(&failed, 1)
+				failed.Add(1)
 			}
 			elapsed := time.Since(before)
 			if elapsed > tripleTime {
@@ -72,7 +72,7 @@ func TestV2(t *testing.T) {
 	}
 	wg.Wait()
 
-	actualFailures := atomic.LoadInt64(&failed)
+	actualFailures := failed.Load()
 	if actualFailures != expectedFailures {
 		t.Errorf(
 			"Expected %d failed Put call, actual %d",
@@ -99,7 +99,7 @@ func TestV2(t *testing.T) {
 	}
 
 	// PutRaw
-	atomic.StoreInt64(&failed, 0)
+	failed.Store(0)
 	const rawData = "hello, world"
 	wg.Add(n)
 	for i := 0; i < n; i++ {
@@ -110,7 +110,7 @@ func TestV2(t *testing.T) {
 			before := time.Now()
 			if err := v2.PutRaw(ctx, []byte(rawData)); err != nil {
 				t.Log("PutRaw failed with:", err)
-				atomic.AddInt64(&failed, 1)
+				failed.Add(1)
 			}
 			elapsed := time.Since(before)
 			if elapsed > tripleTime {
@@ -124,7 +124,7 @@ func TestV2(t *testing.T) {
 	}
 	wg.Wait()
 
-	actualFailures = atomic.LoadInt64(&failed)
+	actualFailures = failed.Load()
 	if actualFailures != expectedFailures {
 		t.Errorf(
 			"Expected %d failed Put call, actual %d",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reddit/baseplate.go
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Shopify/sarama v1.29.1

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -225,12 +225,12 @@ func Retries(limit int, retryOptions ...retry.Option) ClientMiddleware {
 // requests at any given time by returning an error if the maximum is reached.
 func MaxConcurrency(maxConcurrency int64) ClientMiddleware {
 	var (
-		activeRequests int64
+		activeRequests atomic.Int64
 	)
 	return func(next http.RoundTripper) http.RoundTripper {
 		return roundTripperFunc(func(req *http.Request) (resp *http.Response, err error) {
-			attemptedRequests := atomic.AddInt64(&activeRequests, 1)
-			defer atomic.AddInt64(&activeRequests, -1)
+			attemptedRequests := activeRequests.Add(1)
+			defer activeRequests.Add(-1)
 
 			if maxConcurrency > 0 && attemptedRequests > maxConcurrency {
 				return nil, ErrConcurrencyLimit

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -36,11 +36,11 @@ func GlobalLogger() *zap.SugaredLogger {
 	return globalLogger
 }
 
-var v0logDisabled uint64
+var v0logDisabled atomic.Uint64
 
 // SetGlobalLogger allows baseplate v0 to set the global logger.
 func SetGlobalLogger(logger *zap.SugaredLogger) {
-	if atomic.LoadUint64(&v0logDisabled) > 0 {
+	if v0logDisabled.Load() > 0 {
 		globalLogger.Warn("ineffectual call to SetGlobalLogger; baseplate.go v2 compatibility mode is active")
 		return
 	}
@@ -50,7 +50,7 @@ func SetGlobalLogger(logger *zap.SugaredLogger) {
 
 // OverrideLogger allows baseplate v2 to override the global logger irrevocably.
 func OverrideLogger(logger *zap.SugaredLogger) {
-	atomic.StoreUint64(&v0logDisabled, 1)
+	v0logDisabled.Store(1)
 	globalLogger = logger
 }
 

--- a/metricsbp/log_test.go
+++ b/metricsbp/log_test.go
@@ -14,11 +14,11 @@ import (
 
 type wrapper struct {
 	tb     testing.TB
-	called int64
+	called atomic.Int64
 }
 
 func (w *wrapper) log(_ context.Context, msg string) {
-	atomic.AddInt64(&w.called, 1)
+	w.called.Add(1)
 	if w.tb != nil {
 		w.tb.Logf("log called with %q", msg)
 	}
@@ -44,7 +44,7 @@ func TestLogWrapper(t *testing.T) {
 	wrapped.Log(ctx, "called 1")
 	wrapped.Log(ctx, "called 2")
 
-	if called := atomic.LoadInt64(&origin.called); called != expected {
+	if called := origin.called.Load(); called != expected {
 		t.Errorf(
 			"Expect origin log.Wrapper to be called %d times, actual %d",
 			expected,

--- a/metricsbp/statsd.go
+++ b/metricsbp/statsd.go
@@ -63,7 +63,7 @@ type Statsd struct {
 	writer              *bufferedWriter
 	wg                  sync.WaitGroup
 
-	activeRequests int64
+	activeRequests atomic.Int64
 }
 
 func convertSampleRate(rate *float64) float64 {
@@ -340,15 +340,15 @@ func (st *Statsd) WriteTo(w io.Writer) (n int64, err error) {
 
 func (st *Statsd) incActiveRequests() {
 	st = st.fallback()
-	atomic.AddInt64(&st.activeRequests, 1)
+	st.activeRequests.Add(1)
 }
 
 func (st *Statsd) decActiveRequests() {
 	st = st.fallback()
-	atomic.AddInt64(&st.activeRequests, -1)
+	st.activeRequests.Add(-1)
 }
 
 func (st *Statsd) getActiveRequests() int64 {
 	st = st.fallback()
-	return atomic.LoadInt64(&st.activeRequests)
+	return st.activeRequests.Load()
 }

--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -86,9 +86,9 @@ func TestInitialConnectionsFallback(t *testing.T) {
 	}
 	defer ln.Close()
 
-	var counter uint64
+	var counter atomic.Uint64
 	addrGen := func() (string, error) {
-		if atomic.AddUint64(&counter, 1)%2 == 0 {
+		if counter.Add(1)%2 == 0 {
 			// on even attempts, return the valid address
 			return ln.Addr().String(), nil
 		}
@@ -144,10 +144,10 @@ func TestInitialConnectionsFallback(t *testing.T) {
 		},
 	} {
 		t.Run(c.label, func(t *testing.T) {
-			var loggerCalled int64
+			var loggerCalled atomic.Int64
 			logger := func(_ context.Context, msg string) {
 				t.Logf("InitialConnectionsFallbackLogger called with %q", msg)
-				atomic.StoreInt64(&loggerCalled, 1)
+				loggerCalled.Store(1)
 			}
 
 			c.cfg.InitialConnectionsFallbackLogger = logger
@@ -163,7 +163,7 @@ func TestInitialConnectionsFallback(t *testing.T) {
 				if err != nil {
 					t.Errorf("Expected no error, got: %v", err)
 				}
-				if atomic.LoadInt64(&loggerCalled) != 1 {
+				if loggerCalled.Load() != 1 {
 					t.Error("InitialConnectionsFallbackLogger not called")
 				}
 			}

--- a/thriftbp/ttl_client_test.go
+++ b/thriftbp/ttl_client_test.go
@@ -116,7 +116,7 @@ func TestTTLClientRenew(t *testing.T) {
 type alwaysSuccessGenerator struct {
 	transport thrift.TTransport
 
-	called int64
+	called atomic.Int64
 }
 
 func (g *alwaysSuccessGenerator) generator() ttlClientGenerator {
@@ -126,28 +126,28 @@ func (g *alwaysSuccessGenerator) generator() ttlClientGenerator {
 		factory.GetProtocol(g.transport),
 	)
 	return func() (thrift.TClient, thrift.TTransport, error) {
-		atomic.AddInt64(&g.called, 1)
+		g.called.Add(1)
 		return client, g.transport, nil
 	}
 }
 
 func (g *alwaysSuccessGenerator) numCalls() int64 {
-	return atomic.LoadInt64(&g.called)
+	return g.called.Load()
 }
 
 type mockTTransport struct {
 	thrift.TTransport
 
-	closeCalled int64
+	closeCalled atomic.Int64
 }
 
 func (m *mockTTransport) Close() error {
-	atomic.AddInt64(&m.closeCalled, 1)
+	m.closeCalled.Add(1)
 	return nil
 }
 
 func (m *mockTTransport) numCloses() int64 {
-	return atomic.LoadInt64(&m.closeCalled)
+	return m.closeCalled.Load()
 }
 
 func TestTTLClientRefresh(t *testing.T) {


### PR DESCRIPTION
Use the new atomic package API introduced in go 1.19:

* Replace atomic.Value with atomic.Pointer
* Replace atomic.Add*/Store*/Load*/etc. with new Int*/Uint* atomic types
* Except the atomic.Value used in filewatcher, as to take full advantage of that we would need to make breaking API changes to filewatcher
