### PR TITLE
Remove CPU request scale multiplier

### DIFF
--- a/runtimebp/config.go
+++ b/runtimebp/config.go
@@ -24,8 +24,7 @@ type Config struct {
 //     This should cause the runtime to respect this value directly.
 //  2. If $BASEPLATE_CPU_REQUEST is unset/invalid, it relinquishes control to automaxprocs, minimum 2.
 //     See https://pkg.go.dev/go.uber.org/automaxprocs for specific behavior.
-//  3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by $BASEPLATE_CPU_REQUEST_SCALE
-//     (or defaultCPURequestScale) to compute the new GOMAXPROCS, minimum 2.
+//  3. Otherwise, $BASEPLATE_CPU_REQUEST is multiplied by 1.5, minimum 2.
 //
 // InitFromConfig also exports several metrics to facilitate further tuning/analysis.
 //

--- a/runtimebp/internal/maxprocs/maxprocs_test.go
+++ b/runtimebp/internal/maxprocs/maxprocs_test.go
@@ -33,14 +33,6 @@ func TestSet(t *testing.T) {
 			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
 		},
 		{
-			name: "request_with_scale",
-			env: map[string]string{
-				"BASEPLATE_CPU_REQUEST":       "42",
-				"BASEPLATE_CPU_REQUEST_SCALE": "0.9",
-			},
-			wantGOMAXPROCS: 38, // ceil(42 * 0.9)
-		},
-		{
 			name: "invalid_request",
 			env: map[string]string{
 				"BASEPLATE_CPU_REQUEST": "not a number",
@@ -48,35 +40,11 @@ func TestSet(t *testing.T) {
 			wantGOMAXPROCS: automaxprocsSentinel,
 		},
 		{
-			name: "invalid_scale",
-			env: map[string]string{
-				"BASEPLATE_CPU_REQUEST":       "42",
-				"BASEPLATE_CPU_REQUEST_SCALE": "not a number",
-			},
-			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
-		},
-		{
 			name: "zero_request",
 			env: map[string]string{
 				"BASEPLATE_CPU_REQUEST": "0",
 			},
 			wantGOMAXPROCS: automaxprocsSentinel,
-		},
-		{
-			name: "zero_scale",
-			env: map[string]string{
-				"BASEPLATE_CPU_REQUEST":       "42",
-				"BASEPLATE_CPU_REQUEST_SCALE": "0",
-			},
-			wantGOMAXPROCS: 63, // 42 * 1.5 scale default multiplier
-		},
-		{
-			name: "min_2",
-			env: map[string]string{
-				"BASEPLATE_CPU_REQUEST":       "1",
-				"BASEPLATE_CPU_REQUEST_SCALE": "1",
-			},
-			wantGOMAXPROCS: 2,
 		},
 		{
 			name: "gomaxprocs_and_request",


### PR DESCRIPTION
## 💸 TL;DR
Remove `BASEPLATE_CPU_REQUEST_SCALE` to keep users from misusing it. We
still have the `GOMAXPROCS` value as a direct escape hatch for standard
baseplate deployments.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
