### PR TITLE
add support for thrift service name in server traces

### DIFF
--- a/internalv2compat/compat.go
+++ b/internalv2compat/compat.go
@@ -86,8 +86,9 @@ var v2Tracing struct {
 	sync.Mutex
 	enabled bool
 
-	thriftClientMiddlewareProvider ThriftClientTraceMiddlewareProvider
-	thriftServerMiddlewareProvider ThriftServerTraceMiddlewareProvider
+	thriftClientMiddlewareProvider    ThriftClientTraceMiddlewareProvider
+	thriftServerMiddlewareProvider    ThriftServerTraceMiddlewareProvider
+	thriftMethodDescriptorMiddlewares V2ThriftMethodDescriptorMiddlewares
 
 	httpClientMiddleware func(base http.RoundTripper) http.RoundTripper
 	httpServerMiddleware func(name string, next http.Handler) http.Handler
@@ -191,4 +192,21 @@ func V2TracingHTTPServerMiddleware() func(name string, next http.Handler) http.H
 	v2Tracing.Lock()
 	defer v2Tracing.Unlock()
 	return v2Tracing.httpServerMiddleware
+}
+
+type V2ThriftMethodDescriptorMiddlewares struct {
+	ServerMiddlewareProvider func(serviceName string) thrift.ProcessorMiddleware
+	ClientMiddleware         thrift.ClientMiddleware
+}
+
+func SetV2ThriftMethodDescriptorMiddlewares(middleware V2ThriftMethodDescriptorMiddlewares) {
+	v2Tracing.Lock()
+	defer v2Tracing.Unlock()
+	v2Tracing.thriftMethodDescriptorMiddlewares = middleware
+}
+
+func GetV2ThriftMethodDescriptorMiddlewares() V2ThriftMethodDescriptorMiddlewares {
+	v2Tracing.Lock()
+	defer v2Tracing.Unlock()
+	return v2Tracing.thriftMethodDescriptorMiddlewares
 }

--- a/thriftbp/server.go
+++ b/thriftbp/server.go
@@ -3,7 +3,7 @@ package thriftbp
 import (
 	"context"
 	"fmt"
-	"path/filepath"
+	"path"
 	"reflect"
 	"strings"
 	"time"
@@ -207,7 +207,7 @@ func GetThriftServiceName(processor thrift.TProcessor) string {
 	}
 
 	return fmt.Sprintf("%s.%s",
-		filepath.Base(value.PkgPath()),
+		path.Base(value.PkgPath()),
 		strings.TrimSuffix(value.Name(), "Processor"),
 	)
 }

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -169,7 +169,7 @@ func InjectServerSpanWithArgs(args MonitorServerArgs) thrift.ProcessorMiddleware
 	return func(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 		// no-op but log for once
 		injectServerSpanLoggingOnce.Do(func() {
-			slog.Warn("thriftbp.InjectServerSpan: internalv2compat.V2TracingThriftServerMiddleware() returned nil")
+			slog.Warn("thriftbp.InjectServerSpan: internalv2compat.V2TracingThriftServerMiddlewareWithArgs() returned nil")
 		})
 		return next
 	}

--- a/thriftbp/server_test.go
+++ b/thriftbp/server_test.go
@@ -57,6 +57,26 @@ func (s *headerPropagationVerificationService) IsHealthy(ctx context.Context, _ 
 	return true, nil
 }
 
+type echoService struct{}
+
+func (s *echoService) IsHealthy(ctx context.Context, req *baseplatethrift.IsHealthyRequest) (bool, error) {
+	return true, nil
+}
+
+func TestGetServiceName(t *testing.T) {
+	downstreamProcessor := baseplatethrift.NewBaseplateServiceV2Processor(&echoService{})
+	cfg := &thriftbp.ServerConfig{Processor: downstreamProcessor}
+	actualName := thriftbp.GetThriftServiceName(cfg.Processor)
+	if got, want := actualName, "baseplate.BaseplateServiceV2"; got != want {
+		t.Errorf("got = %v, want %v", got, want)
+	}
+
+	actualName = thriftbp.GetThriftServiceName(nil)
+	if got, want := actualName, "unknown"; got != want {
+		t.Errorf("got = %v, want %v", got, want)
+	}
+}
+
 func TestHeaderPropagation(t *testing.T) {
 	store := newSecretsStore(t)
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

Right now server trace spans for thrift report the service name as unknown. Because the thrift compiler doesn't generate schema metadata, we can fallback to relying on compiler conventions to source the service name defined in the schema.

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
