### PR TITLE
thriftbp: Force recoverPanik to be the last server middleware

### DIFF
--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -105,8 +105,12 @@ func NewServer(cfg ServerConfig) (*thrift.TSimpleServer, error) {
 		transport = cfg.Socket
 	}
 
+	middlewares := make([]thrift.ProcessorMiddleware, 0, len(cfg.Middlewares)+1)
+	middlewares = append(middlewares, cfg.Middlewares...)
+	middlewares = append(middlewares, recoverPanik)
+
 	server := thrift.NewTSimpleServer4(
-		thrift.WrapProcessor(cfg.Processor, cfg.Middlewares...),
+		thrift.WrapProcessor(cfg.Processor, middlewares...),
 		transport,
 		thrift.NewTHeaderTransportFactoryConf(nil, nil),
 		thrift.NewTHeaderProtocolFactoryConf(nil),


### PR DESCRIPTION
This was already done in httpbp. Without this, middlewares after it will get nil error when panic happens, which can result in inaccurate/misleading metrics or other bugs.

To do so:
* Mark the old RecoverPanic middleware as deprecated
* Unexport RecoverPanik to recoverPanik. This is a breaking change, but RecoverPanik was only added in beta releases, it's not in v0.9.11.
