### PR TITLE
Make headerbp client middleware safer

### DIFF
--- a/headerbp/headerbp.go
+++ b/headerbp/headerbp.go
@@ -362,11 +362,11 @@ func WithHeaderSetter(setter func(key, value string)) SetOutgoingHeadersOption {
 
 type setOutgoingIdempotencyKey struct{}
 
+// HasSetOutgoingHeaders returns true if the baseplate headers have already been set by the caller.
 func HasSetOutgoingHeaders(ctx context.Context, options ...HasSetOutgoingHeadersOption) bool {
 	cfg := &hasSetOutgoingHeaders{}
 	WithHasSetOutgoingHeadersOptions(options...).ApplyToHasSetOutgoingHeaders(cfg)
-	hasSet, ok := ctx.Value(setOutgoingIdempotencyKey{}).(bool)
-	hasSet = hasSet && ok
+	hasSet, _ := ctx.Value(setOutgoingIdempotencyKey{}).(bool)
 	if hasSet {
 		clientMiddlewareIdempotencyCheckTotal.WithLabelValues(
 			cfg.RPCType,

--- a/headerbp/headerbp.go
+++ b/headerbp/headerbp.go
@@ -371,6 +371,7 @@ func HasSetOutgoingHeaders(ctx context.Context, options ...HasSetOutgoingHeaders
 		clientMiddlewareIdempotencyCheckTotal.WithLabelValues(
 			cfg.RPCType,
 			cfg.Client,
+			"headerbp",
 		).Inc()
 		slog.ErrorContext(
 			ctx, "headerbp client middleware has beet triggered twice",

--- a/headerbp/metrics.go
+++ b/headerbp/metrics.go
@@ -23,6 +23,7 @@ var (
 	}, []string{
 		rpcTypeLabel,
 		clientNameLabel,
+		"middleware",
 	})
 
 	clientHeadersRejectedTotal = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{

--- a/headerbp/metrics.go
+++ b/headerbp/metrics.go
@@ -17,6 +17,14 @@ const (
 )
 
 var (
+	clientMiddlewareIdempotencyCheckTotal = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
+		Name: "baseplate_client_middleware_idempotency_check_total",
+		Help: "Total number of times that the middleware detected that it was already called for the same request",
+	}, []string{
+		rpcTypeLabel,
+		clientNameLabel,
+	})
+
 	clientHeadersRejectedTotal = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
 		Name: "baseplate_client_rejected_headers_total",
 		Help: "Total number of requests that were rejected by a client due to unapproved internal headers",

--- a/headerbp/metrics.go
+++ b/headerbp/metrics.go
@@ -18,7 +18,7 @@ const (
 
 var (
 	clientMiddlewareIdempotencyCheckTotal = promauto.With(prometheusbpint.GlobalRegistry).NewCounterVec(prometheus.CounterOpts{
-		Name: "baseplate_client_middleware_idempotency_check_total",
+		Name: "baseplate_client_middleware_idempotency_check_failures_total",
 		Help: "Total number of times that the middleware detected that it was already called for the same request",
 	}, []string{
 		rpcTypeLabel,

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -388,7 +388,7 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			ctx := req.Context()
 
-			if headerbp.HasSetOutgoingHeaders(ctx) {
+			if headerbp.HasSetOutgoingHeaders(ctx, headerbp.WithHTTPClient("", client, "")) {
 				return next.RoundTrip(req)
 			}
 

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -386,6 +386,11 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 
 	return func(next http.RoundTripper) http.RoundTripper {
 		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if headerbp.HasSetOutgoingHeaders(req.Context()) {
+				return next.RoundTrip(req)
+			}
+
+			ctx := req.Context()
 			signingSecret := getSigningSecret()
 			if signingSecret == nil {
 				return nil, fmt.Errorf("signing secret is required to set use baseplate headers")
@@ -399,10 +404,10 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 				}
 			}
 
-			signature, hasSignature := headerbp.HeaderSignatureFromContext(req.Context())
+			signature, hasSignature := headerbp.HeaderSignatureFromContext(ctx)
 			var baseplateHeaders []string
-			headerbp.SetOutgoingHeaders(
-				req.Context(),
+			ctx = headerbp.SetOutgoingHeaders(
+				ctx,
 				headerbp.WithHTTPClient("", client, ""),
 				headerbp.WithHeaderSetter(func(key, value string) {
 					if !hasSignature {
@@ -414,7 +419,7 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 			// the !hasSignature check is redundant since we do not add to the baseplateHeaders list unless it is false, but
 			// it's here to make it clear that we only need to update the signature if there is no signature in the context
 			if len(baseplateHeaders) > 0 && !hasSignature {
-				if _signature, err := headerbp.SignHeaders(req.Context(), *signingSecret, baseplateHeaders, req.Header.Get); err != nil {
+				if _signature, err := headerbp.SignHeaders(ctx, *signingSecret, baseplateHeaders, req.Header.Get); err != nil {
 					return nil, fmt.Errorf("signing baseplate headers: %w", err)
 				} else {
 					signature = _signature
@@ -423,6 +428,7 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 			if signature != "" {
 				req.Header.Set(headerbp.SignatureHeaderCanonicalHTTP, signature)
 			}
+			req = req.WithContext(ctx)
 			return next.RoundTrip(req)
 		})
 	}

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -397,10 +397,10 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 			}
 
 			for k := range req.Header {
-				if err := headerbp.CheckClientHeader(k,
+				if headerbp.ShouldRemoveClientHeader(k,
 					headerbp.WithHTTPClient("", client, ""),
-				); err != nil {
-					return nil, err
+				) {
+					req.Header.Del(k)
 				}
 			}
 

--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -386,11 +386,12 @@ func ClientBaseplateHeadersMiddleware(client string, store SecretsStore, path st
 
 	return func(next http.RoundTripper) http.RoundTripper {
 		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if headerbp.HasSetOutgoingHeaders(req.Context()) {
+			ctx := req.Context()
+
+			if headerbp.HasSetOutgoingHeaders(ctx) {
 				return next.RoundTrip(req)
 			}
 
-			ctx := req.Context()
 			signingSecret := getSigningSecret()
 			if signingSecret == nil {
 				return nil, fmt.Errorf("signing secret is required to set use baseplate headers")

--- a/httpbp/server_test.go
+++ b/httpbp/server_test.go
@@ -553,7 +553,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 					if resp.StatusCode != http.StatusOK {
 						t.Fatalf("unexpected status code: %d", resp.StatusCode)
 					}
-					
+
 					return nil
 				},
 			},

--- a/httpbp/server_test.go
+++ b/httpbp/server_test.go
@@ -544,6 +544,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 					if err != nil {
 						t.Fatalf("creating request: %v", err)
 					}
+					req.Header.Set("x-bp-test", "bar")
 
 					resp, err := downstreamClient.Do(req)
 					if err != nil {
@@ -552,21 +553,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 					if resp.StatusCode != http.StatusOK {
 						t.Fatalf("unexpected status code: %d", resp.StatusCode)
 					}
-
-					invalidReq, err := http.NewRequestWithContext(
-						ctx,
-						http.MethodGet,
-						downstreamBaseURL.JoinPath("say-hello").String(),
-						nil,
-					)
-					if err != nil {
-						t.Fatalf("creating request: %v", err)
-					}
-					invalidReq.Header.Set("x-bp-test", "bar")
-
-					if _, err := downstreamClient.Do(req); !errors.Is(err, headerbp.ErrNewInternalHeaderNotAllowed) {
-						t.Fatalf("error mismatch, want %v, got %v", headerbp.ErrNewInternalHeaderNotAllowed, err)
-					}
+					
 					return nil
 				},
 			},

--- a/httpbp/server_test.go
+++ b/httpbp/server_test.go
@@ -453,7 +453,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 	t.Cleanup(func() {
 		store.Close()
 	})
-	bp := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
+	downstreamBP := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
 		Config: baseplate.Config{
 			Addr: ":8081",
 		},
@@ -461,7 +461,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 		EdgeContextImpl: ecinterface.Mock(),
 	})
 	downstreamServer, err := httpbp.NewBaseplateServer(httpbp.ServerArgs{
-		Baseplate: bp,
+		Baseplate: downstreamBP,
 		Endpoints: map[httpbp.Pattern]httpbp.Endpoint{
 			"/say-hello": {
 				Name:    "say-hello",
@@ -504,14 +504,22 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 			SecretsStore:           store,
 			HeaderbpSigningKeyPath: "secret/baseplate/headerbp/signature-key",
 		},
-		withBaseURL(downstreamBaseURL),
+		// This is to test that the client middleware is idempotent
+		httpbp.ClientBaseplateHeadersMiddleware("downstream", store, "secret/baseplate/headerbp/signature-key"),
 	)
 	if err != nil {
 		t.Fatalf("failed to create test client: %v", err)
 	}
 
+	originBP := baseplate.NewTestBaseplate(baseplate.NewTestBaseplateArgs{
+		Config: baseplate.Config{
+			Addr: ":8082",
+		},
+		Store:           store,
+		EdgeContextImpl: ecinterface.Mock(),
+	})
 	originServer, err := httpbp.NewBaseplateServer(httpbp.ServerArgs{
-		Baseplate: bp,
+		Baseplate: originBP,
 		Endpoints: map[httpbp.Pattern]httpbp.Endpoint{
 			"/say-hello": {
 				Name:    "say-hello",
@@ -527,7 +535,8 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 						}
 					}
 
-					req, err := http.NewRequest(
+					req, err := http.NewRequestWithContext(
+						ctx,
 						http.MethodGet,
 						downstreamBaseURL.JoinPath("say-hello").String(),
 						nil,
@@ -544,7 +553,8 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 						t.Fatalf("unexpected status code: %d", resp.StatusCode)
 					}
 
-					invalidReq, err := http.NewRequest(
+					invalidReq, err := http.NewRequestWithContext(
+						ctx,
 						http.MethodGet,
 						downstreamBaseURL.JoinPath("say-hello").String(),
 						nil,
@@ -583,7 +593,6 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 		httpbp.ClientConfig{
 			Slug: "downstreamHTTPBPV0",
 		},
-		withBaseURL(baseURL),
 	)
 	if err != nil {
 		t.Fatalf("failed to create test client: %v", err)
@@ -591,7 +600,7 @@ func TestBaseplateHeaderPropagation(t *testing.T) {
 
 	req, err := http.NewRequest(
 		http.MethodGet,
-		baseURL.JoinPath("say-hello").String(),
+		baseURL.JoinPath("/say-hello").String(),
 		nil,
 	)
 	if err != nil {

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
@@ -427,13 +428,11 @@ func ClientBaseplateHeadersMiddleware(service, client string) thrift.ClientMiddl
 				}
 
 				outgoing := thrift.GetWriteHeaderList(ctx)
-				for _, k := range outgoing {
-					if err := headerbp.CheckClientHeader(k,
+				outgoing = slices.DeleteFunc(outgoing, func(name string) bool {
+					return headerbp.ShouldRemoveClientHeader(name,
 						headerbp.WithThriftClient(service, client, method),
-					); err != nil {
-						return thrift.ResponseMeta{}, err
-					}
-				}
+					)
+				})
 
 				var toAdd map[string]string
 				ctx = headerbp.SetOutgoingHeaders(

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -175,6 +175,7 @@ func BaseplateDefaultClientMiddlewares(args DefaultClientMiddlewareArgs) []thrif
 		BaseplateErrorWrapper,
 		thrift.ExtractIDLExceptionClientMiddleware,
 		SetDeadlineBudget,
+		ClientBaseplateHeadersMiddleware(args.ServiceSlug, args.ClientName),
 		clientFaultMiddleware.Middleware(), // clientFaultMiddleware MUST be last
 	)
 	return middlewares

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -423,15 +423,13 @@ func ClientBaseplateHeadersMiddleware(service, client string) thrift.ClientMiddl
 	return func(next thrift.TClient) thrift.TClient {
 		return thrift.WrappedTClient{
 			Wrapped: func(ctx context.Context, method string, args, result thrift.TStruct) (thrift.ResponseMeta, error) {
-				if headerbp.HasSetOutgoingHeaders(ctx) {
+				if headerbp.HasSetOutgoingHeaders(ctx, headerbp.WithThriftClient(service, client, method)) {
 					return next.Call(ctx, method, args, result)
 				}
 
 				outgoing := thrift.GetWriteHeaderList(ctx)
 				outgoing = slices.DeleteFunc(outgoing, func(name string) bool {
-					return headerbp.ShouldRemoveClientHeader(name,
-						headerbp.WithThriftClient(service, client, method),
-					)
+					return headerbp.ShouldRemoveClientHeader(name, headerbp.WithThriftClient(service, client, method))
 				})
 
 				var toAdd map[string]string

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -34,15 +34,16 @@ func initClients(ecImpl ecinterface.Interface) (*thrifttest.MockClient, *thriftt
 	}
 	mock := &thrifttest.MockClient{FailUnregisteredMethods: true}
 	recorder := thrifttest.NewRecordedClient(mock)
-	middlewares := []thrift.ClientMiddleware{thriftbp.ClientBaseplateHeadersMiddleware(service, "")}
-	middlewares = append(middlewares, thriftbp.BaseplateDefaultClientMiddlewares(
-		thriftbp.DefaultClientMiddlewareArgs{
-			EdgeContextImpl: ecImpl,
-			ServiceSlug:     service,
-			Address:         address,
-		},
-	)...)
-	client := thrift.WrapClient(recorder, middlewares...)
+	client := thrift.WrapClient(
+		recorder,
+		thriftbp.BaseplateDefaultClientMiddlewares(
+			thriftbp.DefaultClientMiddlewareArgs{
+				EdgeContextImpl: ecImpl,
+				ServiceSlug:     service,
+				Address:         address,
+			},
+		)...,
+	)
 	return mock, recorder, client
 }
 

--- a/thriftbp/server_test.go
+++ b/thriftbp/server_test.go
@@ -57,12 +57,6 @@ func (s *headerPropagationVerificationService) IsHealthy(ctx context.Context, _ 
 	return true, nil
 }
 
-type echoService struct{}
-
-func (s *echoService) IsHealthy(ctx context.Context, req *baseplatethrift.IsHealthyRequest) (bool, error) {
-	return true, nil
-}
-
 func TestHeaderPropagation(t *testing.T) {
 	store := newSecretsStore(t)
 

--- a/thriftbp/server_test.go
+++ b/thriftbp/server_test.go
@@ -75,9 +75,6 @@ func TestHeaderPropagation(t *testing.T) {
 		Processor:       downstreamProcessor,
 		SecretStore:     store,
 		EdgeContextImpl: ecImpl,
-		ClientMiddlewares: []thrift.ClientMiddleware{
-			thriftbp.ClientBaseplateHeadersMiddleware("", ""),
-		},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
After some investigation, we figured out that the cause of the error we encountered was due to the service wiring up the default client middleware manually and using the `NewBaseplateThriftPool` constructor, resulting in the default middleware running twice. This means that on the first pass, the middleware would add the header to the request. The second pass would then see this and fail the request. I made two changes to make this safer:

1. Added an idempotency check to the client middleware so it only runs once per call. Add an error log and a metric when we detect this happening.
2. Changed the client middlewares to instead drop new baseplate headers and log an error message rather than failing the call.
