### PR TITLE
make secrets.Store middleware threadsafe

### DIFF
--- a/secrets/store.go
+++ b/secrets/store.go
@@ -118,7 +118,8 @@ func (s *Store) secretHandler(middlewares ...SecretMiddleware) {
 
 // secretHandlerFunc guards calling s.unsafeSecretHandlerFunc with a mutex.
 func (s *Store) secretHandlerFunc(sec *Secrets) {
-	// grab current secret handler func while holding the lock
+	// grab current secret handler func while holding the lock to guard against
+	// updates to the handler func.
 	currentSecretHandlerFunc := func() SecretHandlerFunc {
 		s.mu.Lock()
 		defer s.mu.Unlock()
@@ -126,7 +127,8 @@ func (s *Store) secretHandlerFunc(sec *Secrets) {
 		return s.unsafeSecretHandlerFunc
 	}()
 
-	// execute the secret handler func outside the lock
+	// execute the secret handler func outside the lock to not tie it up once
+	// we safely have a handler func.
 	currentSecretHandlerFunc(sec)
 }
 

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -36,7 +36,7 @@ type Store struct {
 	// mutex to guard unsafeSecretHandlerFunc
 	// call handler function using the secretHandlerFunc function rather than
 	// calling unsafeSecretHandlerFunc directly
-	mu                      sync.Mutex
+	mu                      *sync.Mutex
 	unsafeSecretHandlerFunc SecretHandlerFunc
 }
 
@@ -53,6 +53,7 @@ func NewStore(ctx context.Context, path string, logger log.Wrapper, middlewares 
 // Used in tests to override FSEventsDelay
 func newStore(ctx context.Context, fsEventsDelay time.Duration, path string, logger log.Wrapper, middlewares ...SecretMiddleware) (*Store, error) {
 	store := &Store{
+		mu:                      &sync.Mutex{},
 		unsafeSecretHandlerFunc: nopSecretHandlerFunc,
 	}
 	store.secretHandler(middlewares...)

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -36,7 +36,7 @@ type Store struct {
 	// mutex to guard unsafeSecretHandlerFunc
 	// call handler function using the secretHandlerFunc function rather than
 	// calling unsafeSecretHandlerFunc directly
-	mu                      *sync.Mutex
+	mu                      sync.Mutex
 	unsafeSecretHandlerFunc SecretHandlerFunc
 }
 
@@ -53,7 +53,6 @@ func NewStore(ctx context.Context, path string, logger log.Wrapper, middlewares 
 // Used in tests to override FSEventsDelay
 func newStore(ctx context.Context, fsEventsDelay time.Duration, path string, logger log.Wrapper, middlewares ...SecretMiddleware) (*Store, error) {
 	store := &Store{
-		mu:                      &sync.Mutex{},
 		unsafeSecretHandlerFunc: nopSecretHandlerFunc,
 	}
 	store.secretHandler(middlewares...)
@@ -154,17 +153,17 @@ func (s *Store) AddMiddlewares(middlewares ...SecretMiddleware) {
 }
 
 // GetSimpleSecret loads secrets from watcher, and fetches a simple secret from secrets
-func (s Store) GetSimpleSecret(path string) (SimpleSecret, error) {
+func (s *Store) GetSimpleSecret(path string) (SimpleSecret, error) {
 	return s.getSecrets().GetSimpleSecret(path)
 }
 
 // GetVersionedSecret loads secrets from watcher, and fetches a versioned secret from secrets
-func (s Store) GetVersionedSecret(path string) (VersionedSecret, error) {
+func (s *Store) GetVersionedSecret(path string) (VersionedSecret, error) {
 	return s.getSecrets().GetVersionedSecret(path)
 }
 
 // GetCredentialSecret loads secrets from watcher, and fetches a credential secret from secrets
-func (s Store) GetCredentialSecret(path string) (CredentialSecret, error) {
+func (s *Store) GetCredentialSecret(path string) (CredentialSecret, error) {
 	return s.getSecrets().GetCredentialSecret(path)
 }
 
@@ -173,6 +172,6 @@ func (s Store) GetCredentialSecret(path string) (CredentialSecret, error) {
 // role. This is only necessary if talking directly to Vault.
 //
 // This function always returns nil error.
-func (s Store) GetVault() (Vault, error) {
+func (s *Store) GetVault() (Vault, error) {
 	return s.getSecrets().vault, nil
 }

--- a/secrets/store.go
+++ b/secrets/store.go
@@ -116,7 +116,7 @@ func (s *Store) secretHandler(middlewares ...SecretMiddleware) {
 	}
 }
 
-// secretHandlerFunc guards s.unsafeSecretHandlerFunc with a mutex.
+// secretHandlerFunc guards calling s.unsafeSecretHandlerFunc with a mutex.
 func (s *Store) secretHandlerFunc(sec *Secrets) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/secrets/testing.go
+++ b/secrets/testing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+
 	"github.com/reddit/baseplate.go/filewatcher"
 )
 

--- a/secrets/testing.go
+++ b/secrets/testing.go
@@ -77,7 +77,7 @@ func NewTestSecrets(ctx context.Context, raw map[string]GenericSecret, middlewar
 	}
 
 	store := &Store{
-		secretHandlerFunc: nopSecretHandlerFunc,
+		unsafeSecretHandlerFunc: nopSecretHandlerFunc,
 	}
 	store.secretHandler(middlewares...)
 

--- a/secrets/testing.go
+++ b/secrets/testing.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"sync"
 
 	"github.com/reddit/baseplate.go/filewatcher"
 )
@@ -77,6 +78,7 @@ func NewTestSecrets(ctx context.Context, raw map[string]GenericSecret, middlewar
 	}
 
 	store := &Store{
+		mu:                      &sync.Mutex{},
 		unsafeSecretHandlerFunc: nopSecretHandlerFunc,
 	}
 	store.secretHandler(middlewares...)

--- a/secrets/testing.go
+++ b/secrets/testing.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sync"
-
 	"github.com/reddit/baseplate.go/filewatcher"
 )
 
@@ -78,7 +76,6 @@ func NewTestSecrets(ctx context.Context, raw map[string]GenericSecret, middlewar
 	}
 
 	store := &Store{
-		mu:                      &sync.Mutex{},
 		unsafeSecretHandlerFunc: nopSecretHandlerFunc,
 	}
 	store.secretHandler(middlewares...)


### PR DESCRIPTION
## 💸 TL;DR
Guard secrets.Store middleware with a mutex to make adding new middlewares to an existing store threadsafe.

## 📜 Details
Sometimes we have to call `AddMiddleware` in a goroutine which can lead to race conditions with other calls to `AddMiddleware`. Adding a mutex around updating and calling the middleware functions protects us from this.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
