### PR TITLE
[REFACTORED] Add support for Thrift and HTTP client-side fault injection.

### DIFF
--- a/httpbp/faults.go
+++ b/httpbp/faults.go
@@ -1,0 +1,41 @@
+package httpbp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/reddit/baseplate.go/internal/faults"
+)
+
+type clientFaultMiddleware struct {
+	injector faults.Injector[*http.Response]
+}
+
+// NewClientFaultMiddleware creates and returns a new client-side fault
+// injection middleware.
+//
+// This middleware injects faults into the outgoing HTTP requests based on the
+// X-Bp-Fault header values. If valid X-Bp-Fault values exist which are not
+// intended to be interpreted by this middleware, then unintended faults could
+// be injected. This is extremely unlikely given how specific the headers and
+// values must be for them to be compatible, but it's worth calling out
+// as an edge case.
+func NewClientFaultMiddleware(clientName string) clientFaultMiddleware {
+	return clientFaultMiddleware{
+		injector: *faults.NewInjector[*http.Response](
+			clientName,
+			"httpbp.clientFaultMiddleware",
+			400,
+			599,
+		),
+	}
+}
+
+type httpHeaders struct {
+	req *http.Request
+}
+
+// Lookup returns the value of the header, if found.
+func (h httpHeaders) Lookup(ctx context.Context, key string) (string, error) {
+	return h.req.Header.Get(key), nil
+}

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -1,0 +1,282 @@
+// Package faults provides common headers and client-side fault injection
+// functionality.
+package faults
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/reddit/baseplate.go/internal/prometheusbpint"
+)
+
+const (
+	promNamespace      = "faultbp"
+	clientNameLabel    = "fault_client_name"
+	serviceLabel       = "fault_service"
+	methodLabel        = "fault_method"
+	protocolLabel      = "fault_protocol"
+	successLabel       = "fault_success"
+	delayInjectedLabel = "fault_injected_delay"
+	abortInjectedLabel = "fault_injected_abort"
+)
+
+var (
+	totalRequests = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "faultbp_fault_requests_total",
+		Help: "Total count of requests seen by the fault injection middleware.",
+	}, []string{
+		clientNameLabel,
+		serviceLabel,
+		methodLabel,
+		protocolLabel,
+		successLabel,
+		delayInjectedLabel,
+		abortInjectedLabel,
+	})
+)
+
+// Headers is an interface to be implemented by the caller to allow
+// protocol-specific header lookup. Using an interface here rather than a
+// function type avoids any potential closure requirements of a function.
+type Headers interface {
+	// Lookup returns the value of a protocol-specific header with the
+	// given key.
+	Lookup(ctx context.Context, key string) (string, error)
+}
+
+// Resume is the function type to continue processing the protocol-specific
+// request without injecting a fault.
+type Resume[T any] func() (T, error)
+
+// Abort is the function type to inject a protocol-specific fault with the
+// given code and message.
+type Abort[T any] func(code int, message string) (T, error)
+
+// The canonical address for a cluster-local address is <service>.<namespace>,
+// without the local cluster suffix or port. The canonical address for a
+// non-cluster-local address is the full original address without the port.
+func getCanonicalAddress(serverAddress string) string {
+	// Cluster-local address.
+	if i := strings.Index(serverAddress, ".svc.cluster.local"); i != -1 {
+		return serverAddress[:i]
+	}
+	// External host:port address.
+	if i := strings.LastIndex(serverAddress, ":"); i != -1 {
+		port := serverAddress[i+1:]
+		// Verify this is actually a port number.
+		if port != "" && port[0] >= '0' && port[0] <= '9' {
+			return serverAddress[:i]
+		}
+	}
+	// Other address, i.e. unix domain socket.
+	return serverAddress
+}
+
+func parsePercentage(percentage string) (int, error) {
+	if percentage == "" {
+		return 100, nil
+	}
+	intPercentage, err := strconv.Atoi(percentage)
+	if err != nil {
+		return 0, fmt.Errorf("provided percentage %q is not a valid integer: %w", percentage, err)
+	}
+	if intPercentage < 0 || intPercentage > 100 {
+		return 0, fmt.Errorf("provided percentage \"%d\" is outside the valid range of [0-100]", intPercentage)
+	}
+	return intPercentage, nil
+}
+
+// Injector contains the data common across all requests needed to inject
+// faults on outgoing requests.
+type Injector[T any] struct {
+	clientName   string
+	callerName   string
+	abortCodeMin int
+	abortCodeMax int
+
+	defaultAbort Abort[T]
+
+	selected func(int) bool
+	sleep    func(context.Context, time.Duration) error
+}
+
+// WithDefaultAbort is an option to set the default abort function for the
+// Injector.
+func WithDefaultAbort[T any](fn Abort[T]) func(*Injector[T]) {
+	return func(i *Injector[T]) {
+		i.defaultAbort = fn
+	}
+}
+
+func defaultSelected(percentage int) bool {
+	// Use a different random integer per feature as per
+	// https://github.com/grpc/proposal/blob/master/A33-Fault-Injection.md#evaluate-possibility-fraction.
+	return rand.IntN(100) < percentage
+}
+
+func defaultSleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	select {
+	case <-t.C:
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	}
+	return nil
+}
+
+// NewInjector creates a new Injector with the provided parameters.
+func NewInjector[T any](clientName, callerName string, abortCodeMin, abortCodeMax int, option ...func(*Injector[T])) *Injector[T] {
+	i := &Injector[T]{
+		clientName:   clientName,
+		callerName:   callerName,
+		abortCodeMin: abortCodeMin,
+		abortCodeMax: abortCodeMax,
+		selected:     defaultSelected,
+		sleep:        defaultSleep,
+	}
+	for _, o := range option {
+		o(i)
+	}
+	return i
+}
+
+// InjectWithAbortOverride injects a fault using the provided fault function
+// on the outgoing request if it matches the header configuration.
+func (i *Injector[T]) InjectWithAbortOverride(ctx context.Context, address, method string, headers Headers, resume Resume[T], abort Abort[T]) (T, error) {
+	delayed := false
+	totalReqsCounter := func(success, aborted bool) prometheus.Counter {
+		return totalRequests.WithLabelValues(
+			i.clientName,
+			address,
+			method,
+			i.callerName,
+			strconv.FormatBool(success),
+			strconv.FormatBool(delayed),
+			strconv.FormatBool(aborted),
+		)
+	}
+
+	infof := func(format string, args ...interface{}) {
+		slog.With("caller", i.callerName).InfoContext(ctx, fmt.Sprintf(format, args...))
+	}
+	warnf := func(format string, args ...interface{}) {
+		slog.With("caller", i.callerName).WarnContext(ctx, fmt.Sprintf(format, args...))
+	}
+
+	faultHeaderAddress, err := headers.Lookup(ctx, FaultServerAddressHeader)
+	if err != nil {
+		infof("error looking up header %q: %v", FaultServerAddressHeader, err)
+		totalReqsCounter(true, false).Inc()
+		return resume()
+	}
+	requestAddress := getCanonicalAddress(address)
+	if faultHeaderAddress == "" || faultHeaderAddress != requestAddress {
+		infof("address %q does not match the %s header value %q", requestAddress, FaultServerAddressHeader, faultHeaderAddress)
+		totalReqsCounter(true, false).Inc()
+		return resume()
+	}
+
+	serverMethod, err := headers.Lookup(ctx, FaultServerMethodHeader)
+	if err != nil {
+		infof("error looking up header %q: %v", FaultServerMethodHeader, err)
+		totalReqsCounter(true, false).Inc()
+		return resume()
+	}
+	if serverMethod != "" && serverMethod != method {
+		infof("method %q does not match the %s header value %q", method, FaultServerMethodHeader, serverMethod)
+		totalReqsCounter(true, false).Inc()
+		return resume()
+	}
+
+	delayMs, err := headers.Lookup(ctx, FaultDelayMsHeader)
+	if err != nil {
+		infof("error looking up header %q: %v", FaultDelayMsHeader, err)
+	}
+	if delayMs != "" {
+		percentageHeader, err := headers.Lookup(ctx, FaultDelayPercentageHeader)
+		if err != nil {
+			infof("error looking up header %q: %v", FaultDelayPercentageHeader, err)
+		}
+		percentage, err := parsePercentage(percentageHeader)
+		if err != nil {
+			warnf("error parsing percentage header %q: %v", FaultDelayPercentageHeader, err)
+			totalReqsCounter(false, false).Inc()
+			return resume()
+		}
+
+		if i.selected(percentage) {
+			delay, err := strconv.Atoi(delayMs)
+			if err != nil {
+				warnf("unable to convert provided delay %q to integer: %v", delayMs, err)
+				totalReqsCounter(false, false).Inc()
+				return resume()
+			}
+
+			if err := i.sleep(ctx, time.Duration(delay)*time.Millisecond); err != nil {
+				warnf("error when delaying request: %v", err)
+				totalReqsCounter(false, false).Inc()
+				return resume()
+			}
+			delayed = true
+		}
+	}
+
+	abortCode, err := headers.Lookup(ctx, FaultAbortCodeHeader)
+	if err != nil {
+		infof("error looking up header %q: %v", FaultAbortCodeHeader, err)
+	}
+	if abortCode != "" {
+		percentageHeader, err := headers.Lookup(ctx, FaultAbortPercentageHeader)
+		if err != nil {
+			infof("error looking up header %q: %v", FaultAbortPercentageHeader, err)
+		}
+		percentage, err := parsePercentage(percentageHeader)
+		if err != nil {
+			warnf("error parsing percentage header %q: %v", FaultAbortPercentageHeader, err)
+			totalReqsCounter(false, false).Inc()
+			return resume()
+		}
+
+		if i.selected(percentage) {
+			code, err := strconv.Atoi(abortCode)
+			if err != nil {
+				warnf("unable to convert provided abort %q to integer: %v", abortCode, err)
+				totalReqsCounter(false, false).Inc()
+				return resume()
+			}
+			if code < i.abortCodeMin || code > i.abortCodeMax {
+				warnf("provided abort code \"%d\" is outside of the valid range [%d-%d]", code, i.abortCodeMin, i.abortCodeMax)
+				totalReqsCounter(false, false).Inc()
+				return resume()
+			}
+
+			abortMessage, err := headers.Lookup(ctx, FaultAbortMessageHeader)
+			if err != nil {
+				warnf("error looking up header %q: %v", FaultAbortMessageHeader, err)
+				totalReqsCounter(false, false).Inc()
+				return resume()
+			}
+
+			totalReqsCounter(true, true).Inc()
+			return abort(code, abortMessage)
+		}
+	}
+
+	totalReqsCounter(true, false).Inc()
+	return resume()
+}
+
+// Inject injects a fault using the Injector default fault function on the
+// outgoing request if it matches the header configuration.
+func (i *Injector[T]) Inject(ctx context.Context, address, method string, headers Headers, resume Resume[T]) (T, error) {
+	return i.InjectWithAbortOverride(ctx, address, method, headers, resume, i.defaultAbort)
+}

