### PR TITLE
[EX-608] Deprecate Experiments

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -16,7 +16,11 @@ import (
 
 	"github.com/gofrs/uuid"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"github.com/reddit/baseplate.go/filewatcher"
+	"github.com/reddit/baseplate.go/internal/prometheusbpint"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/timebp"
 )
@@ -25,6 +29,16 @@ const (
 	numBuckets        = 1000
 	targetAllOverride = `{"OVERRIDE": true}`
 )
+
+var variantTotalRequests = promauto.With(prometheusbpint.GlobalRegistry).NewCounter(prometheus.CounterOpts{
+	Name: "experiments_go_variant_requests_total",
+	Help: "Total experiments.go Variant() request count",
+})
+
+var exposeTotalRequests = promauto.With(prometheusbpint.GlobalRegistry).NewCounter(prometheus.CounterOpts{
+	Name: "experiments_go_expose_requests_total",
+	Help: "Total experiments.go Expose() request count",
+})
 
 // MissingBucketKeyError is a special error returned by Variant functions,
 // to indicate that the bucket key from the args map is missing.
@@ -100,6 +114,8 @@ func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, l
 // Caller usually want to check for that and handle it differently from other
 // errors. See its documentation for more details.
 func (e *Experiments) Variant(name string, args map[string]interface{}, bucketingEventOverride bool) (string, error) {
+	variantTotalRequests.Inc()
+
 	experiment, err := e.experiment(name)
 	if err != nil {
 		return "", err
@@ -110,6 +126,8 @@ func (e *Experiments) Variant(name string, args map[string]interface{}, bucketin
 // Expose logs an event to indicate that a user has been exposed to an
 // experimental treatment.
 func (e *Experiments) Expose(ctx context.Context, experimentName string, event ExperimentEvent) error {
+	exposeTotalRequests.Inc()
+
 	doc := e.watcher.Get().(document)
 	experiment, ok := doc[experimentName]
 	if !ok {

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -57,6 +57,8 @@ type Experiments struct {
 //
 // Context should come with a timeout otherwise this might block forever, i.e.
 // if the path never becomes available.
+//
+// Deprecated: baseplate.go/experiments is deprecated. Instead, use Decider API (github.snooguts.net/reddit-go/decider).
 func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, logger log.Wrapper) (*Experiments, error) {
 	parser := func(r io.Reader) (interface{}, error) {
 		var doc document
@@ -95,6 +97,9 @@ func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, l
 // This function might return MissingBucketKeyError as the error.
 // Caller usually want to check for that and handle it differently from other
 // errors. See its documentation for more details.
+//
+// Deprecated: Variant() of baseplate.go/experiments is deprecated.
+// Instead, use Choose() of Decider API (github.snooguts.net/reddit-go/decider).
 func (e *Experiments) Variant(name string, args map[string]interface{}, bucketingEventOverride bool) (string, error) {
 	experiment, err := e.experiment(name)
 	if err != nil {
@@ -105,6 +110,10 @@ func (e *Experiments) Variant(name string, args map[string]interface{}, bucketin
 
 // Expose logs an event to indicate that a user has been exposed to an
 // experimental treatment.
+//
+// Deprecated: Expose() of baseplate.go/experiments is deprecated.
+// Instead, Choose() of Decider API (github.snooguts.net/reddit-go/decider) does auto-exposure.
+// If manual exposure is necessary, keep track of exposure events in exposer function and PutRaw() onto event queue later.
 func (e *Experiments) Expose(ctx context.Context, experimentName string, event ExperimentEvent) error {
 	doc := e.watcher.Get().(document)
 	experiment, ok := doc[experimentName]

--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -1,3 +1,7 @@
+// Package experiments has been deprecated in favor of reddit-go/decider internal package.
+// Use Choose() in lieu of Varinat(), which also enables optional auto-exposure.
+//
+// Deprecated: baseplate.go/experiments is deprecated. Instead, use reddit-go/decider (internal).
 package experiments
 
 import (
@@ -57,8 +61,6 @@ type Experiments struct {
 //
 // Context should come with a timeout otherwise this might block forever, i.e.
 // if the path never becomes available.
-//
-// Deprecated: baseplate.go/experiments is deprecated. Instead, use Decider API (github.snooguts.net/reddit-go/decider).
 func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, logger log.Wrapper) (*Experiments, error) {
 	parser := func(r io.Reader) (interface{}, error) {
 		var doc document
@@ -97,9 +99,6 @@ func NewExperiments(ctx context.Context, path string, eventLogger EventLogger, l
 // This function might return MissingBucketKeyError as the error.
 // Caller usually want to check for that and handle it differently from other
 // errors. See its documentation for more details.
-//
-// Deprecated: Variant() of baseplate.go/experiments is deprecated.
-// Instead, use Choose() of Decider API (github.snooguts.net/reddit-go/decider).
 func (e *Experiments) Variant(name string, args map[string]interface{}, bucketingEventOverride bool) (string, error) {
 	experiment, err := e.experiment(name)
 	if err != nil {
@@ -110,10 +109,6 @@ func (e *Experiments) Variant(name string, args map[string]interface{}, bucketin
 
 // Expose logs an event to indicate that a user has been exposed to an
 // experimental treatment.
-//
-// Deprecated: Expose() of baseplate.go/experiments is deprecated.
-// Instead, Choose() of Decider API (github.snooguts.net/reddit-go/decider) does auto-exposure.
-// If manual exposure is necessary, keep track of exposure events in exposer function and PutRaw() onto event queue later.
 func (e *Experiments) Expose(ctx context.Context, experimentName string, event ExperimentEvent) error {
 	doc := e.watcher.Get().(document)
 	experiment, ok := doc[experimentName]


### PR DESCRIPTION
## 💸 TL;DR
In the effort to migrate more services to new Decider experiments SDK, the old baseplate Experiments code is being marked deprecated.

## 📜 Details
[Jira](https://reddit.atlassian.net/browse/EX-608)
