### PR TITLE
Update for go 1.24

### DIFF
--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
+          - "1.24"
 
     container:
       image: golang:${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/reddit/baseplate.go
 
-go 1.22.0
+go 1.23
 
 require (
 	github.com/Shopify/sarama v1.29.1

--- a/internal/admin/server_test.go
+++ b/internal/admin/server_test.go
@@ -57,7 +57,6 @@ var expectedMetrics = []string{
 	"go_godebug_non_default_behavior_randautoseed_events_total",
 	"go_godebug_non_default_behavior_tarinsecurepath_events_total",
 	"go_godebug_non_default_behavior_tlsmaxrsasize_events_total",
-	"go_godebug_non_default_behavior_x509sha1_events_total",
 	"go_godebug_non_default_behavior_x509usefallbackroots_events_total",
 	"go_godebug_non_default_behavior_zipinsecurepath_events_total",
 	"go_goroutines",


### PR DESCRIPTION
- Update go.mod to require 1.23+
- Update CI to run on go 1.23 & 1.24
