### PR TITLE
OAM-8189 Add BucketingKey, BucketingValue to ExperimentEvent

### DIFF
--- a/experiments/experiments.go
+++ b/experiments/experiments.go
@@ -399,7 +399,7 @@ type ExperimentEvent struct {
 	// from (optional).
 	DeviceID uuid.UUID
 	// BucketingKey is the key this experiment is being randomized on (optional).
-	BucketingKey string
+	BucketingField string
 	// BucketingValue is the value for the BucketingKey (optional).
 	BucketingValue string
 	// Experiment is the experiment of the applied treatment (required).


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
Add general field for bucketing key and value instead of adding new rand unit directly as in `device_id`. Instead, we can use the new fields for any new rand units. 
e.g.
- BucketingKey: "post_id"
- BucketingValue: "1k3xqmf"

## 📜 Details
[Jira OAM-8189](https://reddit.atlassian.net/browse/OAM-8189)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
