### PR TITLE
Support attributing client metrics back to the owning cluster

### DIFF
--- a/redis/cache/redispipebp/monitored.go
+++ b/redis/cache/redispipebp/monitored.go
@@ -44,8 +44,9 @@ var (
 
 // MonitoredSync wraps Sync methods in client spans.
 type MonitoredSync struct {
-	Sync redisx.Sync
-	Name string
+	Sync    redisx.Sync
+	Name    string
+	Cluster string
 }
 
 func extractCommand(cmd string) string {
@@ -69,6 +70,7 @@ func (s MonitoredSync) Do(ctx context.Context, cmd string, args ...interface{}) 
 		redisprom.DatabaseLabel:   "", // We don't have that info
 		redisprom.TypeLabel:       "", // We don't have that info
 		redisprom.DeploymentLabel: "", // We don't have that info
+		redisprom.ClusterLabel:    s.Cluster,
 	})
 	active.Inc()
 	defer func(start time.Time) {
@@ -87,6 +89,7 @@ func (s MonitoredSync) Do(ctx context.Context, cmd string, args ...interface{}) 
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Observe(durationSeconds)
 		redisprom.RequestsTotal.With(prometheus.Labels{
 			redisprom.ClientNameLabel: s.Name,
@@ -95,6 +98,7 @@ func (s MonitoredSync) Do(ctx context.Context, cmd string, args ...interface{}) 
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Inc()
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,
@@ -122,6 +126,7 @@ func (s MonitoredSync) Send(ctx context.Context, r redis.Request) (result interf
 		redisprom.DatabaseLabel:   "", // We don't have that info
 		redisprom.TypeLabel:       "", // We don't have that info
 		redisprom.DeploymentLabel: "", // We don't have that info
+		redisprom.ClusterLabel:    s.Cluster,
 	})
 	active.Inc()
 	defer func(start time.Time) {
@@ -140,6 +145,7 @@ func (s MonitoredSync) Send(ctx context.Context, r redis.Request) (result interf
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Observe(durationSeconds)
 		redisprom.RequestsTotal.With(prometheus.Labels{
 			redisprom.ClientNameLabel: s.Name,
@@ -148,6 +154,7 @@ func (s MonitoredSync) Send(ctx context.Context, r redis.Request) (result interf
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Inc()
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,
@@ -172,6 +179,7 @@ func (s MonitoredSync) SendMany(ctx context.Context, reqs []redis.Request) (resu
 		redisprom.DatabaseLabel:   "", // We don't have that info
 		redisprom.TypeLabel:       "", // We don't have that info
 		redisprom.DeploymentLabel: "", // We don't have that info
+		redisprom.ClusterLabel:    s.Cluster,
 	})
 	active.Inc()
 	defer func(start time.Time) {
@@ -209,6 +217,7 @@ func (s MonitoredSync) SendMany(ctx context.Context, reqs []redis.Request) (resu
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Observe(durationSeconds)
 		redisprom.RequestsTotal.With(prometheus.Labels{
 			redisprom.ClientNameLabel: s.Name,
@@ -217,6 +226,7 @@ func (s MonitoredSync) SendMany(ctx context.Context, reqs []redis.Request) (resu
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Inc()
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,
@@ -241,6 +251,7 @@ func (s MonitoredSync) SendTransaction(ctx context.Context, reqs []redis.Request
 		redisprom.DatabaseLabel:   "", // We don't have that info
 		redisprom.TypeLabel:       "", // We don't have that info
 		redisprom.DeploymentLabel: "", // We don't have that info
+		redisprom.ClusterLabel:    s.Cluster,
 	})
 	active.Inc()
 	defer func(start time.Time) {
@@ -258,6 +269,7 @@ func (s MonitoredSync) SendTransaction(ctx context.Context, reqs []redis.Request
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Observe(durationSeconds)
 		redisprom.RequestsTotal.With(prometheus.Labels{
 			redisprom.ClientNameLabel: s.Name,
@@ -266,6 +278,7 @@ func (s MonitoredSync) SendTransaction(ctx context.Context, reqs []redis.Request
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.Cluster,
 		}).Inc()
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,
@@ -281,6 +294,7 @@ func (s MonitoredSync) Scanner(ctx context.Context, opts redis.ScanOpts) redisx.
 	return MonitoredScanIterator{
 		ScanIterator: s.Sync.Scanner(ctx, opts),
 		name:         s.Name,
+		cluster:      s.Cluster,
 		ctx:          ctx,
 	}
 }
@@ -289,8 +303,9 @@ func (s MonitoredSync) Scanner(ctx context.Context, opts redis.ScanOpts) redisx.
 type MonitoredScanIterator struct {
 	redisx.ScanIterator
 
-	name string
-	ctx  context.Context
+	name    string
+	cluster string
+	ctx     context.Context
 }
 
 // Next wraps s.ScanIterator.Next in a client span.
@@ -307,6 +322,7 @@ func (s MonitoredScanIterator) Next() (results []string, err error) {
 		redisprom.DatabaseLabel:   "", // We don't have that info
 		redisprom.TypeLabel:       "", // We don't have that info
 		redisprom.DeploymentLabel: "", // We don't have that info
+		redisprom.ClusterLabel:    s.cluster,
 	})
 	active.Inc()
 	defer func(start time.Time) {
@@ -324,6 +340,7 @@ func (s MonitoredScanIterator) Next() (results []string, err error) {
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.cluster,
 		}).Observe(durationSeconds)
 		redisprom.RequestsTotal.With(prometheus.Labels{
 			redisprom.ClientNameLabel: s.name,
@@ -332,6 +349,7 @@ func (s MonitoredScanIterator) Next() (results []string, err error) {
 			redisprom.DatabaseLabel:   "", // We don't have that info
 			redisprom.TypeLabel:       "", // We don't have that info
 			redisprom.DeploymentLabel: "", // We don't have that info
+			redisprom.ClusterLabel:    s.cluster,
 		}).Inc()
 		span.FinishWithOptions(tracing.FinishOptions{
 			Ctx: ctx,

--- a/redis/db/redisbp/hooks.go
+++ b/redis/db/redisbp/hooks.go
@@ -32,6 +32,9 @@ type SpanHook struct {
 	Type       string
 	Deployment string
 	Database   string
+	// The cluster identifier based on the connection address. If we cannot identify
+	// a cluster based on connection address this field will be empty.
+	Cluster string
 
 	promActive *prometheusbpint.HighWatermarkGauge
 }
@@ -94,6 +97,7 @@ func (h SpanHook) startChildSpan(ctx context.Context, cmdName string) context.Co
 		redisprom.CommandLabel:    cmdName,
 		redisprom.DeploymentLabel: h.Deployment,
 		redisprom.DatabaseLabel:   h.Database,
+		redisprom.ClusterLabel:    h.Cluster,
 	}).Inc()
 	return context.WithValue(ctx, promCtxKey, &promCtx{
 		command: cmdName,
@@ -118,6 +122,7 @@ func (h SpanHook) endChildSpan(ctx context.Context, err error) {
 			redisprom.DeploymentLabel: h.Deployment,
 			redisprom.SuccessLabel:    prometheusbp.BoolString(err == nil),
 			redisprom.DatabaseLabel:   h.Database,
+			redisprom.ClusterLabel:    h.Cluster,
 		}).Observe(durationSeconds)
 	}
 	// Outside of the context casting because we always want this to work.
@@ -128,6 +133,7 @@ func (h SpanHook) endChildSpan(ctx context.Context, err error) {
 		redisprom.DeploymentLabel: h.Deployment,
 		redisprom.SuccessLabel:    prometheusbp.BoolString(err == nil),
 		redisprom.DatabaseLabel:   h.Database,
+		redisprom.ClusterLabel:    h.Cluster,
 	}).Inc()
 	redisprom.ActiveRequests.With(prometheus.Labels{
 		redisprom.ClientNameLabel: h.ClientName,
@@ -135,6 +141,7 @@ func (h SpanHook) endChildSpan(ctx context.Context, err error) {
 		redisprom.CommandLabel:    command,
 		redisprom.DeploymentLabel: h.Deployment,
 		redisprom.DatabaseLabel:   h.Database,
+		redisprom.ClusterLabel:    h.Cluster,
 	}).Dec()
 	if h.promActive != nil {
 		h.promActive.Dec()

--- a/redis/db/redisbp/hooks_test.go
+++ b/redis/db/redisbp/hooks_test.go
@@ -20,6 +20,7 @@ func TestSpanHook(t *testing.T) {
 		ClientName: "redis",
 		Type:       "type",
 		Deployment: "Deployment",
+		Cluster:    "cluster",
 	}
 	statusCmd := redis.NewStatusCmd(ctx, "ping")
 	stringCmd := redis.NewStringCmd(ctx, "get", "1")
@@ -40,6 +41,7 @@ func TestSpanHook(t *testing.T) {
 				redisprom.DeploymentLabel: "Deployment",
 				redisprom.SuccessLabel:    "true",
 				redisprom.DatabaseLabel:   "",
+				redisprom.ClusterLabel:    "cluster",
 			}
 			defer promtest.NewPrometheusMetricTest(t, "spec latency timer", redisprom.LatencySeconds, labels).CheckSampleCountDelta(1)
 			defer promtest.NewPrometheusMetricTest(t, "spec requests total", redisprom.RequestsTotal, labels).CheckDelta(1)

--- a/redis/db/redisbp/monitored_client.go
+++ b/redis/db/redisbp/monitored_client.go
@@ -36,19 +36,19 @@ func getDeploymentType(addr string) string {
 func getTargetCluster(addr string) string {
 	if strings.Contains(addr, "cache.amazonaws") {
 		return ""
-	} else {
-		// redis-<cluster name>.<vpc>.<region>.<postfix>.net:6379
-		tokens := strings.Split(addr, ".")
-		if len(tokens) != 5 {
-			return ""
-		}
+	}
 
-		if strings.Contains(tokens[0], "redis-") && len(tokens[0]) > 6 {
-			return tokens[0][6:]
-		}
-
+	// redis-<cluster name>.<vpc>.<region>.<postfix>.net:6379
+	tokens := strings.Split(addr, ".")
+	if len(tokens) != 5 {
 		return ""
 	}
+
+	if name, found := strings.CutPrefix(tokens[0], "redis-"); found {
+		return name
+	}
+
+	return ""
 }
 
 // NewMonitoredClient creates a new *redis.Client object with a redisbp.SpanHook

--- a/redis/internal/redisprom/requests.go
+++ b/redis/internal/redisprom/requests.go
@@ -15,6 +15,7 @@ const (
 	TypeLabel       = "redis_type"        // MUST BE one of standalone, cluster, sentinel, identifies the backend's configuration for responding to the redis request
 	DeploymentLabel = "redis_deployment"  // MUST BE one of reddit, elasticache, identifies the provider of the redis backend (not the explicit address)
 	CommandLabel    = "redis_command"     // SHALL reflect to Redis command being executed for the request (ie SET)
+	ClusterLabel    = "redis_cluster"     // MAY be blank if the cluster name cannot be determined from the address.
 )
 
 var (
@@ -24,20 +25,20 @@ var (
 			Help:    "latency histogram",
 			Buckets: prometheusbp.DefaultLatencyBuckets,
 		},
-		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel, SuccessLabel},
+		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel, SuccessLabel, ClusterLabel},
 	)
 	ActiveRequests = promauto.With(prometheusbpint.GlobalRegistry).NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "redis_client_active_requests",
 			Help: "total requests that are in-flight",
 		},
-		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel},
+		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel, ClusterLabel},
 	)
 	RequestsTotal = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "redis_client_requests_total",
 			Help: "total request counter",
 		},
-		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel, SuccessLabel},
+		[]string{ClientNameLabel, DatabaseLabel, TypeLabel, DeploymentLabel, CommandLabel, SuccessLabel, ClusterLabel},
 	)
 )


### PR DESCRIPTION
## 💸 TL;DR
This adds a new cluster label to client metrics. This can be used to join the client metrics with the cluster metrics in prometheus based dashboards.

We set the cluster label only if we can determine it from the address, otherwise it remains an empty string.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
