### PR TITLE
add headerbp signature validation/minting

### DIFF
--- a/headerbp/headerbp.go
+++ b/headerbp/headerbp.go
@@ -43,7 +43,7 @@ func SetV0Setters(
 	setV0SignatureSetter func(func(context.Context, string) context.Context),
 ) {
 	setV0HeaderSetter(setHeadersOnContext)
-	//setV0SignatureSetter(setV2SignatureContext)
+	setV0SignatureSetter(setV2SignatureContext)
 }
 
 // IsBaseplateHeader returns true if the header is for baseplate and should be propagated

--- a/headerbp/headerbp.go
+++ b/headerbp/headerbp.go
@@ -38,6 +38,7 @@ func SetV2BaseplateSignatureSetter(setter func(context.Context, string) context.
 	setV2SignatureContext = setter
 }
 
+// SetV0Setters can be used by the baseplate interop library to hook headerbp v0 into v2.
 func SetV0Setters(
 	setV0HeaderSetter func(func(context.Context, map[string]string) context.Context),
 	setV0SignatureSetter func(func(context.Context, string) context.Context),

--- a/headerbp/headerbp.go
+++ b/headerbp/headerbp.go
@@ -44,7 +44,7 @@ func SetV0Setters(
 	setV0SignatureSetter func(func(context.Context, string) context.Context),
 ) {
 	setV0HeaderSetter(setHeadersOnContext)
-	setV0SignatureSetter(setV2SignatureContext)
+	setV0SignatureSetter(setSignatureOnContext)
 }
 
 // IsBaseplateHeader returns true if the header is for baseplate and should be propagated

--- a/headerbp/signing.go
+++ b/headerbp/signing.go
@@ -22,7 +22,7 @@ var ErrInvalidSignatureVersion = fmt.Errorf("invalid  version")
 
 type headerSignatureContextKey struct{}
 
-func setHeaderSignature(ctx context.Context, sig string) context.Context {
+func setSignatureOnContext(ctx context.Context, sig string) context.Context {
 	return context.WithValue(ctx, headerSignatureContextKey{}, sig)
 }
 
@@ -175,5 +175,5 @@ func VerifyHeaders(
 		return ctx, fmt.Errorf("verification error: %w", err)
 	}
 	ctx = setV2SignatureContext(ctx, signature)
-	return setHeaderSignature(ctx, signature), nil
+	return setSignatureOnContext(ctx, signature), nil
 }

--- a/headerbp/signing.go
+++ b/headerbp/signing.go
@@ -1,0 +1,179 @@
+package headerbp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/reddit/baseplate.go/secrets"
+	"github.com/reddit/baseplate.go/signing"
+)
+
+const delimiter = rune(0)
+
+var signatureVersionPrefix = strconv.Itoa(signatureVersion)
+
+var ErrInvalidSignatureVersion = fmt.Errorf("invalid  version")
+
+type headerSignatureContextKey struct{}
+
+func setHeaderSignature(ctx context.Context, sig string) context.Context {
+	return context.WithValue(ctx, headerSignatureContextKey{}, sig)
+}
+
+// HeaderSignatureFromContext gets the header signature from the context. This can be used in client middleware to propagate the
+// signature along with the headers if they are unchanged by the request.
+func HeaderSignatureFromContext(ctx context.Context) (string, bool) {
+	sig, ok := ctx.Value(headerSignatureContextKey{}).(string)
+	return sig, ok
+}
+
+var messageBufferPool = sync.Pool{
+	New: func() interface{} {
+		return new(bytes.Buffer)
+	},
+}
+
+func getBuffer() *bytes.Buffer {
+	buf := messageBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	return buf
+}
+
+func putBuffer(buf *bytes.Buffer) {
+	messageBufferPool.Put(buf)
+}
+
+func concatHeaders(b *bytes.Buffer, headerNames []string, getHeader func(string) string, versionPrefix string) {
+	type manifestEntry struct {
+		// normalized is used to sort the manifest and as the header name in the message
+		normalized string
+
+		// original is maintained in order to potentially reduce the number of allocations when looking up the header
+		// value
+		original string
+	}
+	manifest := make([]manifestEntry, 0, len(headerNames))
+	for _, k := range headerNames {
+		manifest = append(manifest, manifestEntry{
+			// do not cache the normalized key here though since we do not know if we can trust it, and we don't want to
+			// cache junk headers.
+			normalized: normalizeKey(k, false),
+			original:   k,
+		})
+	}
+	slices.SortFunc(manifest, func(i, j manifestEntry) int {
+		if i.normalized < j.normalized {
+			return -1
+		} else if i.normalized > j.normalized {
+			return 1
+		} else {
+			return 0
+		}
+	})
+
+	b.WriteString(versionPrefix)
+	b.WriteRune(delimiter)
+	// include the number of headers to protect against a case where someone tries to embed portions of the message
+	// into a header value.
+	b.WriteString(strconv.Itoa(len(manifest)))
+	b.WriteRune(delimiter)
+	for _, entry := range manifest {
+		b.WriteString(entry.normalized)
+		b.WriteRune(':')
+		b.WriteString(getHeader(entry.original))
+		b.WriteRune(delimiter)
+	}
+}
+
+type signHeadersOptions func()
+
+// SignHeaders signs the given headers with the given signing secret using baseplate message signing. The
+// signature will be valid for 5 minutes.
+//
+// This can be used by middlewares clients that send requests to other services that are exposed to untrusted traffic to
+// sign the headers before sending them or by services that are setting up the initial headers to be propagated.
+func SignHeaders(
+	ctx context.Context,
+	signingSecret secrets.VersionedSecret,
+	headerNames []string,
+	getHeader func(string) string,
+	opts ...signHeadersOptions,
+) (string, error) {
+	b := getBuffer()
+	defer putBuffer(b)
+
+	concatHeaders(b, headerNames, getHeader, signatureVersionPrefix)
+	signature, err := signing.Sign(
+		signing.SignArgs{
+			Message:   b.Bytes(),
+			Secret:    signingSecret,
+			ExpiresIn: 5 * time.Minute,
+		})
+	if err != nil {
+		return "", fmt.Errorf("generating signature: %w", err)
+	}
+
+	b.Reset()
+	b.WriteString(signatureVersionPrefix)
+	b.WriteRune('.')
+	b.WriteString(signature)
+	return b.String(), nil
+}
+
+type signatureComponents struct {
+	version       int
+	versionPrefix string
+	signature     string
+}
+
+func extractVersion(signature string) (*signatureComponents, error) {
+	version, sig, ok := strings.Cut(signature, ".")
+	if !ok {
+		return nil, fmt.Errorf("no version found in signature")
+	}
+	versionInt, err := strconv.Atoi(version)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version format %q: %w", version, err)
+	}
+	return &signatureComponents{
+		version:       versionInt,
+		versionPrefix: version,
+		signature:     sig,
+	}, nil
+}
+
+// VerifyHeaders verifies the signature of the given headers using the given verification secret. If the signature
+// is valid, it sets the signature on the context.
+//
+// This can be used by middlewares that receive requests from untrusted traffic to verify the headers before recording
+// them to be propagated.
+func VerifyHeaders(
+	ctx context.Context,
+	verificationSecret secrets.VersionedSecret,
+	signature string,
+	headerNames []string,
+	getHeader func(string) string,
+) (context.Context, error) {
+	components, err := extractVersion(signature)
+	if err != nil {
+		return ctx, fmt.Errorf("%w: %w", ErrInvalidSignatureVersion, err)
+	}
+	if components.version != 1 {
+		return ctx, fmt.Errorf("%w: unsupported version number %d", ErrInvalidSignatureVersion, components.version)
+	}
+
+	b := getBuffer()
+	defer putBuffer(b)
+	concatHeaders(b, headerNames, getHeader, components.versionPrefix)
+	if err := signing.Verify(b.Bytes(), components.signature, verificationSecret); err != nil {
+		return ctx, fmt.Errorf("verification error: %w", err)
+	}
+	ctx = setV2SignatureContext(ctx, signature)
+	return setHeaderSignature(ctx, signature), nil
+}

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -411,11 +411,11 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 			// the !hasSignature check is redundant since we do not add to the baseplateHeaders list unless it is false, but
 			// it's here to make it clear that we only need to update the signature if there is no signature in the context
 			if len(baseplateHeaders) > 0 && !hasSignature {
-				_signature, err := headerbp.SignHeaders(req.Context(), *signingSecret, baseplateHeaders, req.Header.Get)
-				if err != nil {
+				if _signature, err := headerbp.SignHeaders(req.Context(), *signingSecret, baseplateHeaders, req.Header.Get); err != nil {
 					return nil, fmt.Errorf("signing baseplate headers: %w", err)
+				} else {
+					signature = _signature
 				}
-				signature = _signature
 			}
 			if signature != "" {
 				req.Header.Set(headerbp.SignatureHeaderCanonicalHTTP, signature)

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -15,7 +15,6 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/headerbp"
-	"github.com/reddit/baseplate.go/log"
 	"github.com/reddit/baseplate.go/secrets"
 
 	"github.com/reddit/baseplate.go/breakerbp"
@@ -376,7 +375,11 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 	getSigningSecret := func() *secrets.VersionedSecret {
 		secret, err := store.GetVersionedSecret(path)
 		if err != nil {
-			log.Errorf("Failed to get secret %q: %v", path, err)
+			slog.Error(
+				"Failed to get secret:",
+				slog.String("path", path),
+				slog.String("err", err.Error()),
+			)
 		}
 		return &secret
 	}

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -15,6 +15,8 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/headerbp"
+	"github.com/reddit/baseplate.go/log"
+	"github.com/reddit/baseplate.go/secrets"
 
 	"github.com/reddit/baseplate.go/breakerbp"
 	//lint:ignore SA1019 This library is internal only, not actually deprecated
@@ -96,9 +98,9 @@ func NewClient(config ClientConfig, middleware ...ClientMiddleware) (*http.Clien
 		defaults = append([]ClientMiddleware{CircuitBreaker(*config.CircuitBreaker)}, defaults...)
 	}
 
-	// only add the middleware to forward baseplate headers if the client is for internal calls
-	if config.InternalOnly {
-		defaults = append(defaults, ClientBaseplateHeadersMiddleware(config.Slug))
+	// only add the middleware to forward baseplate headers if the client is configured for it
+	if config.SecretsStore != nil && config.HeaderbpSigningKeyPath != "" {
+		defaults = append(defaults, ClientBaseplateHeadersMiddleware(config.Slug, config.SecretsStore, config.HeaderbpSigningKeyPath))
 	}
 
 	middleware = append(middleware, defaults...)
@@ -370,9 +372,22 @@ func PrometheusClientMetrics(serverSlug string) ClientMiddleware {
 // ClientBaseplateHeadersMiddleware is a middleware that forwards baseplate headers from the context to the outgoing request.
 //
 // If it detects any new baseplate headers set on the request, it will reject the request and return an error.
-func ClientBaseplateHeadersMiddleware(client string) ClientMiddleware {
+func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path string) ClientMiddleware {
+	getSigningSecret := func() *secrets.VersionedSecret {
+		secret, err := store.GetVersionedSecret(path)
+		if err != nil {
+			log.Errorf("Failed to get secret %q: %v", path, err)
+		}
+		return &secret
+	}
+
 	return func(next http.RoundTripper) http.RoundTripper {
 		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			signingSecret := getSigningSecret()
+			if signingSecret == nil {
+				return nil, fmt.Errorf("signing secret is required to set use baseplate headers")
+			}
+
 			for k := range req.Header {
 				if err := headerbp.CheckClientHeader(k,
 					headerbp.WithHTTPClient("", client, ""),
@@ -380,11 +395,31 @@ func ClientBaseplateHeadersMiddleware(client string) ClientMiddleware {
 					return nil, err
 				}
 			}
+
+			signature, hasSignature := headerbp.HeaderSignatureFromContext(req.Context())
+			var baseplateHeaders []string
 			headerbp.SetOutgoingHeaders(
 				req.Context(),
 				headerbp.WithHTTPClient("", client, ""),
-				headerbp.WithHeaderSetter(req.Header.Set),
+				headerbp.WithHeaderSetter(func(key, value string) {
+					if !hasSignature {
+						baseplateHeaders = append(baseplateHeaders, key)
+					}
+					req.Header.Set(key, value)
+				}),
 			)
+			// the !hasSignature check is redundant since we do not add to the baseplateHeaders list unless it is false, but
+			// it's here to make it clear that we only need to update the signature if there is no signature in the context
+			if len(baseplateHeaders) > 0 && !hasSignature {
+				_signature, err := headerbp.SignHeaders(req.Context(), *signingSecret, baseplateHeaders, req.Header.Get)
+				if err != nil {
+					return nil, fmt.Errorf("signing baseplate headers: %w", err)
+				}
+				signature = _signature
+			}
+			if signature != "" {
+				req.Header.Set(headerbp.SignatureHeaderCanonicalHTTP, signature)
+			}
 			return next.RoundTrip(req)
 		})
 	}

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -376,9 +376,9 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 		secret, err := store.GetVersionedSecret(path)
 		if err != nil {
 			slog.Error(
-				"Failed to get secret:",
-				slog.String("path", path),
-				slog.String("err", err.Error()),
+				"Failed to get secret",
+				"path", path,
+				"err", err,
 			)
 		}
 		return &secret

--- a/httpbp/config.go
+++ b/httpbp/config.go
@@ -16,7 +16,12 @@ type ClientConfig struct {
 	MaxConnections    int               `yaml:"maxConnections"`
 	CircuitBreaker    *breakerbp.Config `yaml:"circuitBreaker"`
 	RetryOptions      []retry.Option
-	InternalOnly      bool
+
+	SecretsStore           SecretsStore
+	HeaderbpSigningKeyPath string
+
+	// deprecated
+	InternalOnly bool
 }
 
 // Validate checks ClientConfig for any missing or erroneous values.

--- a/httpbp/config.go
+++ b/httpbp/config.go
@@ -19,9 +19,6 @@ type ClientConfig struct {
 
 	SecretsStore           SecretsStore
 	HeaderbpSigningKeyPath string
-
-	// deprecated
-	InternalOnly bool
 }
 
 // Validate checks ClientConfig for any missing or erroneous values.

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -549,9 +549,9 @@ func ServerBaseplateHeadersMiddleware(service string, store SecretsStore, path s
 		secret, err := store.GetVersionedSecret(path)
 		if err != nil {
 			slog.Error(
-				"Failed to get secret:",
-				slog.String("path", path),
-				slog.String("err", err.Error()),
+				"Failed to get secret",
+				"path", path,
+				"err", err,
 			)
 		}
 		return &secret

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strconv"
@@ -547,7 +548,11 @@ func ServerBaseplateHeadersMiddleware(service string, store SecretsStore, path s
 	getVerificationSecret := func() *secrets.VersionedSecret {
 		secret, err := store.GetVersionedSecret(path)
 		if err != nil {
-			log.Errorf("Failed to get secret %q: %v", path, err)
+			slog.Error(
+				"Failed to get secret:",
+				slog.String("path", path),
+				slog.String("err", err.Error()),
+			)
 		}
 		return &secret
 	}

--- a/httpbp/middlewares.go
+++ b/httpbp/middlewares.go
@@ -531,6 +531,10 @@ func GetUntrustedBaseplateHeaders(ctx context.Context) (map[string]string, bool)
 	return h, ok
 }
 
+// SecretsStore is the minimum inteface required for the ServerBaseplateHeadersMiddleware and ClientBaseplateHeadersMiddleware.
+//
+// *secrets.Store fulfills this interface but an interface is used so that a service using v2 secrets can still use
+// these middlewares if needed through an interop library.
 type SecretsStore interface {
 	GetVersionedSecret(path string) (secrets.VersionedSecret, error)
 }


### PR DESCRIPTION
## 💸 TL;DR

We ran into some issues trying to rely just on the X-Rddt-Untrusted header being set on ingress and are switching over to having a signature on these headers for HTTP requests.

This does include some small breaking changes, but this had not been rolled out to any services yet.
