### PR TITLE
thriftbp: Add a counter for opener calls in client pool

### DIFF
--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -219,6 +219,13 @@ var (
 		Help: "The number of times we failed to release a client back to the pool",
 	}, clientPoolLabels)
 
+	clientPoolOpenerCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "thriftbp_client_pool_opener_calls_total",
+		Help: "The number of calls to open a new connection for a thriftbp client pool",
+	}, []string{
+		"thrift_pool",
+	})
+
 	clientPoolGetsCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "thrift_client_pool_connection_gets_total",
 		Help: "The number of times we tried to lease(get) from a thrift client pool",


### PR DESCRIPTION
We did some work previously to try to move dns out of hot path as much as possible in thrift client pool, by doing background refreshes, etc.. But there are always a (hopefully small) portion of client calls would still do dns on hot path, and we lack observability into how often that actually happens.

To get the precise data would require some breaking changes to clientpool package (to pass in required prometheus labels), so adding a counter to the opener call instead, which is the next best thing, as in we only need to ignore the spikes when a new pod comes up and need to fill in the initial clients when initialize a client pool.
