### PR TITLE
thriftbp: Report request/response payload sizes from client side

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -555,13 +555,15 @@ func newClient(
 	genAddr AddressGenerator,
 	protoFactory thrift.TProtocolFactory,
 ) (*ttlClient, error) {
-	return newTTLClient(func() (thrift.TClient, thrift.TTransport, error) {
+	return newTTLClient(func() (thrift.TClient, *countingDelegateTransport, error) {
 		addr, err := genAddr()
 		if err != nil {
 			return nil, nil, fmt.Errorf("thriftbp: error getting next address for new Thrift client: %w", err)
 		}
 
-		transport := thrift.NewTSocketConf(addr, cfg)
+		transport := &countingDelegateTransport{
+			TTransport: thrift.NewTSocketConf(addr, cfg),
+		}
 		if err := transport.Open(); err != nil {
 			return nil, nil, fmt.Errorf("thriftbp: error opening TSocket for new Thrift client: %w", err)
 		}

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -135,9 +135,15 @@ const (
 )
 
 var (
-	payloadSizeLabels = []string{
+	serverPayloadSizeLabels = []string{
 		methodLabel,
 		protoLabel,
+	}
+
+	clientPayloadSizeLabels = []string{
+		methodLabel,
+		clientNameLabel,
+		successLabel,
 	}
 
 	// 8 bytes to 4 mebibytes
@@ -146,21 +152,29 @@ var (
 	// (up to ~500 KiB).
 	payloadSizeBuckets = prometheus.ExponentialBuckets(8, 2, 20)
 
-	payloadSizeRequestBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemServer,
-		Name:      "request_payload_size_bytes",
-		Help:      "The size of thrift request payloads",
-		Buckets:   payloadSizeBuckets,
-	}, payloadSizeLabels)
+	serverPayloadSizeRequestBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thriftbp_server_request_payload_size_bytes",
+		Help:    "The (approximate) size of thrift request payloads",
+		Buckets: payloadSizeBuckets,
+	}, serverPayloadSizeLabels)
 
-	payloadSizeResponseBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: promNamespace,
-		Subsystem: subsystemServer,
-		Name:      "response_payload_size_bytes",
-		Help:      "The size of thrift response payloads",
-		Buckets:   payloadSizeBuckets,
-	}, payloadSizeLabels)
+	serverPayloadSizeResponseBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thriftbp_server_response_payload_size_bytes",
+		Help:    "The (approximate) size of thrift response payloads",
+		Buckets: payloadSizeBuckets,
+	}, serverPayloadSizeLabels)
+
+	clientPayloadSizeRequestBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thriftbp_client_request_payload_size_bytes",
+		Help:    "The size of thrift request payloads",
+		Buckets: payloadSizeBuckets,
+	}, clientPayloadSizeLabels)
+
+	clientPayloadSizeResponseBytes = promauto.With(prometheusbpint.GlobalRegistry).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thriftbp_client_response_payload_size_bytes",
+		Help:    "The size of thrift response payloads",
+		Buckets: payloadSizeBuckets,
+	}, clientPayloadSizeLabels)
 )
 
 var (


### PR DESCRIPTION
We currently already have a middleware to report that from the server side, but that's simulated by reconstruct THeaderProtocols and read/write to them, which will not include the header size and will not reflect compressions (zlib, etc.).

This client side reporting is done directly at the TTransport (TSocket) level, so it will reflect the exact number actually read/written at that level. If zlib is enabled in THeaderProtocol the size will reflect compressed payload. The only thing it will not reflect is potential SSL layer (e.g. when using TSSLSocket over TSocket, which we don't support yet).
