### PR TITLE
clientpool: Follow up on 6f97656

### DIFF
--- a/clientpool/channel_test.go
+++ b/clientpool/channel_test.go
@@ -55,16 +55,27 @@ func TestChannelPoolWithOpenerFailure(t *testing.T) {
 		}
 	}
 
-	const min, init, max = 0, 1, 5
+	const min, init, max = 0, 2, 5
 	t.Run(
-		"new-with-min-2-should-fail-initialization",
+		"new-with-init-2-should-not-fail-initialization",
 		func(t *testing.T) {
-			pool, err := clientpool.NewChannelPool(context.Background(), min, 2, max, opener())
-			if err == nil {
-				t.Error("NewChannelPool with min = 2 should fail but did not.")
+			pool, err := clientpool.NewChannelPool(context.Background(), min, init, max, opener())
+			if err != nil {
+				t.Errorf(
+					"NewChannelPool with (min, init, max) = (%d, %d, %d) failed with: %v",
+					min,
+					init,
+					max,
+					err,
+				)
 			}
 			if pool == nil {
-				t.Error("NewChannelPool with min = 2 should return non-nil pool.")
+				t.Errorf(
+					"NewChannelPool with (min, init, max) = (%d, %d, %d) should return non-nil pool",
+					min,
+					init,
+					max,
+				)
 			}
 		},
 	)

--- a/thriftbp/client_pool_test.go
+++ b/thriftbp/client_pool_test.go
@@ -241,13 +241,6 @@ func TestInitialConnectionsFallback(t *testing.T) {
 		},
 	} {
 		t.Run(c.label, func(t *testing.T) {
-			var loggerCalled atomic.Int64
-			logger := func(_ context.Context, msg string) {
-				t.Logf("InitialConnectionsFallbackLogger called with %q", msg)
-				loggerCalled.Store(1)
-			}
-
-			c.cfg.InitialConnectionsFallbackLogger = logger
 			factory := thrift.NewTBinaryProtocolFactoryConf(c.cfg.ToTConfiguration())
 
 			_, err := thriftbp.NewCustomClientPool(c.cfg, addrGen, factory)
@@ -259,9 +252,6 @@ func TestInitialConnectionsFallback(t *testing.T) {
 			} else {
 				if err != nil {
 					t.Errorf("Expected no error, got: %v", err)
-				}
-				if loggerCalled.Load() != 1 {
-					t.Error("InitialConnectionsFallbackLogger not called")
 				}
 			}
 		})


### PR DESCRIPTION
The only reason the constructor in clientpool would return both non-nil Pool and error is to avoid making breaking changes. Since we already made a breaking change in 6f97656, it's better to always return nil Pool when returning an error.

Also fix %w used in logging, and add doccomment to the newly added functions in thriftbp.
