### PR TITLE
tracing: log v2-enabled message at info level

### DIFF
--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -85,7 +85,7 @@ type Tracer struct {
 // and the error will be logged if logger is non-nil.
 func InitGlobalTracer(cfg Config) error {
 	if internalv2compat.V2TracingEnabled() {
-		cfg.Logger.Log(context.Background(), `v2 tracing is enabled; skipping v0 tracer configuration`)
+		log.Info(`v2 tracing is enabled; skipping v0 tracer configuration`)
 		return nil
 	}
 	var tracer Tracer


### PR DESCRIPTION
The "v2 tracing is enabled; skipping v0 tracer configuration" message was emitted through cfg.Logger - if a client sets their configured log level to ERROR then this logs at error level. This is purely informational - it shouldn't be logged at the log level set on the logger. It should always be logged as an info level log. It is also logged before the logger is constructed - so it ought to use the default global logger at this point in the constructor.

This fixes the log level so that clients using this API surface don't get spammy error logs.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
