### PR TITLE
Create a secrets.Wrap API for wrapping alternate secrets implementations

### DIFF
--- a/secret/secrets.go
+++ b/secret/secrets.go
@@ -1,0 +1,1 @@
+package secret


### PR DESCRIPTION
## 💸 TL;DR
This change allows creating an API-compatible Store object that delegates the calls to secret-getting functions to another store.

This is necessary because baseplate.go/v0 and edgecontext/v0 both hard-code *secrets.Store, and so it is not only a breaking change to replace them with an interface, it would require a lock-step change across two v0.x libraries, which is very likely to bite consumers.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
