### PR TITLE
randbp: Comment R as deprecated

### DIFF
--- a/randbp/jitter.go
+++ b/randbp/jitter.go
@@ -1,6 +1,7 @@
 package randbp
 
 import (
+	"math/rand/v2"
 	"time"
 )
 
@@ -17,7 +18,7 @@ func JitterRatio(jitter float64) float64 {
 	if jitter > 1 {
 		jitter = 1
 	}
-	return 1 - (R.Float64()*2-1)*jitter
+	return 1 - (rand.Float64()*2-1)*jitter
 }
 
 // JitterDuration applies jitter on the center time duration so the returned

--- a/randbp/jitter_test.go
+++ b/randbp/jitter_test.go
@@ -2,6 +2,7 @@ package randbp_test
 
 import (
 	"math"
+	"math/rand/v2"
 	"testing"
 	"testing/quick"
 
@@ -11,7 +12,7 @@ import (
 func TestJitterRatio(t *testing.T) {
 	t.Run("quick", func(t *testing.T) {
 		f := func() bool {
-			jitter := randbp.R.Float64()
+			jitter := rand.Float64()
 			min := 1 - jitter
 			max := 1 + jitter
 			ratio := randbp.JitterRatio(jitter)
@@ -35,7 +36,7 @@ func TestJitterRatio(t *testing.T) {
 	t.Run("<=0", func(t *testing.T) {
 		const epsilon = 1e-9
 		f := func() bool {
-			jitter := -randbp.R.Float64()
+			jitter := -rand.Float64()
 			ratio := randbp.JitterRatio(jitter)
 			if math.Abs(1-ratio) > epsilon {
 				t.Errorf(
@@ -58,7 +59,7 @@ func TestJitterRatio(t *testing.T) {
 			max = 2
 		)
 		f := func() bool {
-			jitter := 1 + randbp.R.Float64()
+			jitter := 1 + rand.Float64()
 			ratio := randbp.JitterRatio(jitter)
 			if ratio < max && ratio > min {
 				return true

--- a/randbp/rand.go
+++ b/randbp/rand.go
@@ -32,6 +32,9 @@ var readerPool = sync.Pool{
 // See the doc of Rand.Read for more details.
 // All other functions (Uint64, Float64, etc.) have comparable performance to
 // math/rand's implementations.
+//
+// NOTE: This is considered deprecated. New code should use stdlib math/rand/v2
+// instead.
 var R = New(GetSeed())
 
 // Rand embeds *math/rand.Rand.

--- a/randbp/sample.go
+++ b/randbp/sample.go
@@ -1,5 +1,9 @@
 package randbp
 
+import (
+	"math/rand/v2"
+)
+
 // ShouldSampleWithRate generates a random float64 in [0, 1) and check it
 // against rate.
 //
@@ -7,5 +11,5 @@ package randbp
 // When rate <= 0 this function always returns false;
 // When rate >= 1 this function always returns true.
 func ShouldSampleWithRate(rate float64) bool {
-	return R.Float64() < rate
+	return rand.Float64() < rate
 }

--- a/randbp/string.go
+++ b/randbp/string.go
@@ -1,7 +1,8 @@
 package randbp
 
 import (
-	"math/rand"
+	randv1 "math/rand"
+	"math/rand/v2"
 )
 
 // Base64Runes are all the runes allowed in standard and url safe base64
@@ -20,17 +21,12 @@ type RandomStringArgs struct {
 	// If MinLength < 0 or MinLength >= MaxLength it will cause panic.
 	MinLength int
 
-	// Optional. If nil randbp.R will be used instead.
-	R *rand.Rand
-
 	// Optional. If empty []rune(randbp.Base64Runes) will be used instead.
 	Runes []rune
-}
 
-// The common interface between *math/rand.Rand and randbp.Rand used in
-// GenerateRandomString.
-type intner interface {
-	Intn(n int) int
+	// Deprecated: This is no longer used. We always use math/rand/v2 global
+	// PRNG.
+	R *randv1.Rand
 }
 
 // GenerateRandomString generates a random string with length
@@ -38,20 +34,14 @@ type intner interface {
 //
 // It could be used to help implement testing/quick.Generator interface.
 func GenerateRandomString(args RandomStringArgs) string {
-	var r intner
-	if args.R != nil {
-		r = args.R
-	} else {
-		r = R
-	}
 	runes := args.Runes
 	if len(runes) == 0 {
 		runes = []rune(Base64Runes)
 	}
-	n := r.Intn(args.MaxLength-args.MinLength) + args.MinLength
+	n := rand.IntN(args.MaxLength-args.MinLength) + args.MinLength
 	ret := make([]rune, n)
 	for i := range ret {
-		ret[i] = runes[r.Intn(len(runes))]
+		ret[i] = runes[rand.IntN(len(runes))]
 	}
 	return string(ret)
 }

--- a/randbp/string_example_test.go
+++ b/randbp/string_example_test.go
@@ -16,10 +16,9 @@ const (
 
 type RandomString string
 
-func (RandomString) Generate(r *rand.Rand, _ int) reflect.Value {
+func (RandomString) Generate(_ *rand.Rand, _ int) reflect.Value {
 	return reflect.ValueOf(RandomString(randbp.GenerateRandomString(
 		randbp.RandomStringArgs{
-			R:         r,
 			MinLength: MinLength,
 			MaxLength: MaxLength,
 		},

--- a/randbp/string_test.go
+++ b/randbp/string_test.go
@@ -24,10 +24,9 @@ const (
 
 type randomString string
 
-func (randomString) Generate(r *rand.Rand, _ int) reflect.Value {
+func (randomString) Generate(_ *rand.Rand, _ int) reflect.Value {
 	return reflect.ValueOf(randomString(randbp.GenerateRandomString(
 		randbp.RandomStringArgs{
-			R:         r,
 			MinLength: minLength,
 			MaxLength: maxLength,
 		},


### PR DESCRIPTION
Switch all usage of R to the global PRNG from stdlib math/rand/v2 instead.

Don't officially mark it as deprecated as that will break a lot of existing code, and it's still ok to use (same as in stdlib math/rand is still ok to use).
