### PR TITLE
tracing: Do not auto register ErrorReporterCreateServerSpanHook

### DIFF
--- a/tracing/config.go
+++ b/tracing/config.go
@@ -76,18 +76,10 @@ type Config struct {
 	TestOnlyMockMessageQueue mqsend.MessageQueue `yaml:"-"`
 }
 
-// InitFromConfig initializes the global tracer using the given Config and
-// also registers the ErrorReporterCreateServerSpanHook with the global span
-// hook registry.
+// InitFromConfig is an alias to InitGlobalTracerWithCloser.
 //
 // It returns an io.Closer that can be used to close out the tracer when the
 // server is done executing.
 func InitFromConfig(cfg Config) (io.Closer, error) {
-	closer, err := InitGlobalTracerWithCloser(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	RegisterCreateServerSpanHooks(ErrorReporterCreateServerSpanHook{})
-	return closer, nil
+	return InitGlobalTracerWithCloser(cfg)
 }


### PR DESCRIPTION
Currently tracing.InitFromConfig, which is called from baseplate.New, auto registers ErrorReporterCreateServerSpanHook. With the prometheus metrics we already have very good visibility on the errors happened on thrift/grpc/http servers, and those additional sentry reports mostly just adds noise and cost without being useful. Also in the current setup there's not really an easy way for service owners to unregister ErrorReporterCreateServerSpanHook after they called baseplate.New.

As a result, flip it to opt-in. If a service really want it, they can register it themselves in their main function, after baseplate.New call.
