### PR TITLE
[Faults] Add support for matching on the host/authority header.

### DIFF
--- a/httpbp/client_middlewares.go
+++ b/httpbp/client_middlewares.go
@@ -471,6 +471,7 @@ func (c clientFaultMiddleware) Middleware() ClientMiddleware {
 			return c.injector.Inject(req.Context(),
 				faults.InjectParameters[*http.Response]{
 					Address:     address,
+					Host:        req.Host,
 					Method:      method,
 					MethodLabel: "",
 					Headers:     &header,

--- a/httpbp/client_middlewares_test.go
+++ b/httpbp/client_middlewares_test.go
@@ -402,6 +402,7 @@ func TestFaultInjection(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		faultServerAddrMatch bool
+		host                 string
 		remainingFaultHeader string // Fault header after the address portion.
 
 		wantStatusCode int
@@ -414,7 +415,8 @@ func TestFaultInjection(t *testing.T) {
 			name: "abort",
 
 			faultServerAddrMatch: true,
-			remainingFaultHeader: "m=testMethod;f=500",
+			host:                 "testHost",
+			remainingFaultHeader: "h=testHost;m=testMethod;f=500",
 
 			wantStatusCode: http.StatusInternalServerError,
 		},
@@ -431,6 +433,14 @@ func TestFaultInjection(t *testing.T) {
 
 			faultServerAddrMatch: false,
 			remainingFaultHeader: "m=testMethod;f=500",
+
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "host does not match",
+
+			faultServerAddrMatch: true,
+			remainingFaultHeader: "h=fooHost;f=500",
 
 			wantStatusCode: http.StatusOK,
 		},
@@ -479,6 +489,7 @@ func TestFaultInjection(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error when creating request: %v", err)
 			}
+			req.Host = tt.host
 
 			faultHeader := tt.remainingFaultHeader
 			if tt.faultServerAddrMatch {

--- a/internal/faults/faults.go
+++ b/internal/faults/faults.go
@@ -116,6 +116,7 @@ func NewInjector[T any](clientName, callerName string, abortCodeMin, abortCodeMa
 // into the outgoing request.
 type InjectParameters[T any] struct {
 	Address     string
+	Host        string
 	Method      string
 	MethodLabel string
 	Headers     Headers
@@ -135,6 +136,7 @@ func (i *Injector[T]) Inject(ctx context.Context, params InjectParameters[T]) (T
 		return faultmetrics.TotalRequests.WithLabelValues(
 			i.clientName,
 			params.Address,
+			params.Host,
 			params.MethodLabel,
 			i.callerName,
 			status.String(),
@@ -161,7 +163,7 @@ func (i *Injector[T]) Inject(ctx context.Context, params InjectParameters[T]) (T
 		return params.Resume()
 	}
 
-	faultConfiguration, err := parseMatchingFaultConfiguration(faultHeaderValues, getCanonicalAddress(params.Address), params.Method, i.abortCodeMin, i.abortCodeMax)
+	faultConfiguration, err := parseMatchingFaultConfiguration(faultHeaderValues, getCanonicalAddress(params.Address), params.Host, params.Method, i.abortCodeMin, i.abortCodeMax)
 	if err != nil {
 		warnf("error parsing fault header %q: %v", FaultHeader, err)
 

--- a/internal/faults/headers_test.go
+++ b/internal/faults/headers_test.go
@@ -286,9 +286,8 @@ func TestParsingFaultConfiguration(t *testing.T) {
 		},
 	}
 
-	testHost := ""
-	testMethod := ""
-	testAbortCodeMin, testAbortCodeMax := 0, 0
+	var testHost, testMethod string
+	var testAbortCodeMin, testAbortCodeMax int
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/faults/metrics/metrics.go
+++ b/internal/faults/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 const (
 	clientNameLabel    = "fault_client_name"
 	serviceLabel       = "fault_service"
+	hostLabel          = "fault_host"
 	methodLabel        = "fault_method"
 	protocolLabel      = "fault_protocol"
 	statusLabel        = "fault_status"
@@ -52,6 +53,7 @@ var (
 	}, []string{
 		clientNameLabel,
 		serviceLabel,
+		hostLabel,
 		methodLabel,
 		protocolLabel,
 		statusLabel,

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -27,10 +27,6 @@ import (
 	"github.com/reddit/baseplate.go/transport"
 )
 
-// HostHeader is the Thrift equivalent of the HTTP1 Host header and HTTP2 :authority pseudo-header.
-// Exposed for tests.
-const HostHeader = "thrift-hostname"
-
 // MonitorClientWrappedSlugSuffix is a suffix to be added to the service slug
 // arg of MonitorClient function, in order to distinguish from the spans that
 // are the raw client calls.
@@ -474,7 +470,7 @@ func (c clientFaultMiddleware) Middleware() thrift.ClientMiddleware {
 				}
 
 				host := ""
-				if hostHeaderValue, ok := thrift.GetHeader(ctx, HostHeader); ok {
+				if hostHeaderValue, ok := thrift.GetHeader(ctx, ThriftHostnameHeader); ok {
 					host = hostHeaderValue
 				}
 

--- a/thriftbp/client_middlewares.go
+++ b/thriftbp/client_middlewares.go
@@ -469,7 +469,7 @@ func (c clientFaultMiddleware) Middleware() thrift.ClientMiddleware {
 					return next.Call(ctx, method, args, result)
 				}
 
-				host := ""
+				var host string
 				if hostHeaderValue, ok := thrift.GetHeader(ctx, ThriftHostnameHeader); ok {
 					host = hostHeaderValue
 				}

--- a/thriftbp/client_middlewares_test.go
+++ b/thriftbp/client_middlewares_test.go
@@ -482,7 +482,7 @@ func TestFaultInjectionClientMiddleware(t *testing.T) {
 			ctx = headers.SetOnContext(ctx)
 
 			if tt.hostHeader != "" {
-				ctx = thriftbp.AddClientHeader(ctx, thriftbp.HostHeader, tt.hostHeader)
+				ctx = thriftbp.AddClientHeader(ctx, thriftbp.ThriftHostnameHeader, tt.hostHeader)
 			}
 
 			mock, _, client := initClients(impl)


### PR DESCRIPTION
The PRs adding this to bpv2 have already been approved, and this PR is just to get bpv0 up-to-date with those.

This introduces support for a new `h` parameter in the fault configuration header value. Specifically, if the `h` parameter is present, then the value of it will be checked against the host/authority header of the outgoing request before determining whether the request matches for fault injection.

Note that this is _not_ supported for gRPC due to the authority header not being exposed by client-middleware runtime. If you'd like more info on the workaround for gRPC, I'm happy to DM information on what we plan to do.
