### PR TITLE
Rename baseplate_log_latency_seconds to baseplate_log_write_duration_seconds

### DIFF
--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	loggerWriteDurationSeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
+	logWriteDurationSeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "baseplate_logger_write_duration_seconds",
+			Name:    "baseplate_log_write_duration_seconds",
 			Help:    "Latency of log calls",
 			Buckets: []float64{
 				0.000_005,
@@ -45,7 +45,7 @@ func (w wrappedCore) With(fields []zapcore.Field) zapcore.Core {
 
 func (w wrappedCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	defer func(start time.Time) {
-		loggerWriteDurationSeconds.Observe(time.Since(start).Seconds())
+		logWriteDurationSeconds.Observe(time.Since(start).Seconds())
 	}(time.Now())
 	return w.Core.Write(entry, wrapFields(fields))
 }

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -13,9 +13,9 @@ import (
 )
 
 var (
-	logLatencySeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
+	loggerWriteDurationSeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "baseplate_log_latency_seconds",
+			Name:    "baseplate_logger_write_duration_seconds",
 			Help:    "Latency of log calls",
 			Buckets: []float64{
 				0.000_005,
@@ -45,7 +45,7 @@ func (w wrappedCore) With(fields []zapcore.Field) zapcore.Core {
 
 func (w wrappedCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
 	defer func(start time.Time) {
-		logLatencySeconds.Observe(time.Since(start).Seconds())
+		loggerWriteDurationSeconds.Observe(time.Since(start).Seconds())
 	}(time.Now())
 	return w.Core.Write(entry, wrapFields(fields))
 }

--- a/log/core_wrapper.go
+++ b/log/core_wrapper.go
@@ -16,7 +16,7 @@ var (
 	logWriteDurationSeconds = promauto.With(prometheusbpint.GlobalRegistry).NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "baseplate_log_write_duration_seconds",
-			Help:    "Latency of log calls",
+			Help:    "Latency of log writes",
 			Buckets: []float64{
 				0.000_005,
 				0.000_010,


### PR DESCRIPTION
The new name makes it clear that this captures the duration of local logging calls as opposed to end-to-end logging latency to a centralized collector.
