### PR TITLE
httpbp/thriftbp: Tracing middlewares v2 compat fix

### DIFF
--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -2,8 +2,6 @@ package httpbp
 
 import (
 	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -18,8 +16,6 @@ import (
 	"github.com/sony/gobreaker"
 
 	"github.com/reddit/baseplate.go/breakerbp"
-	"github.com/reddit/baseplate.go/mqsend"
-	"github.com/reddit/baseplate.go/tracing"
 )
 
 func TestNewClient(t *testing.T) {
@@ -57,18 +53,6 @@ func TestNewClient(t *testing.T) {
 		}))
 		defer server.Close()
 
-		recorder := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
-			MaxQueueSize:   tracing.MaxQueueSize,
-			MaxMessageSize: tracing.MaxSpanSize,
-		})
-		err := tracing.InitGlobalTracer(tracing.Config{
-			SampleRate:               1,
-			TestOnlyMockMessageQueue: recorder,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		client, err := NewClient(ClientConfig{
 			Slug: "test",
 		})
@@ -84,21 +68,6 @@ func TestNewClient(t *testing.T) {
 		var e *ClientError
 		if !errors.As(err, &e) {
 			t.Errorf("expected error wrap error of type %T", *e)
-		}
-
-		// MonitorClient is applied
-		b, err := recorder.Receive(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		var span tracing.ZipkinSpan
-		err = json.Unmarshal(b, &span)
-		if err != nil {
-			t.Fatal(err)
-		}
-		expected := "test.request"
-		if span.Name != expected {
-			t.Errorf("expected %s, actual: %q", expected, span.Name)
 		}
 	})
 }
@@ -147,47 +116,6 @@ func TestNewClientConcurrency(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
-}
-
-func TestMonitorClient(t *testing.T) {
-	recorder := mqsend.OpenMockMessageQueue(mqsend.MessageQueueConfig{
-		MaxQueueSize:   tracing.MaxQueueSize,
-		MaxMessageSize: tracing.MaxSpanSize,
-	})
-	err := tracing.InitGlobalTracer(tracing.Config{
-		SampleRate:               1,
-		TestOnlyMockMessageQueue: recorder,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	}))
-	defer server.Close()
-
-	middleware := MonitorClient("test")
-	client := &http.Client{
-		Transport: middleware(http.DefaultTransport),
-	}
-	_, err = client.Get(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	b, err := recorder.Receive(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	var span tracing.ZipkinSpan
-	err = json.Unmarshal(b, &span)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected := "test.request"
-	if span.Name != expected {
-		t.Errorf("expected %s, actual: %q", expected, span.Name)
-	}
 }
 
 func TestClientErrorWrapper(t *testing.T) {

--- a/httpbp/fixtures_test.go
+++ b/httpbp/fixtures_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/httpbp"
@@ -16,10 +15,6 @@ import (
 type jsonResponseBody struct {
 	X int `json:"x"`
 }
-
-const (
-	testTimeout = time.Millisecond * 100
-)
 
 var testSecrets = map[string]secrets.GenericSecret{
 	"secret/http/edge-context-signature": {

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -70,15 +70,13 @@ type DefaultMiddlewareArgs struct {
 // DefaultMiddleware returns a slice of all the default Middleware for a
 // Baseplate HTTP server. The default middleware are (in order):
 //
-//  1. InjectServerSpan
-//  2. InjectEdgeRequestContext
-//  3. PrometheusServerMetrics
+//  1. InjectEdgeRequestContext
+//  2. PrometheusServerMetrics
 func DefaultMiddleware(args DefaultMiddlewareArgs) []Middleware {
 	if args.TrustHandler == nil {
 		args.TrustHandler = NeverTrustHeaders{}
 	}
 	return []Middleware{
-		InjectServerSpan(args.TrustHandler),
 		InjectEdgeRequestContext(InjectEdgeRequestContextArgs(args)),
 		PrometheusServerMetrics(""),
 	}


### PR DESCRIPTION
For the following 3 tracing middlewares:

- thriftbp server
- thriftbp client
- httpbp client

The current behavior is to short-circuit to v2 compat middleware if injected, or fallback to v0 tracing implementation if not injected. Change the fallback logic to no-op, as the v0 tracing implementation is not really working any more and it will spam logs.

For httpbp server tracing middleware, remove it from defaults, as the current v2 compat implementation is to skip it when injected as the API is not sufficient for the v2 compat implementation to work.

This replaces and closes https://github.com/reddit/baseplate.go/pull/664.
