### PR TITLE
remove the thrift headerbp client middleware from defaults

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -175,7 +175,6 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 		BaseplateErrorWrapper,
 		thrift.ExtractIDLExceptionClientMiddleware,
 		SetDeadlineBudget,
-		ClientBaseplateHeadersMiddleware(args.ServiceSlug, args.ClientName),
 		clientFaultMiddleware.Middleware(), // clientFaultMiddleware MUST be last
 	)
 	return middlewares

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -34,16 +34,15 @@ func initClients(ecImpl ecinterface.Interface) (*thrifttest.MockClient, *thriftt
 	}
 	mock := &thrifttest.MockClient{FailUnregisteredMethods: true}
 	recorder := thrifttest.NewRecordedClient(mock)
-	client := thrift.WrapClient(
-		recorder,
-		thriftbp.BaseplateDefaultClientMiddlewares(
-			thriftbp.DefaultClientMiddlewareArgs{
-				EdgeContextImpl: ecImpl,
-				ServiceSlug:     service,
-				Address:         address,
-			},
-		)...,
-	)
+	middlewares := []thrift.ClientMiddleware{thriftbp.ClientBaseplateHeadersMiddleware(service, "")}
+	middlewares = append(middlewares, thriftbp.BaseplateDefaultClientMiddlewares(
+		thriftbp.DefaultClientMiddlewareArgs{
+			EdgeContextImpl: ecImpl,
+			ServiceSlug:     service,
+			Address:         address,
+		},
+	)...)
+	client := thrift.WrapClient(recorder, middlewares...)
 	return mock, recorder, client
 }
 

--- a/thriftbp/server_test.go
+++ b/thriftbp/server_test.go
@@ -75,6 +75,9 @@ func TestHeaderPropagation(t *testing.T) {
 		Processor:       downstreamProcessor,
 		SecretStore:     store,
 		EdgeContextImpl: ecImpl,
+		ClientMiddlewares: []thrift.ClientMiddleware{
+			thriftbp.ClientBaseplateHeadersMiddleware("", ""),
+		},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## 💸 TL;DR
There seems to be something wrong with this where it's picking up headers that are being forwarded as ones that are being manually set by the caller.
