### PR TITLE
thriftbp/httpbp: Remove tracing from default middlewares

### DIFF
--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -45,13 +45,9 @@ func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 // plus any additional client middleware passed into this function. Default
 // middlewares are:
 //
-// * MonitorClient with transport.WithRetrySlugSuffix
-//
 // * PrometheusClientMetrics with transport.WithRetrySlugSuffix
 //
 // * Retries
-//
-// * MonitorClient
 //
 // * PrometheusClientMetrics
 //
@@ -78,10 +74,8 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 	}
 
 	defaults := []ClientMiddleware{
-		MonitorClient(config.Slug + transport.WithRetrySlugSuffix),
 		PrometheusClientMetrics(config.Slug + transport.WithRetrySlugSuffix),
 		Retries(config.MaxErrorReadAhead, config.RetryOptions...),
-		MonitorClient(config.Slug),
 		PrometheusClientMetrics(config.Slug),
 	}
 

--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -57,18 +57,6 @@ func TestNewClient(t *testing.T) {
 		}))
 		defer server.Close()
 
-		recorder := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
-			MaxQueueSize:   tracing.MaxQueueSize,
-			MaxMessageSize: tracing.MaxSpanSize,
-		})
-		err := tracing.InitGlobalTracer(tracing.Config{
-			SampleRate:               1,
-			TestOnlyMockMessageQueue: recorder,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		client, err := NewClient(ClientConfig{
 			Slug: "test",
 		})
@@ -84,21 +72,6 @@ func TestNewClient(t *testing.T) {
 		var e *ClientError
 		if !errors.As(err, &e) {
 			t.Errorf("expected error wrap error of type %T", *e)
-		}
-
-		// MonitorClient is applied
-		b, err := recorder.Receive(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		var span tracing.ZipkinSpan
-		err = json.Unmarshal(b, &span)
-		if err != nil {
-			t.Fatal(err)
-		}
-		expected := "test.request"
-		if span.Name != expected {
-			t.Errorf("expected %s, actual: %q", expected, span.Name)
 		}
 	})
 }

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -57,6 +57,8 @@ func Wrap(name string, handle HandlerFunc, middlewares ...Middleware) HandlerFun
 type DefaultMiddlewareArgs struct {
 	// The HeaderTrustHandler to use.
 	// If empty, NeverTrustHeaders will be used instead.
+	//
+	// Deprecated: This is no longer used by default middlewares.
 	TrustHandler HeaderTrustHandler
 
 	// The logger to be called when edgecontext parsing failed.
@@ -70,15 +72,10 @@ type DefaultMiddlewareArgs struct {
 // DefaultMiddleware returns a slice of all the default Middleware for a
 // Baseplate HTTP server. The default middleware are (in order):
 //
-//  1. InjectServerSpan
-//  2. InjectEdgeRequestContext
-//  3. PrometheusServerMetrics
+//  1. InjectEdgeRequestContext
+//  2. PrometheusServerMetrics
 func DefaultMiddleware(args DefaultMiddlewareArgs) []Middleware {
-	if args.TrustHandler == nil {
-		args.TrustHandler = NeverTrustHeaders{}
-	}
 	return []Middleware{
-		InjectServerSpan(args.TrustHandler),
 		InjectEdgeRequestContext(InjectEdgeRequestContextArgs(args)),
 		PrometheusServerMetrics(""),
 	}

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -63,17 +63,14 @@ type DefaultProcessorMiddlewaresArgs struct {
 //
 // 1. ExtractDeadlineBudget
 //
-// 2. InjectServerSpan
+// 2. InjectEdgeContext
 //
-// 3. InjectEdgeContext
+// 3. ReportPayloadSizeMetrics
 //
-// 4. ReportPayloadSizeMetrics
-//
-// 5. PrometheusServerMiddleware
+// 4. PrometheusServerMiddleware
 func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) []thrift.ProcessorMiddleware {
 	return []thrift.ProcessorMiddleware{
 		ExtractDeadlineBudget,
-		InjectServerSpan(args.ErrorSpanSuppressor),
 		InjectEdgeContext(args.EdgeContextImpl),
 		ReportPayloadSizeMetrics(0),
 		PrometheusServerMiddleware,


### PR DESCRIPTION
Servers/clients should manually add v2 tracing middlewares if needed, or switch to v2 servers/clients.
