### PR TITLE
Deprecate events package in favor of GRPC Event Collector

### DIFF
--- a/events/doc.go
+++ b/events/doc.go
@@ -1,5 +1,8 @@
 // Package events implements event publisher per baseplate spec.
 //
+// Deprecated: This package is in maintenance mode and should not be used for new projects.
+// Consider using alternative event publishing solutions for new development.
+//
 // This package is mainly just the serialization part.
 // The actual publishing part is handled by sidecar implemented by baseplate.py,
 // and communicated via mqsend package.

--- a/events/events.go
+++ b/events/events.go
@@ -10,6 +10,8 @@ import (
 )
 
 // Configuration values for the message queue.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 const (
 	// Max size in bytes for a single, serialized event.
 	MaxEventSize = 102400
@@ -27,6 +29,8 @@ const (
 var serializerPool = thrift.NewTSerializerPoolSizeFactory(MaxEventSize, thrift.NewTJSONProtocolFactory())
 
 // A Queue is an event queue.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 type Queue struct {
 	queue      mqsend.MessageQueue
 	maxTimeout time.Duration
@@ -35,6 +39,8 @@ type Queue struct {
 // The Config used to initialize an event queue.
 //
 // Can be deserialized from YAML.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 type Config struct {
 	// The name of the message queue, should not contain the "events-" prefix.
 	//
@@ -59,11 +65,15 @@ type Config struct {
 }
 
 // V2 initializes a new v2 event queue with default configurations.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 func V2() (*Queue, error) {
 	return V2WithConfig(Config{})
 }
 
 // V2WithConfig initializes a new v2 event queue.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 func V2WithConfig(cfg Config) (*Queue, error) {
 	name := cfg.Name
 	if name == "" {
@@ -93,11 +103,15 @@ func v2WithConfig(cfg Config, queue mqsend.MessageQueue) *Queue {
 // Close closes the event queue.
 //
 // After Close is called, all Put calls will return errors.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 func (q *Queue) Close() error {
 	return q.queue.Close()
 }
 
 // Put serializes and puts an event into the event queue.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 func (q *Queue) Put(ctx context.Context, event thrift.TStruct) error {
 	ctx, cancel := context.WithTimeout(ctx, q.maxTimeout)
 	defer cancel()
@@ -115,6 +129,8 @@ func (q *Queue) Put(ctx context.Context, event thrift.TStruct) error {
 // In most cases you should use Put instead.
 // This is only provided for some special cases like experiments-v2 custom
 // exposers.
+//
+// Deprecated: This package is in maintenance mode. Use alternative event publishing solutions.
 func (q *Queue) PutRaw(ctx context.Context, rawEvent []byte) error {
 	ctx, cancel := context.WithTimeout(ctx, q.maxTimeout)
 	defer cancel()


### PR DESCRIPTION
## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->
This PR puts the `events` package in maintenance mode and adds deprecation warnings to discourage new usage. 


## 📜 Details
[Decision Doc](https://docs.google.com/document/d/1SzbXzvSJlW_A7UxwrS4-41RmX43iLjryyu0A2pRaP20/edit?tab=t.0)

[Jira](https://reddit.atlassian.net/browse/DATAPIPE-303)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
