### PR TITLE
[Faults] Require a strict method match when `m` is provided.

### DIFF
--- a/internal/faults/faults_test.go
+++ b/internal/faults/faults_test.go
@@ -67,6 +67,7 @@ type injectTestCase struct {
 	sleepErr bool
 
 	faultHeader string
+	methodEmpty bool
 
 	wantDelay    time.Duration
 	wantResponse *response
@@ -117,6 +118,11 @@ func TestInject(t *testing.T) {
 		{
 			name:        "method does not match",
 			faultHeader: "a=testService.testNamespace;m=fooMethod;f=1;b=test fault",
+		},
+		{
+			name:        "method does not match (empty)",
+			faultHeader: "a=testService.testNamespace;m=testMethod;f=1;b=test fault",
+			methodEmpty: true,
 		},
 		{
 			name:    "guaranteed percent",
@@ -220,9 +226,14 @@ func TestInject(t *testing.T) {
 				return nil
 			}
 
+			var testMethod string
+			if !tc.methodEmpty {
+				testMethod = method
+			}
+
 			resp, err := injector.Inject(context.Background(), InjectParameters[*response]{
 				Address: address,
-				Method:  method,
+				Method:  testMethod,
 				Headers: &headers,
 				Resume:  resume,
 			})

--- a/internal/faults/headers.go
+++ b/internal/faults/headers.go
@@ -110,7 +110,7 @@ func parseMatchingFaultHeader(headerValue string, canonicalAddress, method strin
 			addressMatched = true
 			config.ServerAddress = value
 		case "m":
-			if method != "" && value != method {
+			if value != method {
 				return nil, nil
 			}
 			config.ServerMethod = value

--- a/internal/faults/headers_test.go
+++ b/internal/faults/headers_test.go
@@ -121,6 +121,11 @@ func TestParseMatchingFaultHeader(t *testing.T) {
 			method:           "baz",
 		},
 		{
+			name:             "method does not match (empty)",
+			headerValue:      "a=foo;m=bar",
+			canonicalAddress: "foo",
+		},
+		{
 			name:             "invalid delay value",
 			headerValue:      "a=foo;d=NaN",
 			canonicalAddress: "foo",


### PR DESCRIPTION
Do not allow matching when the configuration is for a specific method and the real method is unknown.

The main idea here is that if someone wanted to inject a fault on the `foobar` method, a request with an unknown method should not also have that fault injected just because the primary address matched.

Note that this has already been merged into bpv2 and this PR is just to get bpv0 on the same page. This will be followed by another PR getting bpv0 up to sync as well.
