### PR TITLE
Differentiate servers running within a single runtime

### DIFF
--- a/internal/prometheusbpint/spectest/spec.go
+++ b/internal/prometheusbpint/spectest/spec.go
@@ -180,7 +180,6 @@ func buildLabels(name, prefix, clientOrServer string) map[string]struct{} {
 //
 // active_requests metrics expect the following labels:
 //   - "method"
-
 func thriftSpecificLabels(name string) []string {
 
 	labelSuffixes := []string{"method"}

--- a/internal/prometheusbpint/spectest/spec.go
+++ b/internal/prometheusbpint/spectest/spec.go
@@ -163,6 +163,10 @@ func buildLabels(name, prefix, clientOrServer string) map[string]struct{} {
 }
 
 // thriftSpecificLabels returns the following labels:
+//
+// All serverside metrics expect the following labels:
+//   - "server_name" (server only)
+//
 // latency_seconds metrics expect the following labels:
 //   - "method"
 //   - "success"
@@ -176,8 +180,14 @@ func buildLabels(name, prefix, clientOrServer string) map[string]struct{} {
 //
 // active_requests metrics expect the following labels:
 //   - "method"
+
 func thriftSpecificLabels(name string) []string {
+
 	labelSuffixes := []string{"method"}
+	if strings.Contains(name, "_server_") {
+		labelSuffixes = []string{"server_name", "method"}
+	}
+
 	switch {
 	case strings.HasSuffix(name, "_latency_seconds"):
 		labelSuffixes = append(labelSuffixes, "success")
@@ -188,6 +198,7 @@ func thriftSpecificLabels(name string) []string {
 	default:
 		return nil
 	}
+
 	return labelSuffixes
 }
 
@@ -216,7 +227,7 @@ func grpcSpecificLabels(name string) []string {
 	case strings.HasSuffix(name, "_requests_total"):
 		labelSuffixes = append(labelSuffixes, "success", "code")
 	case strings.HasSuffix(name, "_active_requests"):
-		// no op
+		return labelSuffixes
 	default:
 		return nil
 	}

--- a/thriftbp/prometheus.go
+++ b/thriftbp/prometheus.go
@@ -22,10 +22,12 @@ const (
 	baseplateStatusLabel     = "thrift_baseplate_status"
 	baseplateStatusCodeLabel = "thrift_baseplate_status_code"
 	clientNameLabel          = "thrift_client_name"
+	serverNameLabel          = "thrift_server_name"
 )
 
 var (
 	serverLatencyLabels = []string{
+		serverNameLabel,
 		methodLabel,
 		successLabel,
 	}
@@ -37,6 +39,7 @@ var (
 	}, serverLatencyLabels)
 
 	serverTotalRequestLabels = []string{
+		serverNameLabel,
 		methodLabel,
 		successLabel,
 		exceptionLabel,
@@ -50,6 +53,7 @@ var (
 	}, serverTotalRequestLabels)
 
 	serverActiveRequestsLabels = []string{
+		serverNameLabel,
 		methodLabel,
 	}
 
@@ -136,6 +140,7 @@ const (
 
 var (
 	serverPayloadSizeLabels = []string{
+		serverNameLabel,
 		methodLabel,
 		protoLabel,
 	}

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -111,6 +111,72 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 	}
 }
 
+func TestReportPayloadSizeMetrics(t *testing.T) {
+	testCases := []struct {
+		name    string
+		wantErr thrift.TException
+		wantOK  bool
+	}{
+		{
+			name:    "success",
+			wantErr: nil,
+			wantOK:  true,
+		},
+		{
+			name:    "error",
+			wantErr: thrift.NewTApplicationException(thrift.UNKNOWN_METHOD, "unknown err msg"),
+			wantOK:  false,
+		},
+	}
+
+	const method = "testmethod"
+	const serverName = "testserver"
+	const proto = "header-binary"
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			serverPayloadSizeRequestBytes.Reset()
+			serverPayloadSizeResponseBytes.Reset()
+
+			payloadLabels := prometheus.Labels{
+				serverNameLabel: serverName,
+				methodLabel:     method,
+				protoLabel:      proto,
+			}
+
+			defer promtest.NewPrometheusMetricTest(t, "request payload", serverPayloadSizeRequestBytes, payloadLabels).CheckSampleCountDelta(1)
+			defer promtest.NewPrometheusMetricTest(t, "response payload", serverPayloadSizeResponseBytes, payloadLabels).CheckSampleCountDelta(1)
+
+			next := thrift.WrappedTProcessorFunction{
+				Wrapped: func(ctx context.Context, seqId int32, in, out thrift.TProtocol) (bool, thrift.TException) {
+					return tt.wantOK, tt.wantErr
+				},
+			}
+
+			// Create THeader transport and protocol to trigger payload size tracking
+			cfg := &thrift.TConfiguration{}
+			transport := thrift.NewTMemoryBuffer()
+			headerTransport := thrift.NewTHeaderTransportConf(transport, cfg)
+			headerProtocol := thrift.NewTHeaderProtocolConf(headerTransport, cfg)
+
+			middleware := ReportPayloadSizeMetricsWithArgs(ReportPayloadSizeMetricsArgs{
+				ServerName: serverName,
+				SampleRate: 0,
+			})
+
+			wrapped := middleware(method, next)
+			gotOK, gotErr := wrapped.Process(context.Background(), 1, headerProtocol, headerProtocol)
+
+			if gotOK != tt.wantOK {
+				t.Errorf("wanted %v, got %v", tt.wantOK, gotOK)
+			}
+			if gotErr != tt.wantErr {
+				t.Errorf("wanted %v, got %v", tt.wantErr, gotErr)
+			}
+		})
+	}
+}
+
 // PromClientMetricsTest keeps track of the Thrift client Prometheus metrics
 // during testing.
 type PromClientMetricsTest struct {

--- a/thriftbp/prometheus_test.go
+++ b/thriftbp/prometheus_test.go
@@ -53,6 +53,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 	}
 
 	const method = "testmethod"
+	const serverName = "testserver"
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,15 +70,18 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 			success := prometheusbp.BoolString(tt.wantErr == nil)
 
 			activeRequestLabels := prometheus.Labels{
-				methodLabel: method,
+				serverNameLabel: serverName,
+				methodLabel:     method,
 			}
 
 			latencyLabels := prometheus.Labels{
-				methodLabel:  method,
-				successLabel: success,
+				serverNameLabel: serverName,
+				methodLabel:     method,
+				successLabel:    success,
 			}
 
 			totalRequestLabels := prometheus.Labels{
+				serverNameLabel:          serverName,
 				methodLabel:              method,
 				successLabel:             success,
 				exceptionLabel:           exceptionType,
@@ -95,7 +99,7 @@ func TestPrometheusServerMiddleware(t *testing.T) {
 					return tt.wantOK, tt.wantErr
 				},
 			}
-			gotOK, gotErr := PrometheusServerMiddleware(method, next).Process(context.Background(), 1, nil, nil)
+			gotOK, gotErr := PrometheusServerMiddlewareWithArgs(PrometheusServerMiddlewareArgs{ServerName: serverName})(method, next).Process(context.Background(), 1, nil, nil)
 
 			if gotOK != tt.wantOK {
 				t.Errorf("wanted %v, got %v", tt.wantOK, gotOK)

--- a/thriftbp/server_middlewares.go
+++ b/thriftbp/server_middlewares.go
@@ -86,8 +86,8 @@ func BaseplateDefaultProcessorMiddlewares(args DefaultProcessorMiddlewaresArgs) 
 		ExtractDeadlineBudget,
 		InjectServerSpanWithArgs(MonitorServerArgs{ServiceSlug: args.ServiceName}),
 		InjectEdgeContext(args.EdgeContextImpl),
-		ReportPayloadSizeMetrics(0),
-		PrometheusServerMiddleware,
+		ReportPayloadSizeMetricsWithArgs(ReportPayloadSizeMetricsArgs{ServerName: args.ServiceName, SampleRate: 0}),
+		PrometheusServerMiddlewareWithArgs(PrometheusServerMiddlewareArgs{ServerName: args.ServiceName}),
 		ServerBaseplateHeadersMiddleware(),
 	}
 }
