### PR TITLE
Metrics cleanup

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -13,7 +13,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.19
+          - "1.19"
+          - "1.20"
 
     container:
       image: golang:${{ matrix.go-version }}

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -288,9 +288,6 @@ func recoverPanik(name string, next HandlerFunc) HandlerFunc {
 	counter := panicRecoverCounter.With(prometheus.Labels{
 		methodLabel: name,
 	})
-	legacyCounter := legacyPanicRecoverCounter.With(prometheus.Labels{
-		methodLabel: name,
-	})
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request) (err error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -306,7 +303,6 @@ func recoverPanik(name string, next HandlerFunc) HandlerFunc {
 					"endpoint", name,
 				)
 				counter.Inc()
-				legacyCounter.Inc()
 
 				// change named return value to a generic 500 error
 				err = RawError(InternalServerError(), rErr, PlainTextContentType)

--- a/httpbp/prometheus.go
+++ b/httpbp/prometheus.go
@@ -128,24 +128,10 @@ var (
 	}, clientActiveRequestsLabels)
 )
 
-const (
-	// Note that this is not used by prometheus metrics defined in Baseplate spec.
-	promNamespace   = "httpbp"
-	subsystemServer = "server"
-)
-
 var (
 	panicRecoverLabels = []string{
 		methodLabel,
 	}
-
-	// TODO: Remove after next release (v0.9.12)
-	legacyPanicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemServer,
-		Name:      "panic_recover_total",
-		Help:      "Deprecated: use httpbp_server_recovered_panics_total instead",
-	}, panicRecoverLabels)
 
 	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "httpbp_server_recovered_panics_total",

--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -3,7 +3,6 @@ package kafkabp
 import (
 	"context"
 	"io"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -11,17 +10,8 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/reddit/baseplate.go/prometheusbp"
 	"github.com/reddit/baseplate.go/tracing"
 )
-
-// TODO: Remove after next release (v0.9.12)
-func init() {
-	// Register the error counter so that it can be monitored.
-	rebalanceCounter.With(prometheus.Labels{
-		successLabel: prometheusbp.BoolString(false),
-	})
-}
 
 // ConsumeMessageFunc is a function type for consuming consumer messages.
 //
@@ -195,10 +185,6 @@ func (kc *consumer) reset() error {
 			if err != nil {
 				rebalanceFailureCounter.Inc()
 			}
-			// TODO: Remove after next release (v0.9.12)
-			rebalanceCounter.With(prometheus.Labels{
-				successLabel: strconv.FormatBool(err == nil),
-			}).Inc()
 		}()
 
 		c, err := sarama.NewConsumer(kc.cfg.Brokers, kc.sc)

--- a/kafkabp/prometheus.go
+++ b/kafkabp/prometheus.go
@@ -18,20 +18,6 @@ const (
 	topicLabel   = "kafka_topic"
 )
 
-// TODO: Remove after next release (v0.9.12)
-var (
-	rebalanceLabels = []string{
-		successLabel,
-	}
-
-	rebalanceCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemConsumer,
-		Name:      "rebalance_total",
-		Help:      "Deprecated: use kafkabp_consumer_rebalances_total and kafkabp_consumer_rebalance_failures_total instead",
-	}, rebalanceLabels)
-)
-
 var (
 	rebalanceTotalCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounter(prometheus.CounterOpts{
 		Namespace: promNamespace,

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -168,14 +168,6 @@ var (
 		methodLabel,
 	}
 
-	// TODO: Remove after the next release (v0.9.12)
-	legacyPanicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemServer,
-		Name:      "panic_recover_total",
-		Help:      "Deprecated: Use thriftbp_server_recovered_panics_total instead",
-	}, panicRecoverLabels)
-
 	panicRecoverCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "thriftbp_server_recovered_panics_total",
 		Help: "The number of panics recovered from thrift server handlers",
@@ -184,17 +176,8 @@ var (
 
 var (
 	clientPoolLabels = []string{
-		clientNameLabel, // TODO: Remove after the next release (v0.9.12)
 		"thrift_pool",
 	}
-
-	// TODO: Remove after the next release (v0.9.12)
-	legacyClientPoolExhaustedCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemClientPool,
-		Name:      "exhausted_total",
-		Help:      "Deprecated: Use thriftbp_client_pool_exhaustions_total instead",
-	}, clientPoolLabels)
 
 	clientPoolExhaustedCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "thriftbp_client_pool_exhaustions_total",
@@ -204,14 +187,6 @@ var (
 	clientPoolClosedConnectionsCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "thriftbp_client_pool_closed_connections_total",
 		Help: "The number of times we closed the client after used it from the pool",
-	}, clientPoolLabels)
-
-	// TODO: Remove after the next release (v0.9.12)
-	legacyClientPoolReleaseErrorCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemClientPool,
-		Name:      "release_error_total",
-		Help:      "Deprecated: Use thriftbp_client_pool_release_errors_total instead",
 	}, clientPoolLabels)
 
 	clientPoolReleaseErrorCounter = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
