### PR TITLE
Add config for the header use by the general ingress

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -434,7 +434,7 @@ func NewCustomClientPoolWithContext(
 	return newClientPool(ctx, cfg, genAddr, protoFactory, middlewares...)
 }
 
-const ThriftHostnameHeader = "Thrift-Hostname"
+const ThriftHostnameHeader = "thrift-hostname"
 
 func ThriftHostnameHeaderMiddleware(hostname string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -214,7 +214,7 @@ type ClientPoolConfig struct {
 
 	// The hostname to add as a "thrift-hostname" header.
 	//
-	// Optional. If empty, not "thrift-hostname" header will be sent.
+	// Optional. If empty, no "thrift-hostname" header will be sent.
 	ThriftHostnameHeader string `yaml:"thriftHostnameHeader"`
 }
 
@@ -436,7 +436,10 @@ func NewCustomClientPoolWithContext(
 
 const ThriftHostnameHeader = "thrift-hostname"
 
-func ThriftHostnameHeaderMiddleware(hostname string) thrift.ClientMiddleware {
+// thriftHostnameHeaderMiddleware adds a `thrift-hostname` header if one was
+// specified in the configuration.
+// This middleware is always added but will only add the header is necessary.
+func thriftHostnameHeaderMiddleware(hostname string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
@@ -525,7 +528,7 @@ func newClientPool(
 
 		slug: cfg.ServiceSlug,
 	}
-	middlewares = append(middlewares, ThriftHostnameHeaderMiddleware(cfg.ThriftHostnameHeader))
+	middlewares = append(middlewares, thriftHostnameHeaderMiddleware(cfg.ThriftHostnameHeader))
 
 	// finish setting up the clientPool by wrapping the inner "Call" with the
 	// given middleware.

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -440,7 +440,9 @@ func ThriftHostnameHeaderMiddleware(hostname string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
-				ctx = AddClientHeader(ctx, ThriftHostnameHeader, hostname)
+				if hostname != "" {
+					ctx = AddClientHeader(ctx, ThriftHostnameHeader, hostname)
+				}
 				return next.Call(ctx, method, args, result)
 			},
 		}
@@ -523,10 +525,7 @@ func newClientPool(
 
 		slug: cfg.ServiceSlug,
 	}
-
-	if cfg.ThriftHostnameHeader != "" {
-		middlewares = append(middlewares, ThriftHostnameHeaderMiddleware(cfg.ThriftHostnameHeader))
-	}
+	middlewares = append(middlewares, ThriftHostnameHeaderMiddleware(cfg.ThriftHostnameHeader))
 
 	// finish setting up the clientPool by wrapping the inner "Call" with the
 	// given middleware.

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -434,7 +434,7 @@ func NewCustomClientPoolWithContext(
 	return newClientPool(ctx, cfg, genAddr, protoFactory, middlewares...)
 }
 
-const ThriftHostnameHeader = "thrift-hostname"
+const ThriftHostnameHeader = "Thrift-Hostname"
 
 func ThriftHostnameHeaderMiddleware(hostname string) thrift.ClientMiddleware {
 	return func(next thrift.TClient) thrift.TClient {


### PR DESCRIPTION
## 💸 TL;DR
We now have a generic ingress for thrift traffic that routes the traffic based on a header. This means that looking at a service config we don't see what service the traffic is going to and that the application need to set the header manually unlike every other configuration bit.

So this PR adds a new configuration to set this header.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
