### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -19,7 +19,13 @@ jobs:
       image: golang:${{ matrix.go-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Workaround Git Security Warning
+        run: |
+          # Workaround a bug in github actions:
+          # https://github.com/actions/runner-images/issues/6775.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install dependencies
         run: |

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -271,9 +271,6 @@ func NewSecrets(r io.Reader) (*Secrets, error) {
 
 // FromDir parses a directory and returns its secrets
 func FromDir(dir fs.FS) (*Secrets, error) {
-	secretsDocument := Document{
-		Secrets: make(map[string]GenericSecret),
-	}
 	secretsDocument, err := walkCSIDirectory(dir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
There's a new security warning from git suddenly started to appear
today, add a workaround to it (see [1]).

Also seems the newer version of staticcheck starts to complain a new
part of the code that's legit, so fix that as well.

[1]: https://github.com/actions/runner-images/issues/6775