@@ -269,6 +269,23 @@ func AbandonCanceledRequests(name string, next thrift.TProcessorFunction) thrift
 // ReportPayloadSizeMetrics returns a ProcessorMiddleware that reports metrics
 // (histograms) of request and response payload sizes in bytes.
 //
+// Deprecated: Use ReportPayloadSizeMetricsWithArgs instead.
+func ReportPayloadSizeMetrics(sampleRate float64) thrift.ProcessorMiddleware {
+	return ReportPayloadSizeMetricsWithArgs(ReportPayloadSizeMetricsArgs{
+		ServerName: "unknown",
+		SampleRate: sampleRate,
+	})
+}
+
+// ReportPayloadSizeMetricsArgs are the arguments for ReportPayloadSizeMetricsWithArgs.
+type ReportPayloadSizeMetricsArgs struct {
+	ServerName string
+	SampleRate float64
+}
+
+// ReportPayloadSizeMetricsWithArgs returns a ProcessorMiddleware that reports metrics
+// (histograms) of request and response payload sizes in bytes.
+//
 // This middleware only works on sampled requests with the given sample rate,
 // but the histograms it reports are overriding global histogram sample rate
 // with 100% sample, to avoid double sampling.
@@ -288,7 +305,7 @@ func AbandonCanceledRequests(name string, next thrift.TProcessorFunction) thrift
 // The prometheus histograms are:
 //   - thriftbp_server_request_payload_size_bytes
 //   - thriftbp_server_response_payload_size_bytes
