### PR TITLE
Add support for MinConnections to thriftbp.ClientPool

### DIFF
--- a/clientpool/channel.go
+++ b/clientpool/channel.go
@@ -10,21 +10,33 @@ import (
 )
 
 type channelPool struct {
-	pool       chan Client
-	opener     ClientOpener
-	numActive  atomic.Int32
-	maxClients int
+	pool                   chan Client
+	opener                 ClientOpener
+	numActive              atomic.Int32
+	numTotal               atomic.Int32
+	backgroundTaskInterval time.Duration
+	minClients             int
+	maxClients             int
+	isClosed               atomic.Bool
 }
+
+const DefaultBackgroundTaskInterval = 5 * time.Second
 
 // Make sure channelPool implements Pool interface.
 var _ Pool = (*channelPool)(nil)
 
 // NewChannelPool creates a new client pool implemented via channel.
 func NewChannelPool(ctx context.Context, requiredInitialClients, bestEffortInitialClients, maxClients int, opener ClientOpener) (_ Pool, err error) {
-	if !(requiredInitialClients <= bestEffortInitialClients && bestEffortInitialClients <= maxClients) {
+	return NewChannelPoolWithMinClients(ctx, requiredInitialClients, bestEffortInitialClients, -1, maxClients, opener, DefaultBackgroundTaskInterval)
+}
+
+// NewChannelPoolWithMinClients creates a new client pool implemented via channel.
+func NewChannelPoolWithMinClients(ctx context.Context, requiredInitialClients, bestEffortInitialClients, minClients, maxClients int, opener ClientOpener, backgroundTaskInterval time.Duration) (_ Pool, err error) {
+	if !(requiredInitialClients <= bestEffortInitialClients && bestEffortInitialClients <= maxClients && minClients <= maxClients) {
 		return nil, &ConfigError{
 			BestEffortInitialClients: bestEffortInitialClients,
 			RequiredInitialClients:   requiredInitialClients,
+			MinClients:               minClients,
 			MaxClients:               maxClients,
 		}
 	}
@@ -44,6 +56,8 @@ func NewChannelPool(ctx context.Context, requiredInitialClients, bestEffortIniti
 		}
 	}()
 
+	var numTotal int32
+
 	for i := 0; i < requiredInitialClients; {
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			if lastAttemptErr == nil {
@@ -59,6 +73,7 @@ func NewChannelPool(ctx context.Context, requiredInitialClients, bestEffortIniti
 		if err == nil {
 			pool <- c
 			i++
+			numTotal++
 		} else {
 			lastAttemptErr = err
 			if chatty.Allow() {
@@ -79,13 +94,25 @@ func NewChannelPool(ctx context.Context, requiredInitialClients, bestEffortIniti
 			break
 		}
 		pool <- c
+		numTotal++
 	}
 
-	return &channelPool{
-		pool:       pool,
-		opener:     opener,
-		maxClients: maxClients,
-	}, nil
+	if backgroundTaskInterval == 0 {
+		backgroundTaskInterval = DefaultBackgroundTaskInterval
+	}
+	cp := &channelPool{
+		pool:                   pool,
+		opener:                 opener,
+		maxClients:             maxClients,
+		minClients:             minClients,
+		backgroundTaskInterval: backgroundTaskInterval,
+	}
+	cp.numTotal.Store(numTotal)
+
+	if cp.minClients > 0 {
+		go cp.ensureMinClients()
+	}
+	return cp, nil
 }
 
 // Get returns a client from the pool.
@@ -111,6 +138,14 @@ func (cp *channelPool) Get() (client Client, err error) {
 		c.Close()
 	default:
 	}
+
+	// Instead of decrementing and re-incrementing numTotal, just decrement if we
+	// failed to open a new connection to replace the closed one.
+	defer func() {
+		if err != nil {
+			cp.numTotal.Add(-1)
+		}
+	}()
 
 	if cp.IsExhausted() {
 		err = ErrExhausted
@@ -141,6 +176,8 @@ func (cp *channelPool) Release(c Client) error {
 
 		newC, err := cp.opener()
 		if err != nil {
+			cp.numActive.Add(-1)
+			cp.numTotal.Add(-1)
 			return err
 		}
 		c = newC
@@ -151,6 +188,7 @@ func (cp *channelPool) Release(c Client) error {
 		return nil
 	default:
 		// Pool is full, just close it instead.
+		cp.numTotal.Add(-1)
 		return c.Close()
 	}
 }
@@ -163,7 +201,9 @@ func (cp *channelPool) Close() error {
 		if err := c.Close(); err != nil {
 			lastErr = err
 		}
+		cp.numTotal.Add(-1)
 	}
+	cp.isClosed.Store(true)
 	return lastErr
 }
 
@@ -180,4 +220,25 @@ func (cp *channelPool) NumAllocated() int32 {
 // IsExhausted returns true when NumActiveClients >= max capacity.
 func (cp *channelPool) IsExhausted() bool {
 	return cp.NumActiveClients() >= int32(cp.maxClients)
+}
+
+func (cp *channelPool) ensureMinClients() {
+	for !cp.isClosed.Load() {
+		time.Sleep(cp.backgroundTaskInterval)
+
+		for cp.numTotal.Load() < int32(cp.minClients) && !cp.isClosed.Load() {
+			c, err := cp.opener()
+			if err != nil {
+				log.Warnf("clientpool: error creating background client (will retry): %v", err)
+				break
+			}
+			select {
+			case cp.pool <- c:
+				cp.numTotal.Add(1)
+			default:
+				// Pool is full
+				c.Close()
+			}
+		}
+	}
 }

--- a/clientpool/channel.go
+++ b/clientpool/channel.go
@@ -176,7 +176,6 @@ func (cp *channelPool) Release(c Client) error {
 
 		newC, err := cp.opener()
 		if err != nil {
-			cp.numActive.Add(-1)
 			cp.numTotal.Add(-1)
 			return err
 		}

--- a/clientpool/errors.go
+++ b/clientpool/errors.go
@@ -25,6 +25,7 @@ func (exhaustedError) Retryable() int {
 type ConfigError struct {
 	BestEffortInitialClients int
 	RequiredInitialClients   int
+	MinClients               int
 	MaxClients               int
 }
 
@@ -32,9 +33,11 @@ var _ error = (*ConfigError)(nil)
 
 func (e *ConfigError) Error() string {
 	return fmt.Sprintf(
-		"clientpool: need requiredClients (%d) <= initialClients (%d) <= maxClients (%d)",
+		"clientpool: need requiredClients (%d) <= initialClients (%d) <= maxClients (%d), and minClients (%d) <= maxClients (%d)",
 		e.RequiredInitialClients,
 		e.BestEffortInitialClients,
+		e.MaxClients,
+		e.MinClients,
 		e.MaxClients,
 	)
 }

--- a/thriftbp/errors.go
+++ b/thriftbp/errors.go
@@ -27,9 +27,10 @@ var (
 
 // ClientPoolConfig errors are returned if the configuration validation fails.
 var (
-	ErrConfigMissingServiceSlug = errors.New("`ServiceSlug` cannot be empty")
-	ErrConfigMissingAddr        = errors.New("`Addr` cannot be empty")
-	ErrConfigInvalidConnections = errors.New("`InitialConnections` cannot be bigger than `MaxConnections`")
+	ErrConfigMissingServiceSlug    = errors.New("`ServiceSlug` cannot be empty")
+	ErrConfigMissingAddr           = errors.New("`Addr` cannot be empty")
+	ErrConfigInvalidConnections    = errors.New("`InitialConnections` cannot be bigger than `MaxConnections`")
+	ErrConfigInvalidMinConnections = errors.New("`MinConnections` cannot be bigger than `MaxConnections`")
 )
 
 // WithDefaultRetryableCodes returns a list including the given error codes and


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This adds the ability to specify a minimum number of connections to `thriftbp.ClientPool` and `clientpool.ChannelPool`. Having a maintained minimum pool size provides benefits for load balancing which can help even out CPU/RAM utilization on the server side.

## 📜 Details

We can't rely on `requiredInitialClients` (since it can fail startup) and if `bestEffortInitialClients` fails we end up with a partly preallocated pool, this provides a mechanism to maintain the pool size on an ongoing basis.

This is accomplished by spinning up an `ensureMinClients` goroutine per pool which will check the total number of connections (active+idle) and open more as needed to keep that amount >= the minimum.

It should be non-breaking as the default behaviour is to not have a minimum set and not spin up the `ensureMinClients` goroutine.

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
