### PR TITLE
Add a prometheus metric for logging latency

### DIFF
--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -16,7 +16,20 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "baseplate_log_latency_seconds",
 			Help:    "Latency of log calls",
-			Buckets: []float64{0.000005, 0.00001, 0.00005, 0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0},
+			Buckets: []float64{
+				0.000_005,
+				0.000_010,
+				0.000_050,
+				0.000_100,
+				0.000_500,
+				0.001,
+				0.005,
+				0.01,
+				0.05,
+				0.1,
+				0.5,
+				1.0,
+			},
 		},
 	)
 )

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	logLatencySeconds = promauto.NewHistogram(
+	logLatencySeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "baseplate_log_latency_seconds",
 			Help:    "Latency of log calls",

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -43,10 +43,10 @@ func (w wrappedCore) With(fields []zapcore.Field) zapcore.Core {
 }
 
 func (w wrappedCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
-	start := time.Now()
-	err := w.Core.Write(entry, wrapFields(fields))
-	logLatencySeconds.Observe(time.Since(start).Seconds())
-	return err
+	defer func(start time.Time) {
+		logLatencySeconds.Observe(time.Since(start).Seconds())
+	}(time.Now())
+	return w.Core.Write(entry, wrapFields(fields))
 }
 
 func (w wrappedCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/reddit/baseplate.go/internal/prometheusbpint"
 	"github.com/reddit/baseplate.go/internal/thriftint"
 )
 


### PR DESCRIPTION
Sample latencies while testing locally with a skeleton baseplate app:

```
# HELP baseplate_log_latency_seconds Latency of log calls
# TYPE baseplate_log_latency_seconds histogram
baseplate_log_latency_seconds_bucket{le="5e-06"} 1287
baseplate_log_latency_seconds_bucket{le="1e-05"} 1513
baseplate_log_latency_seconds_bucket{le="5e-05"} 1531
baseplate_log_latency_seconds_bucket{le="0.0001"} 1534
baseplate_log_latency_seconds_bucket{le="0.0005"} 1535
baseplate_log_latency_seconds_bucket{le="0.001"} 1535
baseplate_log_latency_seconds_bucket{le="0.005"} 1535
baseplate_log_latency_seconds_bucket{le="0.01"} 1535
baseplate_log_latency_seconds_bucket{le="0.05"} 1535
baseplate_log_latency_seconds_bucket{le="0.1"} 1535
baseplate_log_latency_seconds_bucket{le="0.5"} 1535
baseplate_log_latency_seconds_bucket{le="1"} 1535
baseplate_log_latency_seconds_bucket{le="+Inf"} 1538
baseplate_log_latency_seconds_sum 5.996288247000006
baseplate_log_latency_seconds_count 1538
```

Latency buckets loosely based on the [spec](https://github.snooguts.net/reddit/baseplate.spec/blob/master/component-apis/prom-metrics.md#latency-histograms) but had to add a few buckets for low latencies and trim some slower buckets to avoid having too many.