### PR TITLE
bug fix for passing thrift client name in interop

### DIFF
--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -67,6 +67,9 @@ type IsThrift interface {
 	isThrift()
 }
 
+// ClientTraceMiddlewareArgs is the arguments used to instantiate client tracing middleware
+//
+// This struct is exported so that it can be used by baseplate V2 interop utilities.
 type ClientTraceMiddlewareArgs struct {
 	ServiceName string
 }
@@ -113,13 +116,13 @@ func V2TracingThriftClientMiddleware() thrift.ClientMiddleware {
 	return v2Tracing.thriftClientMiddlewareProvider(ClientTraceMiddlewareArgs{ServiceName: "unknown"})
 }
 
-func V2TracingThriftClientMiddlewareWithName(serviceName string) thrift.ClientMiddleware {
+func V2TracingThriftClientMiddlewareWithArgs(args ClientTraceMiddlewareArgs) thrift.ClientMiddleware {
 	v2Tracing.Lock()
 	defer v2Tracing.Unlock()
 	if v2Tracing.thriftClientMiddlewareProvider == nil {
 		return nil
 	}
-	return v2Tracing.thriftClientMiddlewareProvider(ClientTraceMiddlewareArgs{ServiceName: serviceName})
+	return v2Tracing.thriftClientMiddlewareProvider(args)
 }
 
 func SetV2TracingThriftServerMiddleware(middleware thrift.ProcessorMiddleware) {

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -67,12 +67,18 @@ type IsThrift interface {
 	isThrift()
 }
 
+type ClientTraceMiddlewareArgs struct {
+	ServiceName string
+}
+
+type ThriftClientTraceMiddlewareProvider func(args ClientTraceMiddlewareArgs) thrift.ClientMiddleware
+
 var v2Tracing struct {
 	sync.Mutex
 	enabled bool
 
-	thriftClientMiddleware thrift.ClientMiddleware
-	thriftServerMiddleware thrift.ProcessorMiddleware
+	thriftClientMiddlewareProvider ThriftClientTraceMiddlewareProvider
+	thriftServerMiddleware         thrift.ProcessorMiddleware
 
 	httpClientMiddleware func(base http.RoundTripper) http.RoundTripper
 	httpServerMiddleware func(name string, next http.Handler) http.Handler
@@ -93,13 +99,27 @@ func V2TracingEnabled() bool {
 func SetV2TracingThriftClientMiddleware(middleware thrift.ClientMiddleware) {
 	v2Tracing.Lock()
 	defer v2Tracing.Unlock()
-	v2Tracing.thriftClientMiddleware = middleware
+	v2Tracing.thriftClientMiddlewareProvider = func(args ClientTraceMiddlewareArgs) thrift.ClientMiddleware {
+		return middleware
+	}
 }
 
 func V2TracingThriftClientMiddleware() thrift.ClientMiddleware {
 	v2Tracing.Lock()
 	defer v2Tracing.Unlock()
-	return v2Tracing.thriftClientMiddleware
+	if v2Tracing.thriftClientMiddlewareProvider != nil {
+		return nil
+	}
+	return v2Tracing.thriftClientMiddlewareProvider(ClientTraceMiddlewareArgs{ServiceName: "unknown"})
+}
+
+func V2TracingThriftClientMiddlewareWithName(serviceName string) thrift.ClientMiddleware {
+	v2Tracing.Lock()
+	defer v2Tracing.Unlock()
+	if v2Tracing.thriftClientMiddlewareProvider == nil {
+		return nil
+	}
+	return v2Tracing.thriftClientMiddlewareProvider(ClientTraceMiddlewareArgs{ServiceName: serviceName})
 }
 
 func SetV2TracingThriftServerMiddleware(middleware thrift.ProcessorMiddleware) {

--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -107,7 +107,7 @@ func SetV2TracingThriftClientMiddleware(middleware thrift.ClientMiddleware) {
 func V2TracingThriftClientMiddleware() thrift.ClientMiddleware {
 	v2Tracing.Lock()
 	defer v2Tracing.Unlock()
-	if v2Tracing.thriftClientMiddlewareProvider != nil {
+	if v2Tracing.thriftClientMiddlewareProvider == nil {
 		return nil
 	}
 	return v2Tracing.thriftClientMiddlewareProvider(ClientTraceMiddlewareArgs{ServiceName: "unknown"})

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -152,7 +152,7 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 		ForwardEdgeRequestContext(args.EdgeContextImpl),
 		SetClientName(args.ClientName),
 		MonitorClient(MonitorClientArgs{
-			ServiceSlug:         args.ServiceSlug + MonitorClientWrappedSlugSuffix,
+			ServiceSlug:         args.ServiceSlug,
 			ErrorSpanSuppressor: args.ErrorSpanSuppressor,
 		}),
 		PrometheusClientMiddleware(args.ServiceSlug + MonitorClientWrappedSlugSuffix),
@@ -211,7 +211,7 @@ var monitorClientLoggingOnce sync.Once
 // This middleware always use the injected v2 tracing thrift client middleware.
 // If there's no v2 tracing thrift client middleware injected, it's no-op.
 func MonitorClient(args MonitorClientArgs) thrift.ClientMiddleware {
-	if mw := internalv2compat.V2TracingThriftClientMiddleware(); mw != nil {
+	if mw := internalv2compat.V2TracingThriftClientMiddlewareWithName(args.ServiceSlug); mw != nil {
 		return mw
 	}
 	return func(next thrift.TClient) thrift.TClient {

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -211,7 +211,9 @@ var monitorClientLoggingOnce sync.Once
 // This middleware always use the injected v2 tracing thrift client middleware.
 // If there's no v2 tracing thrift client middleware injected, it's no-op.
 func MonitorClient(args MonitorClientArgs) thrift.ClientMiddleware {
-	if mw := internalv2compat.V2TracingThriftClientMiddlewareWithName(args.ServiceSlug); mw != nil {
+	if mw := internalv2compat.V2TracingThriftClientMiddlewareWithArgs(
+		internalv2compat.ClientTraceMiddlewareArgs{ServiceName: args.ServiceSlug},
+	); mw != nil {
 		return mw
 	}
 	return func(next thrift.TClient) thrift.TClient {


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

Services transitioning to baseplate v2 have the service name missing from client traces. Right now its defaulting to `unknown` due to the interop library initializing a global tracer. This is the first change needed to resolve this bug. It is backwards compatible and allows us to rollout the fix gracefully.

More details in internal obs thread.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
