### PR TITLE
thriftbp: Fix a bug caused by bad merge from the previous PR

### DIFF
--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -573,26 +573,26 @@ func newClient(
 			return nil, nil, fmt.Errorf("thriftbp: error getting next address for new Thrift client: %w", err)
 		}
 
-		var transport thrift.TTransport
+		var raw thrift.TTransport
 		if path, ok := strings.CutPrefix(addr, "unix://"); ok {
-			transport = thrift.NewTSocketFromAddrConf(&net.UnixAddr{
+			raw = thrift.NewTSocketFromAddrConf(&net.UnixAddr{
 				Net:  "unix",
 				Name: path,
 			}, cfg)
 		} else {
-			transport = thrift.NewTSocketConf(addr, cfg)
+			raw = thrift.NewTSocketConf(addr, cfg)
 		}
-		cdt := &countingDelegateTransport{
-			TTransport: transport,
+		transport := &countingDelegateTransport{
+			TTransport: raw,
 		}
-		if err := cdt.Open(); err != nil {
+		if err := transport.Open(); err != nil {
 			return nil, nil, fmt.Errorf("thriftbp: error opening TSocket for new Thrift client: %w", err)
 		}
 
 		return thrift.NewTStandardClient(
 			protoFactory.GetProtocol(transport),
 			protoFactory.GetProtocol(transport),
-		), cdt, nil
+		), transport, nil
 	}, maxConnectionAge, maxConnectionAgeJitter, slug)
 }
 


### PR DESCRIPTION
Due to a bad merge between the previous 2 PRs, we are not really using the countingDelegateTransport in the client created by client pool, so the bytes are not counting and we always report 0 as the bytes read/written.

Rename the args inside newClient generator to fix the bug.