-func ReportPayloadSizeMetrics(_ float64) thrift.ProcessorMiddleware {
+func ReportPayloadSizeMetricsWithArgs(args ReportPayloadSizeMetricsArgs) thrift.ProcessorMiddleware {
 	return func(name string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
 		return thrift.WrappedTProcessorFunction{
 			Wrapped: func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (bool, thrift.TException) {
@@ -320,8 +337,9 @@ func ReportPayloadSizeMetrics(_ float64) thrift.ProcessorMiddleware {
 
 						proto := "header-" + tHeaderProtocol2String(protoID)
 						labels := prometheus.Labels{
-							methodLabel: name,
-							protoLabel:  proto,
+							serverNameLabel: args.ServerName,
+							methodLabel:     name,
+							protoLabel:      proto,
 						}
 						serverPayloadSizeRequestBytes.With(labels).Observe(isize)
 						serverPayloadSizeResponseBytes.With(labels).Observe(osize)
@@ -417,10 +435,24 @@ func recoverPanik(name string, next thrift.TProcessorFunction) thrift.TProcessor
 // PrometheusServerMiddleware returns middleware to track Prometheus metrics
 // specific to the Thrift service.
 //
+// Deprecated: Use PrometheusServerMiddlewareWithArgs instead.
+func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+	return PrometheusServerMiddlewareWithArgs(PrometheusServerMiddlewareArgs{ServerName: "unknown"})(method, next)
+}
+
+// PrometheusServerMiddlewareArgs are the arguments for PrometheusServerMiddlewareWithArgs.
+type PrometheusServerMiddlewareArgs struct {
+	ServerName string
+}
+
+// PrometheusServerMiddlewareWithArgs returns middleware to track Prometheus metrics
+// specific to the Thrift service.
+//
 // It emits the following prometheus metrics:
 //
 // * thrift_server_active_requests gauge with labels:
 //
+//   - thrift_server_name: the name of the thrift server
 //   - thrift_method: the method of the endpoint called
 //
 // * thrift_server_latency_seconds histogram with labels above plus:
@@ -435,49 +467,54 @@ func recoverPanik(name string, next thrift.TProcessorFunction) thrift.TProcessor
 //     as a string if present (e.g. 404), or the empty string
 //   - thrift_baseplate_status_code: the human-readable status code, e.g.
 //     NOT_FOUND, or the empty string
-func PrometheusServerMiddleware(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
-	process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
-		start := time.Now()
-		activeRequestLabels := prometheus.Labels{
-			methodLabel: method,
-		}
-		serverActiveRequests.With(activeRequestLabels).Inc()
+func PrometheusServerMiddlewareWithArgs(args PrometheusServerMiddlewareArgs) thrift.ProcessorMiddleware {
+	return func(method string, next thrift.TProcessorFunction) thrift.TProcessorFunction {
+		process := func(ctx context.Context, seqID int32, in, out thrift.TProtocol) (success bool, err thrift.TException) {
+			start := time.Now()
+			activeRequestLabels := prometheus.Labels{
+				serverNameLabel: args.ServerName,
+				methodLabel:     method,
+			}
+			serverActiveRequests.With(activeRequestLabels).Inc()
 
-		defer func() {
-			var baseplateStatusCode, baseplateStatus string
-			exceptionTypeLabel := stringifyErrorType(err)
-			success := prometheusbp.BoolString(err == nil)
-			if err != nil {
-				var bpErr baseplateErrorCoder
-				if errors.As(err, &bpErr) {
-					code := bpErr.GetCode()
-					baseplateStatusCode = strconv.FormatInt(int64(code), 10)
-					if status := baseplate.ErrorCode(code).String(); status != "<UNSET>" {
-						baseplateStatus = status
+			defer func() {
+				var baseplateStatusCode, baseplateStatus string
+				exceptionTypeLabel := stringifyErrorType(err)
+				success := prometheusbp.BoolString(err == nil)
+				if err != nil {
+					var bpErr baseplateErrorCoder
+					if errors.As(err, &bpErr) {
+						code := bpErr.GetCode()
+						baseplateStatusCode = strconv.FormatInt(int64(code), 10)
+						if status := baseplate.ErrorCode(code).String(); status != "<UNSET>" {
+							baseplateStatus = status
+						}
 					}
 				}
-			}
 
-			latencyLabels := prometheus.Labels{
-				methodLabel:  method,
-				successLabel: success,
-			}
-			serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
+				latencyLabels := prometheus.Labels{
+					serverNameLabel: args.ServerName,
+					methodLabel:     method,
+					successLabel:    success,
+				}
+				serverLatencyDistribution.With(latencyLabels).Observe(time.Since(start).Seconds())
 
-			totalRequestLabels := prometheus.Labels{
-				methodLabel:              method,
-				successLabel:             success,
-				exceptionLabel:           exceptionTypeLabel,
-				baseplateStatusLabel:     baseplateStatus,
-				baseplateStatusCodeLabel: baseplateStatusCode,
-			}
-			serverTotalRequests.With(totalRequestLabels).Inc()
-			serverActiveRequests.With(activeRequestLabels).Dec()
-		}()
+				totalRequestLabels := prometheus.Labels{
+					serverNameLabel:          args.ServerName,
+					methodLabel:              method,
+					successLabel:             success,
+					exceptionLabel:           exceptionTypeLabel,
+					baseplateStatusLabel:     baseplateStatus,
+					baseplateStatusCodeLabel: baseplateStatusCode,
+				}
+				serverTotalRequests.With(totalRequestLabels).Inc()
+				serverActiveRequests.With(activeRequestLabels).Dec()
+			}()
 
-		return next.Process(ctx, seqID, in, out)
+			return next.Process(ctx, seqID, in, out)
+		}
+		return thrift.WrappedTProcessorFunction{Wrapped: process}
 	}
-	return thrift.WrappedTProcessorFunction{Wrapped: process}
 }
 
 // ServerBaseplateHeadersMiddleware is a middleware that extracts baseplate headers from the incoming request and adds them to the context.


### PR DESCRIPTION
## 💸 TL;DR
Our thrift server metrics assume that there will only be one server running within a single runtime. This is not always true. If a second server is running, the thrift server metrics will clash with one another. This PR adds a serverName label to our serverside metrics.

## 📜 Details
This update is backwards compatible, and notably should not increase cardinality in any significant way. Preexisting metric usage will emit "unknown" as the serverName, which will retain metric cardinality and will add a negligible amount of data for metric DBs. 

The API itself does not enable backward compatible attribute changes. We have a choice. We can: 
1. inject the serverName into the ctx on each request
2. Always call  GetThriftServiceName(cfg.Processor) -- needs testing
3. (The option chosen) Provide an alternative WithArgs function 

Commonly, we might make use of the optionals or builder pattern for forward looking, backwards compatible changes. Instead though we've opted to use a Cfg struct, as this matches patterns found elsewhere in the repo.  

## 🧪 Testing Steps / Validation
Unit tests

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
