### PR TITLE
errorsbp: Add Prefix

### DIFF
--- a/errorsbp/batch.go
+++ b/errorsbp/batch.go
@@ -146,7 +146,7 @@ func (be *Batch) AddPrefix(prefix string, errs ...error) {
 	}
 
 	appendSingle := func(err error) {
-		be.errors = append(be.errors, fmt.Errorf("%s: %w", prefix, err))
+		be.errors = append(be.errors, Prefix(prefix, err))
 	}
 
 	for _, err := range errs {
@@ -240,4 +240,22 @@ func BatchSize(err error) int {
 	}
 	// single, non-batch error.
 	return 1
+}
+
+// Prefix is a helper function to add prefix to a potential error.
+//
+// If err is nil, it returns nil.
+// If prefix is empty string, it returns err as-is.
+// Otherwise it returns an error that can unwrap to err with message of
+// "prefix: err.Error()".
+//
+// It's useful to be used with errors.Join.
+func Prefix(prefix string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if prefix == "" {
+		return err
+	}
+	return fmt.Errorf("%s: %w", prefix, err)
 }

--- a/errorsbp/batch_test.go
+++ b/errorsbp/batch_test.go
@@ -367,3 +367,49 @@ func TestBatchSize(t *testing.T) {
 		})
 	}
 }
+
+func TestPrefix(t *testing.T) {
+	for _, c := range []struct {
+		label   string
+		orig    error
+		prefix  string
+		wantMsg string
+	}{
+		{
+			label: "nil",
+		},
+		{
+			label:   "empty-prefix",
+			orig:    errors.New("foo"),
+			wantMsg: "foo",
+		},
+		{
+			label:   "normal",
+			orig:    errors.New("foo"),
+			prefix:  "bar",
+			wantMsg: "bar: foo",
+		},
+	} {
+		t.Run(c.label, func(t *testing.T) {
+			err := errorsbp.Prefix(c.prefix, c.orig)
+			if c.orig == nil {
+				if err != nil {
+					t.Errorf("Want nil error when orig is nil, got %v", err)
+				}
+				return
+			}
+			if got, want := err.Error(), c.wantMsg; got != want {
+				t.Errorf("Got error message %q, want %q", got, want)
+			}
+			if c.prefix == "" {
+				if err != c.orig {
+					t.Errorf("Got %v (%p), want %v (%p)", err, err, c.orig, c.orig)
+				}
+			} else {
+				if !errors.Is(err, c.orig) {
+					t.Errorf("errors.Is(%v, %v) is false", err, c.orig)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This replaces errorsbp.Batch.AddPrefix for services already on go 1.20
to migrate from errorsbp.Batch to errors.Join, and help our eventual
deprecation of errorsbp.Batch when we drop support to go 1.19.

Currently a typical use case with errorsbp.Batch is like this:

    var batch errorsbp.Batch
    ...
    for _, work := range works {
      batch.AddPrefix(work.Name(), work.Do())
    }
    ...
    return batch.Compile()

With this change and go 1.20, they would change the code to something
like this:

    var errs []error
    ...
    for _, work := range works {
      errs = append(errs, errorsbp.Prefix(work.Name(), work.Do()))
    }
    ...
    return errors.Join(errs)

Without this change, they would need to add extra ifs to avoid producing
non-nil error if nothing failed:

    var errs []error
    ...
    for _, work := range works {
      if err := work.Do(); err != nil {
        errs = append(errs, fmt.Errorf("%s: %w", work.Name(), err))
      }
    }
    ...
    return errors.Join(errs)

Although errorsbp.Batch.AddPrefix does allow prefixing multiple errors
with the same prefix, which is not easy to do with this new function,
an internal code search shows that almost no one actually use AddPrefix
with multiple errors.