### PR TITLE
secrets: handle Vault KV v1 and v2 envelopes transparently

### DIFF
--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,9 +30,93 @@ func (s Secret) IsEmpty() bool {
 	return len(s) == 0
 }
 
-// CSIFile represents the raw parsed object of a file made by the Vault CSI provider
+// CSIFile represents the raw parsed object of a file made by the Vault CSI
+// provider. The shape mirrors the Vault HTTP API envelope.
+//
+// The Secret field holds the user-visible secret payload. The exact wire
+// format under the top-level "data" key depends on which KV backend version
+// Vault read from:
+//
+//   - KV v1: data is the secret payload directly, e.g.
+//     {"data": {"value": "..."}}
+//   - KV v2: data has an extra layer of nesting, splitting the user payload
+//     from per-version metadata, e.g.
+//     {"data": {"data": {"value": "..."}, "metadata": {"version": 1, ...}}}
+//
+// UnmarshalJSON hides this distinction from callers by hoisting the inner
+// data field out of a KV v2 envelope, so Secret is always populated from the
+// user payload regardless of which backend Vault served the secret from.
 type CSIFile struct {
 	Secret GenericSecret `json:"data"`
+}
+
+// UnmarshalJSON decodes the CSI envelope and, when the payload was sourced
+// from Vault's KV v2 backend, hoists the inner "data" object up so that
+// Secret is decoded from the user-visible secret payload.
+//
+// A payload is treated as KV v2 when the top-level "data" is a JSON object
+// containing both a "data" key and a "metadata" object whose:
+//
+//   - "version" is a JSON number literal, AND
+//   - "created_time" is a non-empty JSON string literal.
+//
+// Both signals must come from Vault's KV v2 implementation; checking the
+// shapes of the metadata fields (rather than just their key names) avoids
+// misclassifying a KV v1 secret that happens to define user-level keys
+// called "data" and "metadata".
+func (c *CSIFile) UnmarshalJSON(b []byte) error {
+	var envelope struct {
+		Data json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(b, &envelope); err != nil {
+		return err
+	}
+
+	if len(envelope.Data) == 0 {
+		return nil
+	}
+
+	payload := envelope.Data
+	var probe struct {
+		Data     json.RawMessage `json:"data"`
+		Metadata struct {
+			Version     json.RawMessage `json:"version"`
+			CreatedTime json.RawMessage `json:"created_time"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(payload, &probe); err == nil {
+		if len(probe.Data) > 0 &&
+			isJSONNumber(probe.Metadata.Version) &&
+			isNonEmptyJSONString(probe.Metadata.CreatedTime) {
+			payload = probe.Data
+		}
+	}
+	// If the inner Unmarshal failed, the payload is not a JSON object (string,
+	// number, array, ...). Leave it untouched; the decode into GenericSecret
+	// below will surface a useful error.
+
+	return json.Unmarshal(payload, &c.Secret)
+}
+
+// isJSONNumber reports whether b is a JSON number literal.
+//
+// We avoid encoding/json's json.Number type for this check because it accepts
+// JSON strings whose contents parse as a number (e.g. "1"), which would let a
+// caller-controlled string field masquerade as a Vault-emitted KV v2 version.
+func isJSONNumber(b []byte) bool {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 {
+		return false
+	}
+	c := b[0]
+	return c == '-' || (c >= '0' && c <= '9')
+}
+
+// isNonEmptyJSONString reports whether b is a JSON string literal with at
+// least one character of content (i.e. not "").
+func isNonEmptyJSONString(b []byte) bool {
+	b = bytes.TrimSpace(b)
+	return len(b) >= 3 && b[0] == '"' && b[len(b)-1] == '"'
 }
 
 // Secrets allows to access secrets based on their different type.

--- a/secrets/secrets_test.go
+++ b/secrets/secrets_test.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -237,6 +238,160 @@ func TestSecretsWrongType(t *testing.T) {
 			}
 			if _, err := tt.function(secrets); !errors.Is(err, tt.expectedError) {
 				t.Fatalf("expected error %v, actual: %v", tt.expectedError, err)
+			}
+		})
+	}
+}
+
+// TestCSIFile_UnmarshalJSON exercises CSIFile's KV v1/v2 envelope handling.
+//
+// Mirrors the matching test in github.snooguts.net/reddit-go/secretsbp's
+// internal/vaultcsi package, adapted to assert on the decoded GenericSecret
+// (which is what CSIFile exposes) rather than the raw payload bytes.
+func TestCSIFile_UnmarshalJSON(t *testing.T) {
+	// populatedSecret is the GenericSecret callers see when v1/v2 detection
+	// works correctly: the user payload is decoded into our typed fields.
+	populatedSecret := GenericSecret{
+		Type:     "simple",
+		Value:    "abc",
+		Encoding: IdentityEncoding,
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		want    GenericSecret
+		wantErr bool
+	}{
+		{
+			name: "KV v1 envelope: user payload decoded",
+			input: `{
+				"request_id": "req-1",
+				"lease_id": "lease-1",
+				"lease_duration": 3600,
+				"renewable": true,
+				"data": {"type": "simple", "value": "abc", "encoding": "identity"},
+				"warnings": ["heads up"]
+			}`,
+			want: populatedSecret,
+		},
+		{
+			name: "KV v2 envelope: inner data hoisted, metadata dropped",
+			input: `{
+				"request_id": "req-2",
+				"lease_duration": 60,
+				"data": {
+					"data": {"type": "simple", "value": "abc", "encoding": "identity"},
+					"metadata": {
+						"version": 7,
+						"created_time": "2024-01-01T00:00:00Z",
+						"destroyed": false,
+						"deletion_time": "",
+						"custom_metadata": null
+					}
+				}
+			}`,
+			want: populatedSecret,
+		},
+		{
+			name: "v2-shaped but metadata.version missing: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": {"created_time": "2024-01-01T00:00:00Z"}
+			}}`,
+			// Outer payload is decoded as GenericSecret; none of its fields
+			// match "data" or "metadata", so the result is zero-valued. A
+			// non-zero result here would mean v2 detection misfired.
+			want: GenericSecret{},
+		},
+		{
+			name: "v2-shaped but metadata.version is a string: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": {"version": "7", "created_time": "2024-01-01T00:00:00Z"}
+			}}`,
+			want: GenericSecret{},
+		},
+		{
+			name: "v2-shaped but metadata.created_time missing: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": {"version": 1}
+			}}`,
+			want: GenericSecret{},
+		},
+		{
+			name: "v2-shaped but metadata.created_time is empty string: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": {"version": 1, "created_time": ""}
+			}}`,
+			want: GenericSecret{},
+		},
+		{
+			name: "v2-shaped but metadata.created_time is a number: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": {"version": 1, "created_time": 1700000000}
+			}}`,
+			want: GenericSecret{},
+		},
+		{
+			name: "v2-shaped but metadata is not an object: treated as v1",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc"},
+				"metadata": "version 1"
+			}}`,
+			want: GenericSecret{},
+		},
+		{
+			name: "v2 with negative metadata.version: still treated as v2",
+			input: `{"data": {
+				"data": {"type": "simple", "value": "abc", "encoding": "identity"},
+				"metadata": {"version": -1, "created_time": "2024-01-01T00:00:00Z"}
+			}}`,
+			want: populatedSecret,
+		},
+		{
+			name:    "data is a JSON string: error, no panic",
+			input:   `{"data": "just-a-string"}`,
+			wantErr: true,
+		},
+		{
+			name:    "data is a JSON array: error, no panic",
+			input:   `{"data": [1, 2, 3]}`,
+			wantErr: true,
+		},
+		{
+			name:    "data is a JSON number: error, no panic",
+			input:   `{"data": 42}`,
+			wantErr: true,
+		},
+		{
+			name:  "no data field: zero secret, no error",
+			input: `{"request_id": "req-3"}`,
+			want:  GenericSecret{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got CSIFile
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; secret=%+v", got.Secret)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got.Secret, tt.want) {
+				t.Fatalf("Secret mismatch:\n got: %+v\nwant: %+v", got.Secret, tt.want)
 			}
 		})
 	}

--- a/secrets/store_internal_test.go
+++ b/secrets/store_internal_test.go
@@ -225,6 +225,71 @@ func TestDirRotation(t *testing.T) {
 	})
 }
 
+// TestDirRotation_KVv2 mirrors TestDirRotation's initial-payload flow but
+// the on-disk secret is wrapped in Vault's KV v2 envelope. The library
+// should hide the v1/v2 distinction from callers: walkCSIDirectory and
+// secretsValidate must succeed and produce the same SimpleSecret.
+func TestDirRotation_KVv2(t *testing.T) {
+	const (
+		delay = 50 * time.Millisecond
+		key   = "secrets/foo"
+
+		// Same secret payload as TestDirRotation's apiKey, but the inner
+		// "data" object is now wrapped in a KV v2 envelope:
+		//
+		//   {"data": {"data": {<payload>}, "metadata": {<v2 metadata>}}}
+		apiKey = `
+{
+  "request_id": "1afc3036-2282-d483-c2d4-6d483efdf16c",
+  "lease_id": "",
+  "lease_duration": 2764800,
+  "renewable": false,
+  "data": {
+    "data": {
+      "type": "simple",
+      "value": "Y2RvVXhNMVdsTXJma3BDaHRGZ0dPYkVGSg==",
+      "encoding": "base64"
+    },
+    "metadata": {
+      "version": 1,
+      "created_time": "2024-01-01T00:00:00Z",
+      "destroyed": false,
+      "deletion_time": "",
+      "custom_metadata": null
+    }
+  },
+  "warnings": null
+}
+`
+	)
+	wantSecret := SimpleSecret{Value: Secret("cdoUxM1WlMrfkpChtFgGObEFJ")}
+
+	dir := t.TempDir()
+	writer, err := fileutil.NewAtomicWriter(dir, "")
+	if err != nil {
+		t.Fatalf("Failed to create k8s atomic writer: %v", err)
+	}
+	if err := writer.Write(map[string]fileutil.FileProjection{
+		key: {Data: []byte(apiKey), Mode: 0777},
+	}); err != nil {
+		t.Fatalf("Failed to write v2 payload: %v", err)
+	}
+
+	store, err := newStore(context.Background(), delay, dir, log.TestWrapper(t))
+	if err != nil {
+		t.Fatalf("Failed to create secrets store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	secret, err := store.GetSimpleSecret(key)
+	if err != nil {
+		t.Fatalf("GetSimpleSecret(%q): %v", key, err)
+	}
+	if !reflect.DeepEqual(secret, wantSecret) {
+		t.Errorf("Got secret %+v, want %+v", secret, wantSecret)
+	}
+}
+
 func TestDirectoryError(t *testing.T) {
 	dir := t.TempDir()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
Provide a compatibility shim between the v1 and v2 secrets formats provided by Vault.

## 📜 Details
The Vault CSI provider writes a different shape under the top-level "data" field depending on the backing KV version. KV v1 places the secret payload directly under "data"; KV v2 wraps it as {"data": {...}, "metadata": {"version": N, "created_time": "...", ...}}.

We only handled v1, so v2 payloads silently decoded into a zero-valued GenericSecret (the outer object has no type/value/current/...), which bubbled up downstream as "unknown secret type" or empty secrets.

Add a custom UnmarshalJSON on CSIFile that detects the v2 shape (requires both metadata.version as a JSON number AND metadata.created_time as a non-empty JSON string, so a v1 secret with user keys named "data"/"metadata" is not misclassified) and hoists the inner "data" up before decoding into GenericSecret. Downstream code continues to see the v1-shaped payload it already expects; CSIFile keeps the same exported field, no API changes.

Mirrors the equivalent fix in secretsbp (b294b8f).

Adds TestCSIFile_UnmarshalJSON covering v1, v2, and the v2-shaped-but-not fallbacks, plus an end-to-end TestDirRotation_KVv2 that exercises walkCSIDirectory through the store loader.

## 🧪 Testing Steps / Validation
Unit test suite.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
