### PR TITLE
kafkabp: Add NewConsumerWithConfigOverriders

### DIFF
--- a/kafkabp/consumer.go
+++ b/kafkabp/consumer.go
@@ -114,9 +114,23 @@ type consumer struct {
 // topic. This implementation of Kafka consumer is suitable for use cases like
 // deliver config/data through Kafka to services.
 func NewConsumer(cfg ConsumerConfig) (Consumer, error) {
+	return NewConsumerWithConfigOverriders(cfg)
+}
+
+// SaramaConfigOverrider provides a way for users to override certain fields in
+// *sarama.Config generated from ConsumerConfig.
+type SaramaConfigOverrider func(*sarama.Config)
+
+// NewConsumerWithConfigOverriders is provided as an escape hatch for use cases
+// requiring specific sarama config not supported by ConsumerConfig.
+func NewConsumerWithConfigOverriders(cfg ConsumerConfig, overriders ...SaramaConfigOverrider) (Consumer, error) {
 	sc, err := cfg.NewSaramaConfig()
 	if err != nil {
 		return nil, err
+	}
+
+	for _, override := range overriders {
+		override(sc)
 	}
 
 	switch {


### PR DESCRIPTION
We occasionally have cases that services need to set some sarama config
that's not supported by kafkabp.ConsumerConfig, and there's currently no
way for them to do that besides forking kafkabp code locally. Provide
this as an escape hatch for easier iteration.