### PR TITLE
Introduce an error for trying to fetch a secret of the wrong type.

### DIFF
--- a/secrets/errors.go
+++ b/secrets/errors.go
@@ -37,3 +37,18 @@ type SecretNotFoundError string
 func (path SecretNotFoundError) Error() string {
 	return "secrets: no secret has been found for " + string(path)
 }
+
+type SecretWrongTypeError struct {
+	Path         string
+	DeclaredType string
+	CorrectType  string
+}
+
+func (e SecretWrongTypeError) Error() string {
+	return fmt.Sprintf(
+		"secrets: requested secret at path '%s' of type '%s' does not exist, but a secret of type '%s' does. Consider using the correct API to retrieve the secret",
+		e.Path,
+		e.DeclaredType,
+		e.CorrectType,
+	)
+}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -49,6 +49,22 @@ func (s *Secrets) GetSimpleSecret(path string) (SimpleSecret, error) {
 	}
 	secret, ok := s.simpleSecrets[path]
 	if !ok {
+		_, vOk := s.versionedSecrets[path]
+		if vOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: SimpleType,
+				CorrectType:  VersionedType,
+			}
+		}
+		_, cOk := s.credentialSecrets[path]
+		if cOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: SimpleType,
+				CorrectType:  CredentialType,
+			}
+		}
 		return secret, SecretNotFoundError(path)
 	}
 
@@ -62,6 +78,22 @@ func (s *Secrets) GetVersionedSecret(path string) (VersionedSecret, error) {
 	}
 	secret, ok := s.versionedSecrets[path]
 	if !ok {
+		_, sOk := s.simpleSecrets[path]
+		if sOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: VersionedType,
+				CorrectType:  SimpleType,
+			}
+		}
+		_, cOk := s.credentialSecrets[path]
+		if cOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: VersionedType,
+				CorrectType:  CredentialType,
+			}
+		}
 		return secret, SecretNotFoundError(path)
 	}
 
@@ -76,6 +108,22 @@ func (s *Secrets) GetCredentialSecret(path string) (CredentialSecret, error) {
 	}
 	secret, ok := s.credentialSecrets[path]
 	if !ok {
+		_, sOk := s.simpleSecrets[path]
+		if sOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: CredentialType,
+				CorrectType:  SimpleType,
+			}
+		}
+		_, vOk := s.versionedSecrets[path]
+		if vOk {
+			return secret, SecretWrongTypeError{
+				Path:         path,
+				DeclaredType: CredentialType,
+				CorrectType:  VersionedType,
+			}
+		}
 		return secret, SecretNotFoundError(path)
 	}
 


### PR DESCRIPTION
## 💸 TL;DR
This PR introduces a new error type for attempting to fetch a secret of the wrong type:
```
secrets: requested secret at path 'secret/myservice/external-account-key' of type 'simple' does not exist, but a secret of type 'versioned' does. Consider using the correct API to retrieve the secret
```

I've seen this issue recently, and had a few infra folks trying to debug why secrets are not being fetched. Turned out, I was using the wrong API (`GetSimpleSecret` instead of `GetVersionedSecret`). This change would've avoided this whole situation.

## 🧪 Testing Steps / Validation
Added some unit tests.

## ✅ Checks
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
