### PR TITLE
tracing: skip reconfiguration if tracer already configured

### DIFF
--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -65,18 +65,18 @@ type IsThrift interface {
 	isThrift()
 }
 
-var (
-	v2TracingEnabledMutex sync.RWMutex
-	v2TracingEnabled      bool
-)
+var v2Tracing struct {
+	sync.Mutex
+	enabled bool
+}
 
 func SetV2TracingEnabled(enabled bool) {
-	v2TracingEnabledMutex.Lock()
-	defer v2TracingEnabledMutex.Unlock()
-	v2TracingEnabled = enabled
+	v2Tracing.Lock()
+	defer v2Tracing.Unlock()
+	v2Tracing.enabled = enabled
 }
 func V2TracingEnabled() bool {
-	v2TracingEnabledMutex.RLock()
-	defer v2TracingEnabledMutex.RUnlock()
-	return v2TracingEnabled
+	v2Tracing.Lock()
+	defer v2Tracing.Unlock()
+	return v2Tracing.enabled
 }

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -8,6 +8,7 @@ package internalv2compat
 
 import (
 	"os"
+	"sync"
 	"sync/atomic"
 
 	"go.uber.org/zap"
@@ -62,4 +63,20 @@ type IsHTTP interface {
 // IsThrift allows detecting the unexported thriftbp.server without resorting to reflection.
 type IsThrift interface {
 	isThrift()
+}
+
+var (
+	v2TracingEnabledMutex sync.RWMutex
+	v2TracingEnabled      bool
+)
+
+func SetV2TracingEnabled(enabled bool) {
+	v2TracingEnabledMutex.Lock()
+	defer v2TracingEnabledMutex.Unlock()
+	v2TracingEnabled = enabled
+}
+func V2TracingEnabled() bool {
+	v2TracingEnabledMutex.RLock()
+	defer v2TracingEnabledMutex.RUnlock()
+	return v2TracingEnabled
 }

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/reddit/baseplate.go/detach"
+	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/mqsend"

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -84,12 +84,8 @@ type Tracer struct {
 // If it fails to do so, UndefinedIP will be used instead,
 // and the error will be logged if logger is non-nil.
 func InitGlobalTracer(cfg Config) error {
-	logger := cfg.Logger
-	if logger == nil {
-		logger = log.NopWrapper
-	}
 	if internalv2compat.V2TracingEnabled() {
-		logger(context.Background(), `v2 tracing is enabled; skipping v0 tracer configuration`)
+		cfg.Logger.Log(context.Background(), `v2 tracing is enabled; skipping v0 tracer configuration`)
 		return nil
 	}
 	var tracer Tracer
@@ -112,7 +108,13 @@ func InitGlobalTracer(cfg Config) error {
 
 	tracer.sampleRate = cfg.SampleRate
 	tracer.useHex = cfg.UseHex
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.NopWrapper
+	}
 	tracer.logger = logger
+
 	tracer.maxRecordTimeout = cfg.MaxRecordTimeout
 
 	ip, err := runtimebp.GetFirstIPv4()


### PR DESCRIPTION
## 💸 TL;DR
In baseplate.go v2 we configure a global opentracing tracer. Currently, calling `baseplate.New` will override the new tracer. This change prevents the override using a flag in `internalv2compat`.

## 📜 Details
If `internalv2compat.SetV2TracingEnabled(true)` is called before `InitGlobalTracer`, the opentracing global tracer will not be configured, and a message will be logged.

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee