### PR TITLE
kafkabp: Add a gauge to report configured version

### DIFF
--- a/kafkabp/config.go
+++ b/kafkabp/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/Shopify/sarama"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/reddit/baseplate.go/log"
 )
@@ -153,6 +154,9 @@ func (cfg *ConsumerConfig) NewSaramaConfig() (*sarama.Config, error) {
 			)
 		}
 	}
+	kafkaVersionGauge.With(prometheus.Labels{
+		"kafka_version": version.String(),
+	}).Set(1)
 
 	c := sarama.NewConfig()
 

--- a/kafkabp/prometheus.go
+++ b/kafkabp/prometheus.go
@@ -82,3 +82,10 @@ var (
 		Help:      "Total failures of getting rack id from http endpoint",
 	})
 )
+
+var (
+	kafkaVersionGauge = promauto.With(prometheusbpint.GlobalRegistry).NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kafkabp_consumer_configured_version",
+		Help: "The kafka version in kafkabp consumer config",
+	}, []string{"kafka_version"})
+)


### PR DESCRIPTION
There are certain kafka features requiring a minimal configured version to work, so this gauge can provide us visibility on whether we have consumers configured on lower version (or didn't configure it and use the default version) before we enable those features to avoid production outage.
