### PR TITLE
[RFC][Snoosweek] Support for DTab overrides

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/google/go-cmp v0.5.9
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/joomcode/errorx v1.0.3
 	github.com/joomcode/redispipe v0.9.4
 	github.com/opentracing/opentracing-go v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
+github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -45,7 +45,7 @@ const (
 	// request headers.
 	TraceIDHeader = "X-Trace"
 
-	DTabsHeader = "X-DTabs-Add"
+	DTabsHeader = "X-DTabs"
 )
 
 // Headers is an interface to collect all of the HTTP headers for a particular

--- a/httpbp/headers.go
+++ b/httpbp/headers.go
@@ -44,6 +44,8 @@ const (
 	// TraceIDHeader is the key use to get the trace ID from the HTTP
 	// request headers.
 	TraceIDHeader = "X-Trace"
+
+	DTabsHeader = "X-DTabs-Add"
 )
 
 // Headers is an interface to collect all of the HTTP headers for a particular

--- a/thriftbp/headers.go
+++ b/thriftbp/headers.go
@@ -13,6 +13,7 @@ import (
 // HeadersToForward are the headers that should always be forwarded to upstream
 // thrift servers, to be used in thrift.TSimpleServer.SetForwardHeaders.
 var HeadersToForward = []string{
+	transport.HeaderDTabs,
 	transport.HeaderEdgeRequest,
 	transport.HeaderTracingTrace,
 	transport.HeaderTracingSpan,

--- a/transport/dtabs.go
+++ b/transport/dtabs.go
@@ -1,0 +1,44 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+/**
+ * DTabs are strings in the following form:
+ * service.from=>service.to;another-service.from=>another-service.to
+ */
+func ParseDTabs(unparsed string) (map[string]string, error) {
+	dentries := filterDEntries(strings.Split(unparsed, ";"))
+	result := make(map[string]string)
+	for _, unparsedDEntry := range dentries {
+		from, to, err := parseDEntry(unparsedDEntry)
+		if err != nil {
+			return nil, err
+		}
+		result[from] = to
+	}
+	return result, nil
+}
+
+func parseDEntry(unparsed string) (string, string, error) {
+	overrides := strings.Split(unparsed, "=>")
+	if len(overrides) != 2 {
+		return "", "", errors.New(fmt.Sprintf("malformed DEntry %s", unparsed))
+	}
+	return strings.TrimSpace(overrides[0]), strings.TrimSpace(overrides[1]), nil
+}
+
+// This makes sure we drop the trailing semi-colon
+func filterDEntries(dentries []string) []string {
+	res := make([]string, 0)
+	for _, dentry := range dentries {
+		trimmed := strings.TrimSpace(dentry)
+		if len(trimmed) != 0 {
+			res = append(res, trimmed)
+		}
+	}
+	return res
+}

--- a/transport/dtabs_test.go
+++ b/transport/dtabs_test.go
@@ -1,0 +1,58 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/reddit/baseplate.go/transport"
+)
+
+func TestDTabs_HappyPath(t *testing.T) {
+	dtab := "prod-service=>test-service;another-service=>different-test-service"
+	expected := map[string]string{
+		"prod-service":    "test-service",
+		"another-service": "different-test-service",
+	}
+	parsed, err := transport.ParseDTabs(dtab)
+	if err != nil {
+		t.Error(err, "Could not parse DTabs")
+	}
+	if len(parsed) != 2 {
+		t.Errorf("Expected to see two items in %v", parsed)
+	}
+	for expectedK, expectedV := range expected {
+		if parsed[expectedK] != expectedV {
+			t.Errorf("Expected %s to map to %s, but got %s in %v", expectedK, expectedV, parsed[expectedK], parsed)
+		}
+	}
+}
+
+func TestDTabs_WithWhatespaces(t *testing.T) {
+	dtab := "; prod-service => test-service ; another-service =>  different-test-service  ;  "
+	expected := map[string]string{
+		"prod-service":    "test-service",
+		"another-service": "different-test-service",
+	}
+	parsed, err := transport.ParseDTabs(dtab)
+	if err != nil {
+		t.Error(err, "Could not parse DTabs")
+	}
+	if len(parsed) != 2 {
+		t.Errorf("Expected to see two items in %v", parsed)
+	}
+	for expectedK, expectedV := range expected {
+		if parsed[expectedK] != expectedV {
+			t.Errorf("Expected %s to map to %s, but got %s in %v", expectedK, expectedV, parsed[expectedK], parsed)
+		}
+	}
+}
+
+func TestDTabs_Malformed(t *testing.T) {
+	dtab := "prod-service=>test-service=>something-is-wrong-here;another-service=>different-test-service"
+	parsed, err := transport.ParseDTabs(dtab)
+	if err == nil {
+		t.Error(err, "Expected to see an error")
+	}
+	if len(parsed) != 0 {
+		t.Errorf("Expected to see no items in %v", parsed)
+	}
+}

--- a/transport/headers.go
+++ b/transport/headers.go
@@ -25,4 +25,9 @@ const (
 	HeaderTracingSampledTrue = "1"
 	// Number of milliseconds, 64-bit integer encoded in decimal.
 	HeaderDeadlineBudget = "Deadline-Budget"
+	// Delegation tables (dtabs for short).
+	// DTabs influence address resolution at request level, and are passed along
+	// in the headers throughout the system. This allows us to do re-routing during
+	// an in-flight request, at arbitrary depth of RPC call graph.
+	HeaderDTabs = "DTabs"
 )


### PR DESCRIPTION
## 📚 Background reading
* [Linkerd doc](https://linkerd.io/1/advanced/dtabs/)
  * [Namers](https://github.com/linkerd/linkerd/blob/master/linkerd/docs/namer.md)
* [Finagle doc](https://twitter.github.io/finagle/guide/Names.html#interpreting-paths-with-delegation-tables)

## 💸 TL;DR
This PR demonstrates a simple support for system-wide request-level target override for services. I've tried my best to demonstrate how it would work in the following diagram:
![Diagram](https://github.com/reddit/baseplate.go/assets/366132/ea409af3-fe47-49ae-8257-4e0603c9f286)

## 📜 Details
This is a demonstration PR, intended to elicit comments/opinions, not intended for merging as is.

This change does not exactly implement DTabs as described in the docs above – those require some internal knowledge of service/name resolver on behalf of the client constructor. Rather, this change is inspired by those documents. Which means the name "DTab" might not actually be very relevant here. Should this be called something like "ServiceAddressOverrides" instead?

### 💡 The general idea is as follows:
* We add a new request header that describes the desired overrides. In this implementation, the header (`X-DTabs`) takes the following form: `service.a.prod=>service.a.staging; service.b.prod=>service.b.staging;`. In this case we instruct the client to replace all the calls to `service.a.prod` with `service.a.staging` and all the calls to `service.b.prod` with `service.b.staging`. See the newly added tests for more context.
* The header gets propagated in the contexts, the same way we propagate other headers (such as the tracing headers).
* Whenever we encounter calls to `service.a.prod` or `service.b.prod` on our request path, and the above DTab is set, we reroute the requests to `service.a.staging`/`service.b.staging` correspondingly.

## 🧑‍🔬 User stories
* I'm a Product Manager, wanting to test out a feature that one of the engineers on my team is working on. Standing up a staged environment of everything is fine I guess. But I'd prefer that the engineer could stage just the services they are changing, and give me some headers I could plug into [ModHeader](https://chrome.google.com/webstore/detail/modheader-modify-http-hea/idgpnmonknjnojddfkpgkljpfnnfcklj), so I could use the actual product we're developing in its production environment (except for that one service).
* I'm an engineer building a [Snoosweek](https://www.reddit.com/r/RedditEng/comments/15r5oez/the_fall_2023_of_snoosweek/) feature. A bunch of the code I've written is in other teams' codebases, and lacks testing coverage (since it's a prototype, and I only had half a week to tie it all together). Reasonably enough, that other team won't let me merge/deploy the code to be able to demo it, even if I promise to hide everything behind an experiment and roll everything back next week.
* I'm an on-call engineer from a Core Services team during Snoosweek. Dozens of engineers have amazing ideas that involve code changes in my team's codebases. I'm happy to facilitate them demoing those changes, but a lot of these changes have merge conflicts with each other, and I don't exactly want all of those prototypes in our codebase during a code freeze. Wouldn't it be great if they could just stage their own versions of the service?

## 🔨 Improvements that can/should be made here
- [x] Creating new clients for dtabbed requests is much more expensive than just fetching a client from the pool. We could add an LRU cache for newly created client pools, to avoid re-creating them upon each call.
- [ ] DTabs should be passed around in a parsed form, rather than the string representation I have here, since this requires each successive service to re-parse the header.
- [ ] This PR only implements overriding target addresses for thrift clients. Complete implementation would involve supporting these overrides for all the clients baseplate has (e.g. gRPC).
- [ ] These headers should likely be filtered out from external (outside of Reddit) requests, to avoid leaking existing staged internal service addresses.
- [ ] Tests asserting new clients with address overrides get created when DTab headers are present.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