@@ -238,22 +213,6 @@ var (
 		Name: "thrift_client_pool_max_size",
 		Help: "The configured max size of a thrift client pool",
 	}, []string{"thrift_pool"})
-
-	// TODO: Remove after the next release (v0.9.12)
-	legacyClientPoolActiveConnectionsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(promNamespace, subsystemClientPool, "active_connections"),
-		"The number of active (in-use) connections of a thrift client pool",
-		clientPoolLabels,
-		nil, // const labels
-	)
-
-	// TODO: Remove after the next release (v0.9.12)
-	legacyClientPoolAllocatedClientsDesc = prometheus.NewDesc(
-		prometheus.BuildFQName(promNamespace, subsystemClientPool, "allocated_clients"),
-		"The number of allocated (in-pool) clients of a thrift client pool",
-		clientPoolLabels,
-		nil, // const labels
-	)
 
 	clientPoolPeakActiveConnectionsDesc = prometheus.NewDesc(
 		"thrift_client_pool_peak_active_connections",
@@ -314,21 +273,6 @@ func (e *clientPoolGaugeExporter) Collect(ch chan<- prometheus.Metric) {
 
 	// MustNewConstMetric would only panic if there's a label mismatch, which we
 	// have a unit test to cover.
-	ch <- prometheus.MustNewConstMetric(
-		legacyClientPoolActiveConnectionsDesc,
-		prometheus.GaugeValue,
-		float64(active),
-		e.slug,
-		e.slug,
-	)
-	ch <- prometheus.MustNewConstMetric(
-		legacyClientPoolAllocatedClientsDesc,
-		prometheus.GaugeValue,
-		idle,
-		e.slug,
-		e.slug,
-	)
-
 	ch <- prometheus.MustNewConstMetric(
 		clientPoolActiveConnectionsDesc,
 		prometheus.GaugeValue,

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -374,10 +374,6 @@ func recoverPanik(name string, next thrift.TProcessorFunction) thrift.TProcessor
 	counter := panicRecoverCounter.With(prometheus.Labels{
 		methodLabel: name,
 	})
-	// TODO: Remove after next release (v0.9.12)
-	legacyCounter := legacyPanicRecoverCounter.With(prometheus.Labels{
-		methodLabel: name,
-	})
 	return thrift.WrappedTProcessorFunction{
 		Wrapped: func(ctx context.Context, seqId int32, in, out thrift.TProtocol) (ok bool, err thrift.TException) {
 			defer func() {
@@ -394,7 +390,6 @@ func recoverPanik(name string, next thrift.TProcessorFunction) thrift.TProcessor
 						"endpoint", name,
 					)
 					counter.Inc()
-					legacyCounter.Inc()
 
 					// changed named return values to show that the request failed and
 					// return the panic value error.


### PR DESCRIPTION
1. Change some of the references to statsd metrics in doc comments to prometheus metrics.
2. Remove the deprecated prometheus metrics/labels from the previous release.

While I'm here, also add go 1.20 to CI.