### PR TITLE
omitempty for tags that marshal into zero val but should be nil

### DIFF
--- a/httpbp/config.go
+++ b/httpbp/config.go
@@ -15,7 +15,7 @@ type ClientConfig struct {
 	MaxErrorReadAhead int               `yaml:"limitErrorReading"`
 	MaxConnections    int               `yaml:"maxConnections"`
 	CircuitBreaker    *breakerbp.Config `yaml:"circuitBreaker"`
-	RetryOptions      []retry.Option
+	RetryOptions      []retry.Option    `yaml:"-"`
 
 	SecretsStore           SecretsStore
 	HeaderbpSigningKeyPath string

--- a/log/sentry.go
+++ b/log/sentry.go
@@ -45,7 +45,7 @@ type SentryConfig struct {
 	// List of regexp strings that will be used to match against event's message
 	// and if applicable, caught errors type and value.
 	// If the match is found, then a whole event will be dropped.
-	IgnoreErrors []string `yaml:"ignoreErrors"`
+	IgnoreErrors []string `yaml:"ignoreErrors,omitempty"`
 
 	// FlushTimeout is the timeout to be used to call sentry.Flush when closing
 	// the Closer returned by InitSentry.

--- a/metricsbp/config.go
+++ b/metricsbp/config.go
@@ -20,7 +20,7 @@ type Config struct {
 	Endpoint string `yaml:"endpoint"`
 
 	// Tags are the base tags that will be applied to all metrics.
-	Tags Tags `yaml:"tags"`
+	Tags Tags `yaml:"tags,omitempty"`
 
 	// HistogramSampleRate is the fraction of histograms (including timings) that
 	// you want to send to your metrics  backend.

--- a/thriftbp/client_pool.go
+++ b/thriftbp/client_pool.go
@@ -162,7 +162,7 @@ type ClientPoolConfig struct {
 	// This includes the optional pool stats.
 	//
 	// Deprecated: We no longer emit any statsd metrics so this has no effect.
-	MetricsTags metricsbp.Tags `yaml:"metricsTags"`
+	MetricsTags metricsbp.Tags `yaml:"metricsTags,omitempty"`
 
 	// DefaultRetryOptions is the list of retry.Options to apply as the defaults
 	// for the Retry middleware.


### PR DESCRIPTION
## 💸 TL;DR
By default, if we marshal a map or slice from nil into yaml, then back into the map/slice, the value will not be the same!
Without omitempty, we marshal nil into the emptyval, then emptyval as is back into the struct. It is not a known guarantee for users that nil == empty.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
