### PR TITLE
always update thrift header write list in headerbp client middleware

### DIFF
--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -449,8 +449,8 @@ func ClientBaseplateHeadersMiddleware(service, client string) thrift.ClientMiddl
 					for k, v := range toAdd {
 						ctx = thrift.SetHeader(ctx, k, v)
 					}
-					ctx = thrift.SetWriteHeaderList(ctx, outgoing)
 				}
+				ctx = thrift.SetWriteHeaderList(ctx, outgoing)
 				return next.Call(ctx, method, args, result)
 			},
 		}


### PR DESCRIPTION
## 💸 TL;DR

This is really just to make the code cleaner since it _technically_ works because `thrift.GetWriteHeaderList` returns the underlying list, not a copy, and `slices.Delete` deletes from the source slice. I think the code is a lot clearer and less likely to have a bug later if we always set the outgoing header list.

I verified this by adding a test case. The test passes without my changes, but it fails if I copy `outgoing` before deleting the headers from it.
