### PR TITLE
clientpool: Check Get after Close and return appropriate error

### DIFF
--- a/clientpool/channel.go
+++ b/clientpool/channel.go
@@ -2,6 +2,7 @@ package clientpool
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -97,7 +98,10 @@ func (cp *channelPool) Get() (client Client, err error) {
 	}()
 
 	select {
-	case c := <-cp.pool:
+	case c, ok := <-cp.pool:
+		if !ok {
+			return nil, errors.New("clientpool: Get called after Close")
+		}
 		if c.IsOpen() {
 			return c, nil
 		}

--- a/clientpool/interface_test.go
+++ b/clientpool/interface_test.go
@@ -283,4 +283,10 @@ func testPool(t *testing.T, pool clientpool.Pool, openerCalled *atomic.Int32, mi
 			t.Logf("opener called %d times", openerCalled.Load())
 		},
 	)
+
+	t.Run("get-after-close", func(t *testing.T) {
+		if _, err := pool.Get(); err == nil {
+			t.Error("Want pool.Get to return an error, got nil")
+		}
+	})
 }


### PR DESCRIPTION
Currently, when Get is Called after Close, we'll just get a nil client from the pool and the next `c.IsOpen` check will just panic, which makes it very hard to debug why. Add a check to return an appropriate error.