--- a/internal/faults/faults_test.go
+++ b/internal/faults/faults_test.go
@@ -1,0 +1,434 @@
+package faults
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	address      = "testService.testNamespace.svc.cluster.local:12345"
+	method       = "testMethod"
+	minAbortCode = 0
+	maxAbortCode = 10
+)
+
+func TestGetCanonicalAddress(t *testing.T) {
+	testCases := []struct {
+		name    string
+		address string
+		want    string
+	}{
+		{
+			name:    "cluster local address",
+			address: "testService.testNamespace.svc.cluster.local:12345",
+			want:    "testService.testNamespace",
+		},
+		{
+			name:    "external address port stripped",
+			address: "foo.bar:12345",
+			want:    "foo.bar",
+		},
+		{
+			name:    "unexpected address path stripped",
+			address: "foo.bar:12345/path",
+			want:    "foo.bar",
+		},
+		{
+			name:    "unexpected trailing colon untouched",
+			address: "foo.bar:",
+			want:    "foo.bar:",
+		},
+		{
+			name:    "external address without port untouched",
+			address: "unix://foo",
+			want:    "unix://foo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getCanonicalAddress(tc.address)
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestParsePercentage(t *testing.T) {
+	testCases := []struct {
+		name       string
+		percentage string
+		want       int
+		wantErr    string
+	}{
+		{
+			name:       "empty",
+			percentage: "",
+			want:       100,
+		},
+		{
+			name:       "valid",
+			percentage: "50",
+			want:       50,
+		},
+		{
+			name:       "NaN",
+			percentage: "NaN",
+			want:       0,
+			wantErr:    "not a valid integer",
+		},
+		{
+			name:       "under min",
+			percentage: "-1",
+			want:       0,
+			wantErr:    "outside the valid range",
+		},
+		{
+			name:       "over max",
+			percentage: "101",
+			want:       0,
+			wantErr:    "outside the valid range",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parsePercentage(tc.percentage)
+			if got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+			if tc.wantErr == "" && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error to contain %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+type response struct {
+	code    int
+	message string
+}
+type injectTestCase struct {
+	name     string
+	randInt  int
+	sleepErr bool
+
+	faultServerAddressHeader   string
+	faultServerMethodHeader    string
+	faultDelayMsHeader         string
+	faultDelayPercentageHeader string
+	faultAbortCodeHeader       string
+	faultAbortMessageHeader    string
+	faultAbortPercentageHeader string
+
+	wantDelayMs  int
+	wantResponse *response
+}
+
+type headers injectTestCase
+
+func (tc *headers) Lookup(_ context.Context, key string) (string, error) {
+	if key == FaultServerAddressHeader {
+		return tc.faultServerAddressHeader, nil
+	}
+	if key == FaultServerMethodHeader {
+		return tc.faultServerMethodHeader, nil
+	}
+	if key == FaultDelayMsHeader {
+		return tc.faultDelayMsHeader, nil
+	}
+	if key == FaultDelayPercentageHeader {
+		return tc.faultDelayPercentageHeader, nil
+	}
+	if key == FaultAbortCodeHeader {
+		return tc.faultAbortCodeHeader, nil
+	}
+	if key == FaultAbortMessageHeader {
+		return tc.faultAbortMessageHeader, nil
+	}
+	if key == FaultAbortPercentageHeader {
+		return tc.faultAbortPercentageHeader, nil
+	}
+	return "", fmt.Errorf("header %q not found", key)
+}
+
+func TestInject(t *testing.T) {
+	testCases := []injectTestCase{
+		{
+			name: "no fault specified",
+		},
+		{
+			name: "delay",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultDelayMsHeader:       "1",
+
+			wantDelayMs: 1,
+		},
+		{
+			name: "abort",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultAbortCodeHeader:     "1",
+			faultAbortMessageHeader:  "test fault",
+
+			wantResponse: &response{
+				code:    1,
+				message: "test fault",
+			},
+		},
+		{
+			name: "server address does not match",
+
+			faultServerAddressHeader: "fooService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultAbortCodeHeader:     "1",
+			faultAbortMessageHeader:  "test fault",
+		},
+		{
+			name: "method does not match",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "fooMethod",
+			faultAbortCodeHeader:     "1",
+			faultAbortMessageHeader:  "test fault",
+		},
+		{
+			name:    "guaranteed percent",
+			randInt: 99, // Maximum possible integer returned by rand.Intn(100)
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "100", // All requests delayed
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "100", // All requests aborted
+
+			wantDelayMs: 250,
+			wantResponse: &response{
+				code:    1,
+				message: "test fault",
+			},
+		},
+		{
+			name:    "fence post below percent",
+			randInt: 49,
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "50",
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "50",
+
+			wantDelayMs: 250,
+			wantResponse: &response{
+				code:    1,
+				message: "test fault",
+			},
+		},
+		{
+			name:    "fence post at percent",
+			randInt: 50,
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "50",
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "50",
+
+			wantDelayMs: 0,
+		},
+		{
+			name:    "guaranteed skip percent",
+			randInt: 0, // Minimum possible integer returned by rand.Intn(100)
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "0", // No requests delayed
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "0", // No requests aborted
+
+			wantDelayMs: 0,
+		},
+		{
+			name:    "only skip delay",
+			randInt: 50,
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "0", // No requests delayed
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "100", // All requests aborted
+
+			wantDelayMs: 0,
+			wantResponse: &response{
+				code:    1,
+				message: "test fault",
+			},
+		},
+		{
+			name: "invalid delay percentage negative",
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "-1",
+
+			wantDelayMs: 0,
+		},
+		{
+			name: "invalid delay percentage over 100",
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultDelayMsHeader:         "250",
+			faultDelayPercentageHeader: "101",
+
+			wantDelayMs: 0,
+		},
+		{
+			name: "invalid delay ms",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultDelayMsHeader:       "NaN",
+
+			wantDelayMs: 0,
+		},
+		{
+			name:     "error while sleeping short circuits",
+			sleepErr: true,
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultDelayMsHeader:       "1",
+			faultAbortCodeHeader:     "1",
+			faultAbortMessageHeader:  "test fault",
+
+			wantDelayMs: 0,
+		},
+		{
+			name: "invalid abort percentage negative",
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "-1",
+		},
+		{
+			name: "invalid abort percentage over 100",
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "101",
+		},
+		{
+			name: "invalid abort code",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultAbortCodeHeader:     "NaN",
+			faultAbortMessageHeader:  "test fault",
+		},
+		{
+			name: "less than min abort code",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultAbortCodeHeader:     "-1",
+			faultAbortMessageHeader:  "test fault",
+		},
+		{
+			name: "greater than max abort code",
+
+			faultServerAddressHeader: "testService.testNamespace",
+			faultServerMethodHeader:  "testMethod",
+			faultAbortCodeHeader:     "11",
+			faultAbortMessageHeader:  "test fault",
+		},
+		{
+			name: "invalid abort percentage",
+
+			faultServerAddressHeader:   "testService.testNamespace",
+			faultServerMethodHeader:    "testMethod",
+			faultAbortCodeHeader:       "1",
+			faultAbortMessageHeader:    "test fault",
+			faultAbortPercentageHeader: "NaN",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			injector := NewInjector(
+				"TestClient",
+				"faults_test.TestInjectFault",
+				minAbortCode,
+				maxAbortCode,
+				WithDefaultAbort(func(code int, message string) (*response, error) {
+					return &response{
+						code:    code,
+						message: message,
+					}, nil
+				}),
+			)
+
+			headers := headers(tc)
+
+			var resume Resume[*response] = func() (*response, error) {
+				return nil, nil
+			}
+
+			// Override the selected and sleep functions for testing.
+			injector.selected = func(percentage int) bool {
+				return tc.randInt < percentage
+			}
+			delayMs := 0
+			injector.sleep = func(_ context.Context, d time.Duration) error {
+				if tc.sleepErr {
+					return fmt.Errorf("context cancelled")
+				}
+				delayMs = int(d.Milliseconds())
+				return nil
+			}
+
+			resp, err := injector.Inject(context.Background(), address, method, &headers, resume)
+
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if tc.wantDelayMs != delayMs {
+				t.Fatalf("expected delay of %v ms, got %v ms", tc.wantDelayMs, delayMs)
+			}
+			if tc.wantResponse == nil && resp != nil {
+				t.Fatalf("expected no response, got %v", resp)
+			}
+			if tc.wantResponse != nil && resp == nil {
+				t.Fatalf("expected response %v, got nil", tc.wantResponse)
+			}
+			if resp != nil && *tc.wantResponse != *resp {
+				t.Fatalf("expected response %v, got %v", tc.wantResponse, resp)
+			}
+		})
+	}
+}

--- a/internal/faults/headers.go
+++ b/internal/faults/headers.go
@@ -1,0 +1,11 @@
+package faults
+
+const (
+	FaultServerAddressHeader   = "x-bp-fault-server-address"
+	FaultServerMethodHeader    = "x-bp-fault-server-method"
+	FaultDelayMsHeader         = "x-bp-fault-delay-ms"
+	FaultDelayPercentageHeader = "x-bp-fault-delay-percentage"
+	FaultAbortCodeHeader       = "x-bp-fault-abort-code"
+	FaultAbortMessageHeader    = "x-bp-fault-abort-message"
+	FaultAbortPercentageHeader = "x-bp-fault-abort-percentage"
+)

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -275,6 +275,13 @@ func SetDeadlineBudget(next thrift.TClient) thrift.TClient {
 	}
 }
 
+func getClientError(result thrift.TStruct, err error) error {
+	if err != nil {
+		return err
+	}
+	return thrift.ExtractExceptionFromResult(result)
+}
+
 // Retry returns a thrift.ClientMiddleware that can be used to automatically
 // retry thrift requests.
 func Retry(defaults ...retry.Option) thrift.ClientMiddleware {
@@ -464,11 +471,4 @@ func (c clientFaultMiddleware) Middleware() thrift.ClientMiddleware {
 			},
 		}
 	}
-}
-
-func getClientError(result thrift.TStruct, err error) error {
-	if err != nil {
-		return err
-	}
-	return thrift.ExtractExceptionFromResult(result)
 }

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -18,6 +18,7 @@ import (
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/internal/thriftint"
+
 	//lint:ignore SA1019 This library is internal only, not actually deprecated
 	"github.com/reddit/baseplate.go/internalv2compat"
 	"github.com/reddit/baseplate.go/prometheusbp"
@@ -67,6 +68,11 @@ type DefaultClientMiddlewareArgs struct {
 	//     ImageUploadService -> image-upload
 	ServiceSlug string
 
+	// Address is the DNS address of the thrift service you are creating clients for.
+	//
+	// If not provided, the client will be unable to use the fault injection middleware.
+	Address string
+
 	// RetryOptions is the list of retry.Options to apply as the defaults for the
 	// Retry middleware.
 	//
@@ -106,7 +112,7 @@ type DefaultClientMiddlewareArgs struct {
 //
 // Currently they are (in order):
 //
-// 1. ForwardEdgeRequestContext.
+// 1. ForwardEdgeRequestContext
 //
 // 2. SetClientName(clientName)
 //
@@ -133,6 +139,12 @@ type DefaultClientMiddlewareArgs struct {
 // 10. thrift.ExtractIDLExceptionClientMiddleware
 //
 // 11. SetDeadlineBudget
+//
+// 12. clientFaultMiddleware - This injects faults at the client side if the
+// request matches the provided configuration.
+//
+// IMPORTANT: clientFaultMiddleware MUST be the last middleware as it simulates
+// faults as if they originated from the upstream server.
 func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrift.ClientMiddleware {
 	if len(args.RetryOptions) == 0 {
 		args.RetryOptions = []retry.Option{retry.Attempts(1)}
@@ -153,6 +165,7 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 			breakerbp.NewFailureRatioBreaker(*args.BreakerConfig).ThriftMiddleware,
 		)
 	}
+	clientFaultMiddleware := NewClientFaultMiddleware(args.ClientName, args.Address)
 	middlewares = append(
 		middlewares,
 		MonitorClient(MonitorClientArgs{
@@ -164,6 +177,7 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 		thrift.ExtractIDLExceptionClientMiddleware,
 		SetDeadlineBudget,
 		ClientBaseplateHeadersMiddleware(args.ServiceSlug, args.ClientName),
+		clientFaultMiddleware.Middleware(), // clientFaultMiddleware MUST be last
 	)
 	return middlewares
 }
@@ -387,6 +401,24 @@ func PrometheusClientMiddleware(remoteServerSlug string) thrift.ClientMiddleware
 				}()
 
 				return next.Call(ctx, method, args, result)
+			},
+		}
+	}
+}
+
+func (c clientFaultMiddleware) Middleware() thrift.ClientMiddleware {
+	return func(next thrift.TClient) thrift.TClient {
+		return thrift.WrappedTClient{
+			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
+				if c.address == "" {
+					return next.Call(ctx, method, args, result)
+				}
+
+				resume := func() (thrift.ResponseMeta, error) {
+					return next.Call(ctx, method, args, result)
+				}
+
+				return c.injector.Inject(ctx, c.address, method, thriftHeaders{}, resume)
 			},
 		}
 	}

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -401,6 +401,7 @@ func NewBaseplateClientPoolWithContext(ctx context.Context, cfg ClientPoolConfig
 	}
 	defaults := BaseplateDefaultClientMiddlewares(
 		DefaultClientMiddlewareArgs{
+			Address:             cfg.Addr,
 			EdgeContextImpl:     cfg.EdgeContextImpl,
 			ServiceSlug:         cfg.ServiceSlug,
 			RetryOptions:        cfg.DefaultRetryOptions,

--- a/thriftbp/faults.go
+++ b/thriftbp/faults.go
@@ -1,0 +1,41 @@
+package thriftbp
+
+import (
+	"context"
+
+	"github.com/apache/thrift/lib/go/thrift"
+	"github.com/reddit/baseplate.go/internal/faults"
+)
+
+type clientFaultMiddleware struct {
+	address  string
+	injector faults.Injector[thrift.ResponseMeta]
+}
+
+// NewClientFaultMiddleware creates and returns a new client-side fault
+// injection middleware.
+func NewClientFaultMiddleware(clientName, address string) clientFaultMiddleware {
+	return clientFaultMiddleware{
+		address: address,
+		injector: *faults.NewInjector(
+			clientName,
+			"thriftpb.clientFaultMiddleware",
+			thrift.UNKNOWN_TRANSPORT_EXCEPTION,
+			thrift.END_OF_FILE,
+			faults.WithDefaultAbort(func(code int, message string) (thrift.ResponseMeta, error) {
+				return thrift.ResponseMeta{}, thrift.NewTTransportException(code, message)
+			}),
+		),
+	}
+}
+
+type thriftHeaders struct{}
+
+// Lookup returns the value of the header, if found.
+func (h thriftHeaders) Lookup(ctx context.Context, key string) (string, error) {
+	header, ok := thrift.GetHeader(ctx, key)
+	if !ok {
+		return "", nil
+	}
+	return header, nil
+}


### PR DESCRIPTION
## 💸 TL;DR
NOTE: This is a refactor of the approved PR https://github.com/reddit/baseplate.go/pull/666 based on offline feedback. In addition to being a refactor, this also moves the fault injection middleware to be the final middleware for each protocol, as it is meant to simulate the upstream service being unavailable.

This PR introduces client-side fault injection capability to HTTP and Thrift clients. The behavior is controlled via new `X-Bp-Fault` headers, and does nothing if they aren't present, are invalid, or don't match the outgoing request.

## 📜 Details
If clients are currently passing matching `X-Bp-Fault` headers around and they happen to be valid according to this change, then unintended fault injection could take place. This is extremely unlikely to occur given how specific the headers and their valid values are, but I wanted to call it out as technically it could affect requests unintentionally.

## 🧪 Testing Steps / Validation
Thorough unit tests were added across the common library and protocol-specific code.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] CI tests (if present) are passing
- [X] Adheres to code style for repo
- [X] Contributor License Agreement (CLA) completed if not a Reddit employee