### PR TITLE
Upgrade fsnotify and install a workaround for fsnotify/v2

### DIFF
--- a/filewatcher/v2/filewatcher.go
+++ b/filewatcher/v2/filewatcher.go
@@ -143,6 +143,7 @@ func (r *Result[T]) watcherLoop(
 		}
 		// then read all new files to watch
 		for _, path := range files {
+			// Evaluate any symlinks before adding to work around https://github.com/fsnotify/fsnotify/issues/652
 			real, err := filepath.EvalSymlinks(path)
 			if err != nil {
 				slog.ErrorContext(r.ctx, "filewatcher: failed to evaluate symlinks, using original name", "err", err, "path", path)
@@ -419,6 +420,7 @@ func New[T any](ctx context.Context, path string, parser Parser[T], options ...O
 		return nil, err
 	}
 	for _, path := range files {
+		// Evaluate any symlinks before adding to work around https://github.com/fsnotify/fsnotify/issues/652
 		real, err := filepath.EvalSymlinks(path)
 		if err != nil {
 			slog.ErrorContext(ctx, "filewatcher: failed to evaluate symlinks; using original name", "err", err, "path", path)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.14.3
 	github.com/apache/thrift v0.21.0
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/fsnotify/fsnotify v1.5.4
+	github.com/fsnotify/fsnotify v1.8.0
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/go-kit/kit v0.9.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/garyburd/redigo v1.6.2 h1:yE/pwKCrbLpLpQICzYTeZ7JsTA/C53wFTJHaEtRqniM=
 github.com/garyburd/redigo v1.6.2/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
-github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/garyburd/redigo v1.6.2 h1:yE/pwKCrbLpLpQICzYTeZ7JsTA/C53wFTJHaEtRqniM=
@@ -384,7 +382,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/secrets/store_internal_test.go
+++ b/secrets/store_internal_test.go
@@ -171,6 +171,58 @@ func TestDirRotation(t *testing.T) {
 			t.Errorf("Got secret %+v, want %+v", secret, wantSecret)
 		}
 	})
+
+	t.Run("rotate_back", func(t *testing.T) {
+		const (
+			correctKey = key1
+			wrongKey   = key2
+		)
+		if err := writer.Write(map[string]fileutil.FileProjection{
+			correctKey: content,
+		}); err != nil {
+			t.Fatalf("Failed to write initial payload: %v", err)
+		}
+		time.Sleep(sleep)
+
+		_, err := store.GetSimpleSecret(wrongKey)
+		if err == nil {
+			t.Errorf("Expected error when getting %q, got nil", wrongKey)
+		}
+
+		secret, err := store.GetSimpleSecret(correctKey)
+		if err != nil {
+			t.Fatalf("Expected no error when getting %q, got %v", correctKey, err)
+		}
+		if !reflect.DeepEqual(secret, wantSecret) {
+			t.Errorf("Got secret %+v, want %+v", secret, wantSecret)
+		}
+	})
+
+	t.Run("rotated-payload-again", func(t *testing.T) {
+		const (
+			correctKey = key2
+			wrongKey   = key1
+		)
+		if err := writer.Write(map[string]fileutil.FileProjection{
+			correctKey: content,
+		}); err != nil {
+			t.Fatalf("Failed to write rotated payload: %v", err)
+		}
+		time.Sleep(sleep)
+
+		_, err := store.GetSimpleSecret(wrongKey)
+		if err == nil {
+			t.Errorf("Expected error when getting %q, got nil", wrongKey)
+		}
+
+		secret, err := store.GetSimpleSecret(correctKey)
+		if err != nil {
+			t.Fatalf("Expected no error when getting %q, got %v", correctKey, err)
+		}
+		if !reflect.DeepEqual(secret, wantSecret) {
+			t.Errorf("Got secret %+v, want %+v", secret, wantSecret)
+		}
+	})
 }
 
 func TestDirectoryError(t *testing.T) {


### PR DESCRIPTION
## 💸 TL;DR
Works around the bug https://github.com/fsnotify/fsnotify bug 652 (not linking to avoid creating xref)

## 🧪 Testing Steps / Validation
Note that the bug above **only reproduces on Linux**, which makes it fun to reproduce.

```
❯ docker run --rm -it \
    -v "$(pwd)":/app \
    -w /app \
    golang:1 \
    go test ./filewatcher/v2 -test.v
```

can be used to test / reproduce it on Mac OS.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
