### PR TITLE
feat: Improve shutdown Delay default

### DIFF
--- a/baseplate.go
+++ b/baseplate.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// DefaultStopDelay is the default StopDelay to be used in Serve.
-	DefaultStopDelay = 1 * time.Second
+	DefaultStopDelay = 5 * time.Second
 )
 
 // Configer defines the interface that allows you to extend Config with your own


### PR DESCRIPTION
When a baseplate server is shutting down in k8s

* baseplate calls func (srv *Server) Shutdown(ctx context.Context) error which does the following:
* Shutdown works by first closing all open listeners

* k8s is attempting to remove the endpoint for the endpoints group and thus make (new) incoming traffic to the pod 0

This is a race condition because some callers are still trying to connect. We have empirically seen that the 5 second default is good enough for most services.
