### PR TITLE
Use empty string as the fault metric method label for HTTP requests.

### DIFF
--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -15,6 +15,7 @@ import (
 	"github.com/avast/retry-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/reddit/baseplate.go/headerbp"
+	"github.com/reddit/baseplate.go/internal/faults"
 	"github.com/reddit/baseplate.go/secrets"
 
 	"github.com/reddit/baseplate.go/breakerbp"
@@ -467,7 +468,15 @@ func (c clientFaultMiddleware) Middleware() ClientMiddleware {
 			address := req.URL.Hostname()
 			method := strings.TrimPrefix(req.URL.Path, "/")
 			header := httpHeader(req.Header)
-			return c.injector.InjectWithAbortOverride(req.Context(), address, method, &header, resume, abort)
+			return c.injector.Inject(req.Context(),
+				faults.InjectParameters[*http.Response]{
+					Address:     address,
+					Method:      method,
+					MethodLabel: "",
+					Headers:     &header,
+					Resume:      resume,
+					Abort:       abort,
+				})
 		})
 	}
 }

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -21,8 +21,6 @@ import (
 const (
 	promNamespace      = "faultbp"
 	clientNameLabel    = "fault_client_name"
-	serviceLabel       = "fault_service"
-	methodLabel        = "fault_method"
 	protocolLabel      = "fault_protocol"
 	successLabel       = "fault_success"
 	delayInjectedLabel = "fault_injected_delay"
@@ -35,8 +33,6 @@ var (
 		Help: "Total count of requests seen by the fault injection middleware.",
 	}, []string{
 		clientNameLabel,
-		// serviceLabel,
-		// methodLabel,
 		protocolLabel,
 		successLabel,
 		delayInjectedLabel,
@@ -146,8 +142,6 @@ func (i *Injector[T]) InjectWithAbortOverride(ctx context.Context, address, meth
 	totalReqsCounter := func(success, aborted bool) prometheus.Counter {
 		return totalRequests.WithLabelValues(
 			i.clientName,
-			// address,
-			// method,
 			i.callerName,
 			strconv.FormatBool(success),
 			strconv.FormatBool(delayed),

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -139,6 +139,8 @@ func NewInjector[T any](clientName, callerName string, abortCodeMin, abortCodeMa
 	return i
 }
 
+// InjectParameters contains the parameters needed to match and inject a fault
+// into the outgoing request.
 type InjectParameters[T any] struct {
 	Address     string
 	Method      string

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -34,7 +34,7 @@ var (
 		Name: "faultbp_fault_requests_total",
 		Help: "Total count of requests seen by the fault injection middleware.",
 	}, []string{
-		// clientNameLabel,
+		clientNameLabel,
 		// serviceLabel,
 		// methodLabel,
 		protocolLabel,
@@ -145,7 +145,7 @@ func (i *Injector[T]) InjectWithAbortOverride(ctx context.Context, address, meth
 	delayed := false
 	totalReqsCounter := func(success, aborted bool) prometheus.Counter {
 		return totalRequests.WithLabelValues(
-			// i.clientName,
+			i.clientName,
 			// address,
 			// method,
 			i.callerName,

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -34,9 +34,9 @@ var (
 		Name: "faultbp_fault_requests_total",
 		Help: "Total count of requests seen by the fault injection middleware.",
 	}, []string{
-		clientNameLabel,
-		serviceLabel,
-		methodLabel,
+		// clientNameLabel,
+		// serviceLabel,
+		// methodLabel,
 		protocolLabel,
 		successLabel,
 		delayInjectedLabel,
@@ -145,9 +145,9 @@ func (i *Injector[T]) InjectWithAbortOverride(ctx context.Context, address, meth
 	delayed := false
 	totalReqsCounter := func(success, aborted bool) prometheus.Counter {
 		return totalRequests.WithLabelValues(
-			i.clientName,
-			address,
-			method,
+			// i.clientName,
+			// address,
+			// method,
 			i.callerName,
 			strconv.FormatBool(success),
 			strconv.FormatBool(delayed),

--- a/internal/faults/faults_test.go
+++ b/internal/faults/faults_test.go
@@ -220,7 +220,12 @@ func TestInject(t *testing.T) {
 				return nil
 			}
 
-			resp, err := injector.Inject(context.Background(), address, method, &headers, resume)
+			resp, err := injector.Inject(context.Background(), InjectParameters[*response]{
+				Address: address,
+				Method:  method,
+				Headers: &headers,
+				Resume:  resume,
+			})
 
 			if err != nil {
 				t.Fatalf("expected no error, got %v", err)

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -16,6 +16,7 @@ import (
 	"github.com/reddit/baseplate.go/ecinterface"
 	"github.com/reddit/baseplate.go/errorsbp"
 	"github.com/reddit/baseplate.go/headerbp"
+	"github.com/reddit/baseplate.go/internal/faults"
 	"github.com/reddit/baseplate.go/internal/gen-go/reddit/baseplate"
 	"github.com/reddit/baseplate.go/internal/thriftint"
 
@@ -469,7 +470,14 @@ func (c clientFaultMiddleware) Middleware() thrift.ClientMiddleware {
 					return next.Call(ctx, method, args, result)
 				}
 
-				return c.injector.Inject(ctx, c.address, method, &thriftHeaders{}, resume)
+				return c.injector.Inject(ctx,
+					faults.InjectParameters[thrift.ResponseMeta]{
+						Address:     c.address,
+						Method:      method,
+						MethodLabel: method,
+						Headers:     &thriftHeaders{},
+						Resume:      resume,
+					})
 			},
 		}
 	}


### PR DESCRIPTION
In-path parameters were causing this label to explode in cardinality. Until a better solution is worked out, we will drop that label value entirely for HTTP requests. This PR updates the `Inject` function to take in both a `method` and `methodLabel` parameter, since while we don't want to output the label, we do still want the method to be available for matching against the fault configuration in case a very specific fault is desired. Note that matching against all methods is unchanged by just not including a method to match against in the fault configuration, as was always the case. The parameter list was additionally updated to be a struct as it was getting long and unwieldy.